### PR TITLE
Changelog for make_shared_data entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,5 +15,8 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Require `psf_fwhms` regardless of whether `include_perturb_auf` is yes or
+  not. [#9, #10]
+
 - Preliminary API established, with parameters ingested from several
   input files. [#7]


### PR DESCRIPTION
Fix to #8 which was missing its changelog entry and was accidentally merged without it.