### PR TITLE
Fix github action workflow for gfortran

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install Tox and any other packages
         run: |
-          sudo ln -s /usr/bin/gfortran-9 /usr/bin/gfortran
+          sudo ln -sf /usr/bin/gfortran-9 /usr/bin/gfortran
           pip install numpy
           pip install tox
       - name: Run tests


### PR DESCRIPTION
`/usr/bin/gfortran` previously did not link to anything in the Github VM used to run the Actions, so we could just `ln -s` to point it to `/usr/bin/gfortran-9`. However, this was changed so I added the `-f` flag to overwrite the default (7.5.0 vs 9.3.0 as of writing).