### PR TITLE
Creation of the framework for the perturbation component of the AUF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build
 docs/_api
 .tox
 *.egg-info
+build/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 docs/_build
 docs/_api
 .tox
+.tmp
 *.egg-info
 build/*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- Creation of the perturbation aspect of the AUF, in the limit that it is
+  unused (i.e., the AUF is assumed to be Gaussian). [#12]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/macauff/__init__.py
+++ b/macauff/__init__.py
@@ -1,1 +1,3 @@
 from .matching import *
+from .perturbation_auf import *
+from .perturbation_auf_fortran import *

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -412,7 +412,7 @@ class CrossMatch():
         self.rho = np.linspace(0, self.four_max_rho, self.four_hankel_points)
         self.drho = np.diff(self.rho)
 
-    def create_perturb_auf(self, files_per_auf_sim, perturb_auf_func=create_perturb_auf):
+    def create_perturb_auf(self, files_per_auf_sim, perturb_auf_func=make_perturb_aufs):
         '''
         Function wrapping the main perturbation AUF component creation routines.
 
@@ -443,10 +443,10 @@ class CrossMatch():
                 # Once run AUf flag is updated, all other flags need to be set to run
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-            make_perturb_aufs(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
-                              self.a_auf_region_points, self.a_psf_fwhms, self.a_download_tri,
-                              self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
-                              'a', self.include_perturb_auf, a_n_sources, self.mem_chunk_num)
+            perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
+                             self.a_auf_region_points, self.a_psf_fwhms, self.a_download_tri,
+                             self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
+                             'a', self.include_perturb_auf, a_n_sources, self.mem_chunk_num)
         else:
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
@@ -466,10 +466,10 @@ class CrossMatch():
                               'cross-match process.')
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-            make_perturb_aufs(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
-                              self.b_auf_region_points, self.b_psf_fwhms, self.b_download_tri,
-                              self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
-                              'b', self.include_perturb_auf, b_n_sources, self.mem_chunk_num)
+            perturb_auf_func(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
+                             self.b_auf_region_points, self.b_psf_fwhms, self.b_download_tri,
+                             self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
+                             'b', self.include_perturb_auf, b_n_sources, self.mem_chunk_num)
         else:
             print('Loading empirical crowding AUFs for catalogue "b"...')
             sys.stdout.flush()

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -428,8 +428,8 @@ class CrossMatch():
         # and N simulation files per filter. Additionally, it will contain a
         # single file with each source's index reference into the cube of AUFs,
         # and a convenience cube for each N-m combination array's length.
-        a_expected_files = 3 + len(self.a_auf_region_points) + (files_per_auf_sim *
-                                                                len(self.a_auf_region_points))
+        a_expected_files = 3 + len(self.a_auf_region_points) + (
+            files_per_auf_sim * len(self.a_filt_names) * len(self.a_auf_region_points))
         a_file_number = np.sum([len(files) for _, _, files in
                                 os.walk(self.a_auf_folder_path)])
         a_correct_file_number = a_expected_files == a_file_number
@@ -437,7 +437,9 @@ class CrossMatch():
         a_n_sources = len(np.load('{}/magref.npy'.format(self.a_cat_folder_path), mmap_mode='r'))
 
         if self.run_auf or not a_correct_file_number:
-            if not a_correct_file_number:
+            # Only warn if we did NOT choose to run AUF, but DID hit wrong file
+            # number.
+            if not a_correct_file_number and not self.run_auf:
                 warnings.warn('Incorrect number of files in catalogue "a" perturbation'
                               'AUF simulation folder. Deleting all files and re-running '
                               'cross-match process.')
@@ -456,8 +458,8 @@ class CrossMatch():
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
 
-        b_expected_files = 3 + len(self.b_auf_region_points) + (files_per_auf_sim *
-                                                                len(self.b_auf_region_points))
+        b_expected_files = 3 + len(self.b_auf_region_points) + (
+            files_per_auf_sim * len(self.b_filt_names) * len(self.b_auf_region_points))
         b_file_number = np.sum([len(files) for _, _, files in
                                 os.walk(self.b_auf_folder_path)])
         b_correct_file_number = b_expected_files == b_file_number
@@ -465,7 +467,7 @@ class CrossMatch():
         b_n_sources = len(np.load('{}/magref.npy'.format(self.b_cat_folder_path), mmap_mode='r'))
 
         if self.run_auf or not b_correct_file_number:
-            if not b_correct_file_number:
+            if not b_correct_file_number and not self.run_auf:
                 warnings.warn('Incorrect number of files in catalogue "b" perturbation'
                               'AUF simulation folder. Deleting all files and re-running '
                               'cross-match process.')

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -433,6 +433,8 @@ class CrossMatch():
                                 os.walk(self.a_auf_folder_path)])
         a_correct_file_number = a_expected_files == a_file_number
 
+        a_n_sources = len(np.load('{}/magref.npy'.format(self.a_cat_folder_path), mmap_mode='r'))
+
         if self.run_auf or not a_correct_file_number:
             if not a_correct_file_number:
                 warnings.warn('Incorrect number of files in catalogue "a" perturbation'
@@ -441,7 +443,10 @@ class CrossMatch():
                 # Once run AUf flag is updated, all other flags need to be set to run
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-            create_perturb_auf()
+            create_perturb_auf(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
+                               self.a_auf_region_points, self.a_psf_fwhms, self.a_download_tri,
+                               self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
+                               'a', self.include_perturb_auf, a_n_sources, self.mem_chunk_num)
         else:
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
@@ -452,6 +457,8 @@ class CrossMatch():
                                 os.walk(self.b_auf_folder_path)])
         b_correct_file_number = b_expected_files == b_file_number
 
+        b_n_sources = len(np.load('{}/magref.npy'.format(self.b_cat_folder_path), mmap_mode='r'))
+
         if self.run_auf or not b_correct_file_number:
             if not b_correct_file_number:
                 warnings.warn('Incorrect number of files in catalogue "b" perturbation'
@@ -459,7 +466,10 @@ class CrossMatch():
                               'cross-match process.')
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-            create_perturb_auf()
+            create_perturb_auf(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
+                               self.b_auf_region_points, self.b_psf_fwhms, self.b_download_tri,
+                               self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
+                               'b', self.include_perturb_auf, b_n_sources, self.mem_chunk_num)
         else:
             print('Loading empirical crowding AUFs for catalogue "b"...')
             sys.stdout.flush()

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -9,7 +9,7 @@ import warnings
 from configparser import ConfigParser
 import numpy as np
 
-from .perturbation_auf import create_perturb_auf
+from .perturbation_auf import make_perturb_aufs
 
 __all__ = ['CrossMatch']
 
@@ -134,7 +134,7 @@ class CrossMatch():
         # The first step is to create the perturbation AUF components, if needed.
         # If run_auf is set to True or if there are not the appropriate number of
         # pre-saved outputs from a previous run then run perturbation AUF creation.
-        self.create_auf()
+        self.create_perturb_auf()
 
     def _replace_line(self, file_name, line_num, text, out_file=None):
         '''
@@ -412,7 +412,7 @@ class CrossMatch():
         self.rho = np.linspace(0, self.four_max_rho, self.four_hankel_points)
         self.drho = np.diff(self.rho)
 
-    def create_auf(self, files_per_auf_sim, perturb_auf_func=create_perturb_auf):
+    def create_perturb_auf(self, files_per_auf_sim, perturb_auf_func=create_perturb_auf):
         '''
         Function wrapping the main perturbation AUF component creation routines.
 
@@ -443,10 +443,10 @@ class CrossMatch():
                 # Once run AUf flag is updated, all other flags need to be set to run
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-            create_perturb_auf(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
-                               self.a_auf_region_points, self.a_psf_fwhms, self.a_download_tri,
-                               self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
-                               'a', self.include_perturb_auf, a_n_sources, self.mem_chunk_num)
+            make_perturb_aufs(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
+                              self.a_auf_region_points, self.a_psf_fwhms, self.a_download_tri,
+                              self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
+                              'a', self.include_perturb_auf, a_n_sources, self.mem_chunk_num)
         else:
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
@@ -466,10 +466,10 @@ class CrossMatch():
                               'cross-match process.')
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-            create_perturb_auf(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
-                               self.b_auf_region_points, self.b_psf_fwhms, self.b_download_tri,
-                               self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
-                               'b', self.include_perturb_auf, b_n_sources, self.mem_chunk_num)
+            make_perturb_aufs(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
+                              self.b_auf_region_points, self.b_psf_fwhms, self.b_download_tri,
+                              self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
+                              'b', self.include_perturb_auf, b_n_sources, self.mem_chunk_num)
         else:
             print('Loading empirical crowding AUFs for catalogue "b"...')
             sys.stdout.flush()

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -134,7 +134,8 @@ class CrossMatch():
         # The first step is to create the perturbation AUF components, if needed.
         # If run_auf is set to True or if there are not the appropriate number of
         # pre-saved outputs from a previous run then run perturbation AUF creation.
-        self.create_perturb_auf()
+        # TODO: generalise the number of files per AUF simulation as input arg.
+        self.create_perturb_auf(7)
 
     def _replace_line(self, file_name, line_num, text, out_file=None):
         '''

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -8,6 +8,8 @@ import warnings
 from configparser import ConfigParser
 import numpy as np
 
+from .perturbation_auf import create_perturb_auf
+
 __all__ = ['CrossMatch']
 
 
@@ -94,7 +96,6 @@ class CrossMatch():
         # If run_auf is set to True or if there are not the appropriate number of
         # pre-saved outputs from a previous run then run perturbation AUF creation.
         self.create_auf()
-
 
     def _replace_line(self, file_name, line_num, text, out_file=None):
         '''
@@ -368,7 +369,16 @@ class CrossMatch():
         self.rho = np.linspace(0, self.four_max_rho, self.four_hankel_points)
         self.drho = np.diff(self.rho)
 
-    def create_auf(self, files_per_auf_sim):
+    def create_auf(self, files_per_auf_sim, perturb_auf_func=create_perturb_auf):
+        '''
+        Function wrapping the main perturbation AUF component creation routines.
+
+        files_per_auf_sim : integer
+            The number of output files for each individual perturbation simulation.
+        perturb_auf_func : callable, optional
+            ``perturb_auf_func`` should create the perturbation AUF output files
+            for each filter-pointing combination.
+        '''
         # Each catalogue has in its auf_folder_path a single file, a local
         # normalising density, plus -- per AUF "pointing" -- a simulation file
         # and N simulation files per filter.
@@ -383,7 +393,7 @@ class CrossMatch():
                 warnings.warn('Incorrect number of files in catalogue "a" perturbation'
                               'AUF simulation folder. Deleting all files and re-running.')
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-            # TODO: put call to function here
+            create_perturb_auf()
 
         b_expected_files = 1 + len(self.b_auf_region_points) + (files_per_auf_sim *
                                                                 len(self.b_auf_region_points))
@@ -396,4 +406,4 @@ class CrossMatch():
                 warnings.warn('Incorrect number of files in catalogue "b" perturbation'
                               'AUF simulation folder. Deleting all files and re-running.')
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-            # TODO: put call to function here
+            create_perturb_auf()

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -392,7 +392,10 @@ class CrossMatch():
         if self.run_auf or not a_correct_file_number:
             if not a_correct_file_number:
                 warnings.warn('Incorrect number of files in catalogue "a" perturbation'
-                              'AUF simulation folder. Deleting all files and re-running.')
+                              'AUF simulation folder. Deleting all files and re-running '
+                              'cross-match process.')
+                # Once run AUf flag is updated, all other flags need to be set to run
+                self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
             create_perturb_auf()
         else:
@@ -408,7 +411,9 @@ class CrossMatch():
         if self.run_auf or not b_correct_file_number:
             if not b_correct_file_number:
                 warnings.warn('Incorrect number of files in catalogue "b" perturbation'
-                              'AUF simulation folder. Deleting all files and re-running.')
+                              'AUF simulation folder. Deleting all files and re-running '
+                              'cross-match process.')
+                self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
             create_perturb_auf()
         else:

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -444,10 +444,14 @@ class CrossMatch():
                 # Once run AUf flag is updated, all other flags need to be set to run
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
+            if self.include_perturb_auf:
+                _kwargs = {'psf_fwhms': self.a_psf_fwhms, 'tri_download_flag': self.a_download_tri}
+            else:
+                _kwargs = {}
             perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
-                             self.a_auf_region_points, self.a_psf_fwhms, self.a_download_tri,
-                             self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
-                             'a', self.include_perturb_auf, a_n_sources, self.mem_chunk_num)
+                             self.a_auf_region_points, self.cross_match_extent, self.r, self.dr,
+                             self.rho, self.drho, 'a', self.include_perturb_auf, a_n_sources,
+                             self.mem_chunk_num, **_kwargs)
         else:
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
@@ -467,10 +471,14 @@ class CrossMatch():
                               'cross-match process.')
                 self.run_group, self.run_cf, self.run_star = True, True, True
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
+            if self.include_perturb_auf:
+                _kwargs = {'psf_fwhms': self.b_psf_fwhms, 'tri_download_flag': self.b_download_tri}
+            else:
+                _kwargs = {}
             perturb_auf_func(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
-                             self.b_auf_region_points, self.b_psf_fwhms, self.b_download_tri,
-                             self.cross_match_extent, self.r, self.dr, self.rho, self.drho,
-                             'b', self.include_perturb_auf, b_n_sources, self.mem_chunk_num)
+                             self.b_auf_region_points, self.cross_match_extent, self.r, self.dr,
+                             self.rho, self.drho, 'b', self.include_perturb_auf, b_n_sources,
+                             self.mem_chunk_num, **_kwargs)
         else:
             print('Loading empirical crowding AUFs for catalogue "b"...')
             sys.stdout.flush()

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -382,8 +382,10 @@ class CrossMatch():
         '''
         # Each catalogue has in its auf_folder_path a single file, a local
         # normalising density, plus -- per AUF "pointing" -- a simulation file
-        # and N simulation files per filter.
-        a_expected_files = 1 + len(self.a_auf_region_points) + (files_per_auf_sim *
+        # and N simulation files per filter. Additionally, it will contain a
+        # single file with each source's index reference into the cube of AUFs,
+        # and a convenience cube for each N-m combination array's length.
+        a_expected_files = 3 + len(self.a_auf_region_points) + (files_per_auf_sim *
                                                                 len(self.a_auf_region_points))
         a_file_number = np.sum([len(files) for _, _, files in
                                 os.walk(self.a_auf_folder_path)])
@@ -402,7 +404,7 @@ class CrossMatch():
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
 
-        b_expected_files = 1 + len(self.b_auf_region_points) + (files_per_auf_sim *
+        b_expected_files = 3 + len(self.b_auf_region_points) + (files_per_auf_sim *
                                                                 len(self.b_auf_region_points))
         b_file_number = np.sum([len(files) for _, _, files in
                                 os.walk(self.b_auf_folder_path)])

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -4,6 +4,7 @@ This module provides the high-level framework for performing catalogue-catalogue
 '''
 
 import os
+import sys
 import warnings
 from configparser import ConfigParser
 import numpy as np
@@ -394,6 +395,9 @@ class CrossMatch():
                               'AUF simulation folder. Deleting all files and re-running.')
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
             create_perturb_auf()
+        else:
+            print('Loading empirical crowding AUFs for catalogue "a"...')
+            sys.stdout.flush()
 
         b_expected_files = 1 + len(self.b_auf_region_points) + (files_per_auf_sim *
                                                                 len(self.b_auf_region_points))
@@ -407,3 +411,6 @@ class CrossMatch():
                               'AUF simulation folder. Deleting all files and re-running.')
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
             create_perturb_auf()
+        else:
+            print('Loading empirical crowding AUFs for catalogue "b"...')
+            sys.stdout.flush()

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -10,12 +10,12 @@ import numpy as np
 
 import perturbation_auf_fortran as paf
 
-__all__ = ['create_perturb_auf']
+__all__ = ['make_perturb_aufs']
 
 
-def create_perturb_auf(auf_folder, cat_folder, filters, auf_points, psf_fwhms, tri_download_flag,
-                       ax_lims, r, dr, rho, drho, which_cat, include_perturb_auf, n_sources,
-                       mem_chunk_num):
+def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, psf_fwhms, tri_download_flag,
+                      ax_lims, r, dr, rho, drho, which_cat, include_perturb_auf, n_sources,
+                      mem_chunk_num):
     """
     Function to perform the creation of the blended object perturbation component
     of the AUF.

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -8,6 +8,8 @@ import os
 import sys
 import numpy as np
 
+import perturbation_auf_fortran as paf
+
 __all__ = ['create_perturb_auf']
 
 
@@ -144,7 +146,7 @@ def create_perturb_auf(auf_folder, cat_folder, filters, auf_points, psf_fwhms, t
     sys.stdout.flush()
 
     modelrefinds = np.lib.format.open_memmap('{}/modelrefinds.npy'.format(auf_folder),
-                                             mode='w+', dtype=int, shape=(4, n_sources),
+                                             mode='w+', dtype=int, shape=(3, n_sources),
                                              fortran_order=True)
 
     for cnum in range(0, mem_chunk_num):
@@ -173,4 +175,5 @@ def create_perturb_auf(auf_folder, cat_folder, filters, auf_points, psf_fwhms, t
         # Which sky position to use is more complex; this involves determining
         # the smallest great-circle distance to each auf_point AUF mapping for
         # each source.
-
+        modelrefinds[2, indexmap] = paf.find_nearest_auf_point(a[:, 0], a[:, 1],
+                                                               auf_points[:, 0], auf_points[:, 1])

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -13,9 +13,9 @@ from .perturbation_auf_fortran import perturbation_auf_fortran as paf
 __all__ = ['make_perturb_aufs']
 
 
-def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, psf_fwhms, tri_download_flag,
-                      ax_lims, r, dr, rho, drho, which_cat, include_perturb_auf, n_sources,
-                      mem_chunk_num):
+def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, dr, rho,
+                      drho, which_cat, include_perturb_auf, n_sources, mem_chunk_num,
+                      psf_fwhms=None, tri_download_flag=False):
     """
     Function to perform the creation of the blended object perturbation component
     of the AUF.
@@ -32,11 +32,6 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, psf_fwhms, tr
     auf_points : numpy.ndarray
         Two-dimensional array containing pairs of coordinates at which to evaluate
         the perturbation AUF components.
-    psf_fwhms : numpy.ndarray
-        Array of full width at half-maximums for each filter in ``filters``.
-    tri_download_flag : boolean
-        A ``True``/``False`` flag, whether to re-download TRILEGAL simulated star
-        counts or not if a simulation already exists in a given folder.
     ax_lims : numpy.ndarray
         Array containing the four sky coordinate limits of the cross-match region.
     r : numpy.ndarray
@@ -59,6 +54,13 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, psf_fwhms, tr
     mem_chunk_num : int
         Number of individual sub-sections to break catalogue into for memory
         saving purposes.
+    psf_fwhms : numpy.ndarray, optional
+        Array of full width at half-maximums for each filter in ``filters``. Only
+        required if ``include_perturb_auf`` is True; defaults to ``None``.
+    tri_download_flag : boolean, optional
+        A ``True``/``False`` flag, whether to re-download TRILEGAL simulated star
+        counts or not if a simulation already exists in a given folder. Only
+        needed if ``include_perturb_auf`` is True.
     """
     print('Creating empirical crowding AUFs for catalogue "{}"...'.format(which_cat))
     sys.stdout.flush()

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -63,6 +63,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, psf_fwhms, tr
     print('Creating empirical crowding AUFs for catalogue "{}"...'.format(which_cat))
     sys.stdout.flush()
 
+    # TODO: assign these variables as input args.
     # The number of simulated PSFs to create for statistical purposes
     N_trials = 1000000
     # Magnitude offsets corresponding to relative fluxes of perturbing sources; here

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE
 '''
-This module provides the high-level framework for performing catalogue-catalogue cross-matches.
+This module provides the framework to handle the creation of the perturbation
+component of the astrometric uncertainty function.
 '''
 
 import os
@@ -100,7 +101,7 @@ def create_perturb_auf(auf_folder, filters, auf_points, psf_fwhms, tri_download_
                 offset = np.zeros((len(r)-1, num_N_mag), float, order='F')
                 # Fix offsets such that the probability density function looks like
                 # a delta function, such that a two-dimensional circular coordinate
-                # integral would evaluate to one at every point, cf. ``cumuative``.
+                # integral would evaluate to one at every point, cf. ``cumulative``.
                 offset[0, :] = 1 / (2 * np.pi * (r[0] + dr[0]/2) * dr[0])
                 np.save('{}/{}/offset.npy'.format(filt_folder), offset)
                 # The cumulative integral of a delta function is always unity.

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -113,9 +113,9 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
                 # subroutines to create the perturbation simulations, so we make
                 # f-ordered dummy parameters.
                 Frac = np.zeros((len(delta_mag_cuts), num_N_mag), float, order='F')
-                np.save('{}/{}/frac.npy'.format(filt_folder), Frac)
+                np.save('{}/frac.npy'.format(filt_folder), Frac)
                 Flux = np.zeros(num_N_mag, float, order='F')
-                np.save('{}/{}/flux.npy'.format(filt_folder), Flux)
+                np.save('{}/flux.npy'.format(filt_folder), Flux)
                 # Remember that r is bins, so the evaluations at bin middle are one
                 # shorter in length.
                 offset = np.zeros((len(r)-1, num_N_mag), float, order='F')
@@ -123,22 +123,22 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
                 # a delta function, such that a two-dimensional circular coordinate
                 # integral would evaluate to one at every point, cf. ``cumulative``.
                 offset[0, :] = 1 / (2 * np.pi * (r[0] + dr[0]/2) * dr[0])
-                np.save('{}/{}/offset.npy'.format(filt_folder), offset)
+                np.save('{}/offset.npy'.format(filt_folder), offset)
                 # The cumulative integral of a delta function is always unity.
                 cumulative = np.ones((len(r)-1, num_N_mag), float, order='F')
-                np.save('{}/{}/cumulative.npy'.format(filt_folder), cumulative)
+                np.save('{}/cumulative.npy'.format(filt_folder), cumulative)
                 # The Hankel transform of a delta function is a flat line; this
                 # then preserves the convolution being multiplication in fourier
                 # space, as F(x) x 1 = F(x), similar to how f(x) * d(0) = f(x).
                 fourieroffset = np.ones((len(rho)-1, num_N_mag), float, order='F')
-                np.save('{}/{}/fourier.npy'.format(filt_folder), fourieroffset)
+                np.save('{}/fourier.npy'.format(filt_folder), fourieroffset)
                 # Both normalising density and magnitude arrays can be proxied
                 # with a dummy parameter, as any minimisation of N-m distance
                 # must pick the single value anyway.
                 Narray = np.array([[1]], float)
-                np.save('{}/{}/N.npy'.format(filt_folder), Narray)
+                np.save('{}/N.npy'.format(filt_folder), Narray)
                 magarray = np.array([[1]], float)
-                np.save('{}/{}/mag.npy'.format(filt_folder), magarray)
+                np.save('{}/mag.npy'.format(filt_folder), magarray)
             arraylengths[j, i] = len(Narray)
 
     # Once the individual AUF simulations are saved, we also need to calculate
@@ -159,7 +159,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
         magref = np.load('{}/magref.npy'.format(cat_folder), mmap_mode='r')[lowind:highind]
         # As we chunk in even steps through the files this is simple for now,
         # but could be replaced with a more complex mapping in the future.
-        indexmap = np.arange(lowind, highind+1, 1)
+        indexmap = np.arange(lowind, highind, 1)
 
         if include_perturb_auf:
             # TODO: load 3-D cube of N-m combinations for unique sky/filter pairs.

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -3,13 +3,15 @@
 This module provides the high-level framework for performing catalogue-catalogue cross-matches.
 '''
 
+import os
+import sys
 import numpy as np
 
 __all__ = ['create_perturb_auf']
 
 
 def create_perturb_auf(auf_folder, filters, auf_points, psf_fwhms, tri_download_flag, ax_lims,
-                       r, dr, rho, drho, which_cat):
+                       r, dr, rho, drho, which_cat, include_perturb_auf):
     """
     Function to perform the creation of the blended object perturbation component
     of the AUF.
@@ -39,4 +41,80 @@ def create_perturb_auf(auf_folder, filters, auf_points, psf_fwhms, tri_download_
         The fourier-space coordinates for Hankel transformations.
     drho : numpy.ndarray
         The spacings between ``rho`` elements.
+    which_cat : string
+        Indicator as to whether these perturbation AUFs are for catalogue "a"
+        or catalogue "b" within the cross-match process.
+    include_perturb_auf : boolean
+        ``True`` or ``False`` flag indicating whether perturbation component of the
+        AUF should be used or not within the cross-match process.
     """
+    print('Creating empirical crowding AUFs for catalogue "{}"...'.format(which_cat))
+    sys.stdout.flush()
+
+    # The number of simulated PSFs to create for statistical purposes
+    N_trials = 1000000
+    # Magnitude offsets corresponding to relative fluxes of perturbing sources; here
+    # dm of 2.5 is 10% relative flux and dm = 5 corresponds to 1% relative flux. Used
+    # to inform the fraction of simulations with a contaminant above these relative
+    # fluxes.
+    delta_mag_cuts = np.array([2.5, 5])
+
+    for i in range(len(auf_points)):
+        ax1, ax2 = auf_points[i]
+        ax_folder = '{}/{}/{}'.format(auf_folder, ax1, ax2)
+        if not os.path.exists(ax_folder):
+            os.makedirs(ax_folder, exist_ok=True)
+        if include_perturb_auf:
+            # TODO: download TRILEGAL simulation here
+            raise NotImplementedError("Perturbation AUF components are not currently"
+                                      "included in the cross-match process.")
+
+        for j in range(len(filters)):
+            filt = filters[j]
+
+            filt_folder = '{}/{}'.format(ax_folder, filt)
+            if not os.path.exists(filt_folder):
+                os.makedirs(filt_folder, exist_ok=True)
+
+            if include_perturb_auf:
+                # TODO: extend with create_single_auf
+                raise NotImplementedError("Perturbation AUF components are not currently"
+                                          "included in the cross-match process.")
+            else:
+                # Without the simulations to force local normalising density N or
+                # individual source brightness magnitudes, we can simply combine
+                # all data into a single "bin".
+                num_N_mag = 1
+                # In cases where we do not want to use the perturbation AUF component,
+                # we currently don't have separate functions, but instead set up dummy
+                # functions and variables to pass what mathematically amounts to
+                # "nothing" through the cross-match. Here we would use fortran
+                # subroutines to create the perturbation simulations, so we make
+                # f-ordered dummy parameters.
+                Frac = np.zeros((len(delta_mag_cuts), num_N_mag), float, order='F')
+                np.save('{}/{}/frac.npy'.format(filt_folder), Frac)
+                Flux = np.zeros(num_N_mag, float, order='F')
+                np.save('{}/{}/flux.npy'.format(filt_folder), Flux)
+                # Remember that r is bins, so the evaluations at bin middle are one
+                # shorter in length.
+                offset = np.zeros((len(r)-1, num_N_mag), float, order='F')
+                # Fix offsets such that the probability density function looks like
+                # a delta function, such that a two-dimensional circular coordinate
+                # integral would evaluate to one at every point, cf. ``cumuative``.
+                offset[0, :] = 1 / (2 * np.pi * (r[0] + dr[0]/2) * dr[0])
+                np.save('{}/{}/offset.npy'.format(filt_folder), offset)
+                # The cumulative integral of a delta function is always unity.
+                cumulative = np.ones((len(r)-1, num_N_mag), float, order='F')
+                np.save('{}/{}/cumulative.npy'.format(filt_folder), cumulative)
+                # The Hankel transform of a delta function is a flat line; this
+                # then preserves the convolution being multiplication in fourier
+                # space, as F(x) x 1 = F(x), similar to how f(x) * d(0) = f(x).
+                fourieroffset = np.ones((len(rho)-1, num_N_mag), float, order='F')
+                np.save('{}/{}/fourier.npy'.format(filt_folder), fourieroffset)
+                # Both normalising density and magnitude arrays can be proxied
+                # with a dummy parameter, as any minimisation of N-m distance
+                # must pick the single value anyway.
+                Narray = np.array([[1]], float)
+                np.save('{}/{}/N.npy'.format(filt_folder), Narray)
+                magarray = np.array([[1]], float)
+                np.save('{}/{}/mag.npy'.format(filt_folder), magarray)

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE
+'''
+This module provides the high-level framework for performing catalogue-catalogue cross-matches.
+'''
+
+import numpy as np
+
+__all__ = ['create_perturb_auf']
+
+
+def create_perturb_auf(auf_folder, filters, auf_points, psf_fwhms, tri_download_flag, ax_lims,
+                       r, dr, rho, drho, which_cat):
+    """
+    Function to perform the creation of the blended object perturbation component
+    of the AUF.
+
+    auf_folder : string
+        The overall folder into which to create filter-pointing folders and save
+        individual simulation files.
+    filters : list of strings or numpy.ndarray of strings
+        An array containing the list of filters in this catalogue to create
+        simulated AUF components for.
+    auf_points : numpy.ndarray
+        Two-dimensional array containing pairs of coordinates at which to evaluate
+        the perturbation AUF components.
+    psf_fwhms : numpy.ndarray
+        Array of full width at half-maximums for each filter in ``filters``.
+    tri_download_flag : boolean
+        A ``True``/``False`` flag, whether to re-download TRILEGAL simulated star
+        counts or not if a simulation already exists in a given folder.
+    ax_lims : numpy.ndarray
+        Array containing the four sky coordinate limits of the cross-match region.
+    r : numpy.ndarray
+        The real-space coordinates for the Hankel transformations used in AUF-AUF
+        convolution.
+    dr : numpy.ndarray
+        The spacings between ``r`` elements.
+    rho : numpy.ndarray
+        The fourier-space coordinates for Hankel transformations.
+    drho : numpy.ndarray
+        The spacings between ``rho`` elements.
+    """

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -8,7 +8,7 @@ import os
 import sys
 import numpy as np
 
-import perturbation_auf_fortran as paf
+from .perturbation_auf_fortran import perturbation_auf_fortran as paf
 
 __all__ = ['make_perturb_aufs']
 

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -67,7 +67,7 @@ def create_perturb_auf(auf_folder, filters, auf_points, psf_fwhms, tri_download_
             os.makedirs(ax_folder, exist_ok=True)
         if include_perturb_auf:
             # TODO: download TRILEGAL simulation here
-            raise NotImplementedError("Perturbation AUF components are not currently"
+            raise NotImplementedError("Perturbation AUF components are not currently "
                                       "included in the cross-match process.")
 
         for j in range(len(filters)):
@@ -79,7 +79,7 @@ def create_perturb_auf(auf_folder, filters, auf_points, psf_fwhms, tri_download_
 
             if include_perturb_auf:
                 # TODO: extend with create_single_auf
-                raise NotImplementedError("Perturbation AUF components are not currently"
+                raise NotImplementedError("Perturbation AUF components are not currently "
                                           "included in the cross-match process.")
             else:
                 # Without the simulations to force local normalising density N or

--- a/macauff/perturbation_auf_fortran.f90
+++ b/macauff/perturbation_auf_fortran.f90
@@ -1,0 +1,37 @@
+module perturbation_auf_fortran
+implicit none
+private
+public haversine
+integer, parameter :: dp = kind(0.0d0)  ! double precision
+real(dp), parameter :: pi = 4.0_dp*atan(1.0_dp)
+
+contains
+
+subroutine haversine(lon1, lon2, lat1, lat2, hav_dist)
+! Function to calculate the haversine formula.
+
+integer, parameter :: dp = kind(0.0d0)  ! double precision
+
+! The longitudes and latitudes (orthogonal celestial sphere coordinates, in a consistent frame)
+! to compute the great-circle distance of, in degrees.
+real(dp), intent(in) :: lon1, lon2, lat1, lat2
+! Longitude and latitude separations, and individual latitudes, but in radians.
+real(dp) :: dlon_rad, dlat_rad, lat1_rad, lat2_rad
+! Haversine distance, in degrees.
+real(dp), intent(out) :: hav_dist
+
+dlon_rad = (lon1 - lon2) / 180.0_dp * pi
+dlat_rad = (lat1 - lat2) / 180.0_dp * pi
+lat1_rad = lat1 / 180.0_dp * pi
+lat2_rad = lat2 / 180.0_dp * pi
+
+hav_dist = 2.0_dp * asin(sqrt((sin(dlat_rad/2.0_dp))**2 + cos(lat1_rad)*cos(lat2_rad)*(sin(dlon_rad)/2.0_dp)**2))
+hav_dist = hav_dist * 180.0_dp / pi  ! convert radians to degrees
+
+end subroutine haversine
+
+! subroutine find_nearest_auf_point()
+
+! end subroutine find_nearest_auf_point
+
+end module perturbation_auf_fortran

--- a/macauff/perturbation_auf_fortran.f90
+++ b/macauff/perturbation_auf_fortran.f90
@@ -25,7 +25,7 @@ dlat_rad = (lat1 - lat2) / 180.0_dp * pi
 lat1_rad = lat1 / 180.0_dp * pi
 lat2_rad = lat2 / 180.0_dp * pi
 
-hav_dist = 2.0_dp * asin(sqrt((sin(dlat_rad/2.0_dp))**2 + cos(lat1_rad)*cos(lat2_rad)*(sin(dlon_rad)/2.0_dp)**2))
+hav_dist = 2.0_dp * asin(min(1.0_dp, sqrt((sin(dlat_rad/2.0_dp))**2 + cos(lat1_rad)*cos(lat2_rad)*(sin(dlon_rad)/2.0_dp)**2)))
 hav_dist = hav_dist * 180.0_dp / pi  ! convert radians to degrees
 
 end subroutine haversine

--- a/macauff/perturbation_auf_fortran.f90
+++ b/macauff/perturbation_auf_fortran.f90
@@ -1,7 +1,7 @@
 module perturbation_auf_fortran
 implicit none
 private
-public haversine
+public haversine, find_nearest_auf_point
 integer, parameter :: dp = kind(0.0d0)  ! double precision
 real(dp), parameter :: pi = 4.0_dp*atan(1.0_dp)
 
@@ -30,8 +30,39 @@ hav_dist = hav_dist * 180.0_dp / pi  ! convert radians to degrees
 
 end subroutine haversine
 
-! subroutine find_nearest_auf_point()
+subroutine find_nearest_auf_point(source_lon, source_lat, auf_point_lon, auf_point_lat, auf_point_ind)
+! Find the nearest on-sky distance between a series of coordinates and another list of positions.
 
-! end subroutine find_nearest_auf_point
+integer, parameter :: dp = kind(0.0d0)  ! double precision
+
+! 1-D arrays of longitudes and latitudes (or equivalent) to search the nearest point of.
+real(dp), intent(in) :: source_lon(:), source_lat(:)
+! 1-D arrays of lon & lat (consistent with source_lon & source_lat) points that AUFs are sampled
+! from in create_perturb_auf.
+real(dp), intent(in) :: auf_point_lon(:), auf_point_lat(:)
+
+! 1-D array of indices, for each source position, of the closest AUF position.
+real(dp), intent(out) :: auf_point_ind(size(source_lon))
+
+! Loop counters
+integer :: i, j
+! Great-circle distance
+real(dp) :: hav_dist, min_hav_dist
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i, min_hav_dist, hav_dist) SHARED(source_lon, source_lat, auf_point_lon, &
+!$OMP& auf_point_lat, auf_point_ind)
+do i = 1, size(source_lon)
+    min_hav_dist = 9999.9_dp
+    do j = 1, size(auf_point_lon)
+        call haversine(source_lon(i), auf_point_lon(j), source_lat(i), auf_point_lat(j), hav_dist)
+        if (hav_dist < min_hav_dist) then
+            auf_point_ind(i) = j - 1  ! pre-convert one-index fortran to zero-index python indices
+            min_hav_dist = hav_dist
+        end if
+    end do
+end do
+!$OMP END PARALLEL DO
+
+end subroutine find_nearest_auf_point
 
 end module perturbation_auf_fortran

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -13,7 +13,7 @@ psf_fwhms = 0.12 0.12 0.12
 norm_scale_laws = 2 2 2
 
 # TRILEGAL Perturbation AUF parameters
-# Names of TRILEGAL filter sets for the two catalogues
+# Names of TRILEGAL filter sets for the catalogue
 tri_set_name = gaiadr2
 tri_filt_names = G G_BP G_RP
 # Filter number to define limiting magnitude of TRILEGAL simulation in, based on output data file column (one-indexed) number

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -1,5 +1,6 @@
 # Catalogue name -- used both for folder creation and output file names
 cat_name = Gaia
+cat_folder_path = gaia_folder
 # Folder for all AUF-related files to be created in. Should be an absolute path, or relative to folder script called in.
 auf_folder_path = gaia_auf_folder
 

--- a/macauff/tests/data/cat_b_params.txt
+++ b/macauff/tests/data/cat_b_params.txt
@@ -1,5 +1,6 @@
 # Catalogue name -- used both for folder creation and output file names
 cat_name = WISE
+cat_folder_path = wise_folder
 # Folder for all AUF-related files to be created in. Should be an absolute path, or relative to folder script called in.
 auf_folder_path = wise_auf_folder
 

--- a/macauff/tests/data/cat_b_params.txt
+++ b/macauff/tests/data/cat_b_params.txt
@@ -13,7 +13,7 @@ psf_fwhms = 6.08 6.84 7.36 11.99
 norm_scale_laws = 2 2 2 2
 
 # TRILEGAL Perturbation AUF parameters
-# Names of TRILEGAL filter sets for the two catalogues
+# Names of TRILEGAL filter sets for the catalogue
 tri_set_name = 2mass_spitzer_wise
 tri_filt_names = W1 W2 W3 W4
 # Filter number to define limiting magnitude of TRILEGAL simulation in, based on output data file column (one-indexed) number

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -5,541 +5,638 @@ Tests for the "matching" module.
 
 import pytest
 import os
+from configparser import ConfigParser
 from numpy.testing import assert_almost_equal
 import numpy as np
 
 from ..matching import CrossMatch
 
 
-def test_crossmatch_run_input():
-    with pytest.raises(FileNotFoundError):
-        cm = CrossMatch('./file.txt', './file2.txt', './file3.txt')
-    with pytest.raises(FileNotFoundError):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        './file2.txt', './file3.txt')
-    with pytest.raises(FileNotFoundError):
+class TestInputs:
+    def setup_class(self):
+        joint_config = ConfigParser()
+        with open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')) as f:
+            joint_config.read_string('[config]\n' + f.read())
+        joint_config = joint_config['config']
+        cat_a_config = ConfigParser()
+        with open(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt')) as f:
+            cat_a_config.read_string('[config]\n' + f.read())
+        cat_a_config = cat_a_config['config']
+        cat_b_config = ConfigParser()
+        with open(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt')) as f:
+            cat_b_config.read_string('[config]\n' + f.read())
+        cat_b_config = cat_b_config['config']
+        self.a_cat_folder_path = os.path.abspath(cat_a_config['cat_folder_path'])
+        self.b_cat_folder_path = os.path.abspath(cat_b_config['cat_folder_path'])
+
+        os.makedirs(self.a_cat_folder_path, exist_ok=True)
+        os.makedirs(self.b_cat_folder_path, exist_ok=True)
+
+        np.save('{}/con_cat_astro.npy'.format(self.a_cat_folder_path), np.zeros((2, 3), float))
+        np.save('{}/con_cat_photo.npy'.format(self.a_cat_folder_path), np.zeros((2, 3), float))
+        np.save('{}/magref.npy'.format(self.a_cat_folder_path), np.zeros(2, float))
+
+        np.save('{}/con_cat_astro.npy'.format(self.b_cat_folder_path), np.zeros((2, 3), float))
+        np.save('{}/con_cat_photo.npy'.format(self.b_cat_folder_path), np.zeros((2, 4), float))
+        np.save('{}/magref.npy'.format(self.b_cat_folder_path), np.zeros(2, float))
+
+    def test_crossmatch_run_input(self):
+        with pytest.raises(FileNotFoundError):
+            cm = CrossMatch('./file.txt', './file2.txt', './file3.txt')
+        with pytest.raises(FileNotFoundError):
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                            './file2.txt', './file3.txt')
+        with pytest.raises(FileNotFoundError):
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                            './file3.txt')
+
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        './file3.txt')
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.run_auf is False
+        assert cm.run_group is False
+        assert cm.run_cf is True
+        assert cm.run_star is True
 
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.run_auf is False
-    assert cm.run_group is False
-    assert cm.run_cf is True
-    assert cm.run_star is True
-
-    # List of simple one line config file replacements for error message checking
-    f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
-    for old_line, new_line, match_text in zip(['run_cf = yes', 'run_auf = no', 'run_auf = no'],
-                                              ['', 'run_auf = aye\n', 'run_auf = yes\n'],
-                                              ['Missing key', 'Boolean flag key not set',
-                                               'Inconsistency between run/no run']):
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                                  'data/crossmatch_params.txt'),
-                                 idx, new_line, out_file=os.path.join(os.path.dirname(__file__),
-                                 'data/crossmatch_params_.txt'))
-
-        with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-
-
-def test_crossmatch_auf_cf_input():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.cf_region_frame == 'equatorial'
-    assert_almost_equal(cm.cf_region_points,
-                        np.array([[131, -1], [132, -1], [133, -1], [134, -1],
-                                  [131, 0], [132, 0], [133, 0], [134, 0],
-                                  [131, 1], [132, 1], [133, 1], [134, 1]]))
-
-    f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
-    old_line = 'include_perturb_auf = no'
-    new_line = 'include_perturb_auf = yes\n'
-    idx = np.where([old_line in line for line in f])[0][0]
-    CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                             'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
-                             os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.a_auf_region_frame == 'equatorial'
-    assert_almost_equal(cm.a_auf_region_points,
-                        np.array([[131, -1], [132, -1], [133, -1], [134, -1],
-                                  [131, 0], [132, 0], [133, 0], [134, 0],
-                                  [131, 1], [132, 1], [133, 1], [134, 1]]))
-    assert_almost_equal(cm.b_auf_region_points,
-                        np.array([[131, -1], [132, -1], [133, -1], [134, -1],
-                                  [131, -1/3], [132, -1/3], [133, -1/3], [134, -1/3],
-                                  [131, 1/3], [132, 1/3], [133, 1/3], [134, 1/3],
-                                  [131, 1], [132, 1], [133, 1], [134, 1]]))
-
-    for kind in ['auf_region_', 'cf_region_']:
-        in_file = 'crossmatch_params' if 'cf' in kind else 'cat_a_params'
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/{}.txt'.format(in_file))).readlines()
         # List of simple one line config file replacements for error message checking
-        for old_line, new_line, match_text in zip(
-            ['{}type = rectangle'.format(kind), '{}type = rectangle'.format(kind),
-             '{}points = 131 134 4 -1 1 3'.format(kind),
-             '{}points = 131 134 4 -1 1 3'.format(kind),
-             '{}frame = equatorial'.format(kind), '{}points = 131 134 4 -1 1 3'.format(kind)],
-            ['', '{}type = triangle\n'.format(kind), '{}points = 131 134 4 -1 1 a\n'.format(kind),
-             '{}points = 131 134 4 -1 1\n'.format(kind), '{}frame = ecliptic\n'.format(kind),
-             '{}points = 131 134 4 -1 1 3.4\n'.format(kind)],
-            ['Missing key {}type'.format(kind),
-             "{}{}type should either be 'rectangle' or".format('' if 'cf' in kind else 'a_', kind),
-             '{}{}points should be 6 numbers'.format('' if 'cf' in kind else 'a_', kind),
-             '{}{}points should be 6 numbers'.format('' if 'cf' in kind else 'a_', kind),
-             "{}{}frame should either be 'equatorial' or".format(
-                '' if 'cf' in kind else 'a_', kind),
-             'start and stop values for {}{}points'.format('' if 'cf' in kind else 'a_', kind)]):
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        for old_line, new_line, match_text in zip(['run_cf = yes', 'run_auf = no', 'run_auf = no'],
+                                                  ['', 'run_auf = aye\n', 'run_auf = yes\n'],
+                                                  ['Missing key', 'Boolean flag key not set',
+                                                   'Inconsistency between run/no run']):
             idx = np.where([old_line in line for line in f])[0][0]
             CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                                      'data/crossmatch_params.txt'),
+                                     idx, new_line,
                                      out_file=os.path.join(os.path.dirname(__file__),
-                                                           'data/{}_.txt'.format(in_file)))
+                                     'data/crossmatch_params_.txt'))
 
             with pytest.raises(ValueError, match=match_text):
                 cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                             'data/crossmatch_params{}.txt'.format(
-                                             '_' if 'cf' in kind else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                             'data/cat_a_params{}.txt'.format(
-                                             '_' if 'cf' not in kind else '')),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
 
-        # Check correct and incorrect *_region_points when *_region_type is 'points'
-        idx = np.where(['{}type = rectangle'.format(kind) in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                                  'data/{}.txt'.format(in_file)),
-                                 idx, '{}type = points\n'.format(kind),
-                                 out_file=os.path.join(os.path.dirname(__file__),
-                                                       'data/{}_.txt'.format(in_file)))
-
-        idx = np.where(['{}points = 131 134 4 -1 1 3'.format(kind) in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}_.txt'.format(in_file)),
-                                 idx, '{}points = (131, 0), (133, 0), (132, -1)\n'.format(kind),
-                                 out_file=os.path.join(os.path.dirname(__file__),
-                                                       'data/{}_2.txt'.format(in_file)))
-
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                        'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
-                        os.path.join(os.path.dirname(__file__),
-                        'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
+    def test_crossmatch_auf_cf_input(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind else 'a_', kind)),
-                            np.array([[131, 0], [133, 0], [132, -1]]))
-
-        old_line = '{}points = 131 134 4 -1 1 3'.format(kind)
-        for new_line in ['{}points = (131, 0), (131, )\n'.format(kind),
-                         '{}points = (131, 0), (131, 1, 2)\n'.format(kind),
-                         '{}points = (131, 0), (131, a)\n'.format(kind)]:
-            idx = np.where([old_line in line for line in f])[0][0]
-            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                     'data/{}_.txt'.format(in_file)), idx, new_line,
-                                     out_file=os.path.join(
-                                     os.path.dirname(__file__), 'data/{}_2.txt'.format(in_file)))
-
-            with pytest.raises(ValueError):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                             'data/crossmatch_params{}.txt'.format(
-                                             '_2' if 'cf' in kind else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                             'data/cat_a_params{}.txt'.format(
-                                             '_2' if 'cf' not in kind else '')),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-
-        # Check single-length point grids are fine
-        idx = np.where(['{}points = 131 134 4 -1 1 3'.format(kind) in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)),
-                                 idx, '{}points = 131 131 1 0 0 1\n'.format(kind),
-                                 out_file=os.path.join(os.path.dirname(__file__),
-                                                       'data/{}_.txt'.format(in_file)))
-
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                        'data/crossmatch_params{}.txt'.format('_' if 'cf' in kind else '')),
-                        os.path.join(os.path.dirname(__file__),
-                        'data/cat_a_params{}.txt'.format('_' if 'cf' not in kind else '')),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind else 'a_', kind)),
-                            np.array([[131, 0]]))
-
-        idx = np.where(['{}type = rectangle'.format(kind) in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)),
-                                 idx, '{}type = points\n'.format(kind),
-                                 out_file=os.path.join(os.path.dirname(__file__),
-                                                       'data/{}_.txt'.format(in_file)))
-
-        idx = np.where(['{}points = 131 134 4 -1 1 3'.format(kind) in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}_.txt'.format(in_file)),
-                                 idx, '{}points = (131, 0)\n'.format(kind),
-                                 out_file=os.path.join(os.path.dirname(__file__),
-                                                       'data/{}_2.txt'.format(in_file)))
-
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                        'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
-                        os.path.join(os.path.dirname(__file__),
-                        'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind else 'a_', kind)),
-                            np.array([[131, 0]]))
-
-    # Check galactic run is also fine -- here we have to replace all 3 parameter
-    # options with "galactic", however.
-    for in_file in ['crossmatch_params', 'cat_a_params', 'cat_b_params']:
-        kind = 'cf_region_' if 'h_p' in in_file else 'auf_region_'
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/{}.txt'.format(in_file))).readlines()
-        idx = np.where(['{}frame = equatorial'.format(kind) in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)),
-                                 idx, '{}frame = galactic\n'.format(kind),
-                                 out_file=os.path.join(os.path.dirname(__file__),
-                                                       'data/{}_.txt'.format(in_file)))
-
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
-    for kind in ['auf_region_', 'cf_region_']:
-        assert getattr(cm, '{}{}frame'.format('' if 'cf' in kind else 'a_', kind)) == 'galactic'
-        assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind else 'a_', kind)),
+        assert cm.cf_region_frame == 'equatorial'
+        assert_almost_equal(cm.cf_region_points,
                             np.array([[131, -1], [132, -1], [133, -1], [134, -1],
                                       [131, 0], [132, 0], [133, 0], [134, 0],
                                       [131, 1], [132, 1], [133, 1], [134, 1]]))
 
-
-def test_crossmatch_folder_path_inputs():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.joint_folder_path == os.path.join(os.getcwd(), 'test_path')
-    assert os.path.isdir(os.path.join(os.getcwd(), 'test_path'))
-    assert cm.a_auf_folder_path == os.path.join(os.getcwd(), 'gaia_auf_folder')
-    assert cm.b_auf_folder_path == os.path.join(os.getcwd(), 'wise_auf_folder')
-
-    # List of simple one line config file replacements for error message checking
-    for old_line, new_line, match_text, error, in_file in zip(
-            ['joint_folder_path = test_path', 'joint_folder_path = test_path',
-             'auf_folder_path = gaia_auf_folder', 'auf_folder_path = wise_auf_folder'],
-            ['', 'joint_folder_path = /User/test/some/path/\n', '',
-             'auf_folder_path = /User/test/some/path\n'],
-            ['Missing key', 'Error when trying to create temporary',
-             'Missing key auf_folder_path from catalogue "a"',
-             'folder for catalogue "b" AUF outputs. Please ensure that b_auf_folder_path'],
-            [ValueError, OSError, ValueError, OSError],
-            ['crossmatch_params', 'crossmatch_params', 'cat_a_params', 'cat_b_params']):
-        f = open(os.path.join(os.path.dirname(__file__),
-                 'data/{}.txt'.format(in_file))).readlines()
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        old_line = 'include_perturb_auf = no'
+        new_line = 'include_perturb_auf = yes\n'
         idx = np.where([old_line in line for line in f])[0][0]
         CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
+                                 'data/crossmatch_params.txt'), idx, new_line,
                                  out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
-
-        with pytest.raises(error, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format(
-                            '_' if 'h_p' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
-
-
-def test_crossmatch_tri_inputs():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert not hasattr(cm, 'a_tri_set_name')
-
-    f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
-    old_line = 'include_perturb_auf = no'
-    new_line = 'include_perturb_auf = yes\n'
-    idx = np.where([old_line in line for line in f])[0][0]
-    CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                             'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
-                             os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
-
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.a_tri_set_name == 'gaiadr2'
-    assert np.all(cm.b_tri_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
-    assert cm.a_tri_filt_num == 1
-    assert not cm.b_download_tri
-
-    # List of simple one line config file replacements for error message checking
-    for old_line, new_line, match_text, in_file in zip(
-            ['tri_set_name = gaiadr2', 'tri_filt_num = 11', 'tri_filt_num = 11',
-             'download_tri = no', 'download_tri = no'],
-            ['', 'tri_filt_num = a\n', 'tri_filt_num = 3.4\n', 'download_tri = aye\n',
-             'download_tri = yes\n'],
-            ['Missing key tri_set_name from catalogue "a"',
-             'tri_filt_num should be a single integer number in catalogue "b"',
-             'tri_filt_num should be a single integer number in catalogue "b"',
-             'Boolean flag key not set', 'a_download_tri is True and run_auf is False'],
-            ['cat_a_params', 'cat_b_params', 'cat_b_params', 'cat_a_params', 'cat_a_params']):
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/{}.txt'.format(in_file))).readlines()
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
-                                 out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
-
-        with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params_.txt'),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
-
-
-def test_crossmatch_psf_param_inputs():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert not hasattr(cm, 'a_norm_scale_laws')
-    assert np.all(cm.b_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
-
-    f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
-    old_line = 'include_perturb_auf = no'
-    new_line = 'include_perturb_auf = yes\n'
-    idx = np.where([old_line in line for line in f])[0][0]
-    CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                             'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
-                             os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
-
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert np.all(cm.a_psf_fwhms == np.array([0.12, 0.12, 0.12]))
-    assert np.all(cm.b_norm_scale_laws == np.array([2, 2, 2, 2]))
-
-    # List of simple one line config file replacements for error message checking
-    for old_line, new_line, match_text, in_file in zip(
-            ['filt_names = G G_BP G_RP', 'filt_names = G G_BP G_RP', 'norm_scale_laws = 2 2 2',
-             'psf_fwhms = 6.08 6.84 7.36 11.99', 'psf_fwhms = 6.08 6.84 7.36 11.99'],
-            ['', 'filt_names = G G_BP\n', 'norm_scale_laws = 2 2 a\n',
-             'psf_fwhms = 6.08 6.84 7.36\n', 'psf_fwhms = 6.08 6.84 7.36 word\n'],
-            ['Missing key filt_names from catalogue "a"',
-             'a_tri_filt_names and a_filt_names should contain the same',
-             'norm_scale_laws should be a list of floats in catalogue "a"',
-             'b_psf_fwhms and b_filt_names should contain the same',
-             'psf_fwhms should be a list of floats in catalogue "b".'],
-            ['cat_a_params', 'cat_a_params', 'cat_a_params', 'cat_b_params', 'cat_b_params']):
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/{}.txt'.format(in_file))).readlines()
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
-                                 out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
-
-        with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params_.txt'),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
-
-
-def test_crossmatch_cat_name_inputs():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.b_cat_name == 'WISE'
-    assert os.path.exists('{}/test_path/WISE'.format(os.getcwd()))
-
-    f = open(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt')).readlines()
-    old_line = 'cat_name = Gaia'
-    new_line = ''
-    idx = np.where([old_line in line for line in f])[0][0]
-    CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                             'data/cat_a_params.txt'), idx, new_line, out_file=os.path.join(
-                             os.path.dirname(__file__), 'data/cat_a_params_.txt'))
-
-    match_text = 'Missing key cat_name from catalogue "a"'
-    with pytest.raises(ValueError, match=match_text):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                                 os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.a_auf_region_frame == 'equatorial'
+        assert_almost_equal(cm.a_auf_region_points,
+                            np.array([[131, -1], [132, -1], [133, -1], [134, -1],
+                                      [131, 0], [132, 0], [133, 0], [134, 0],
+                                      [131, 1], [132, 1], [133, 1], [134, 1]]))
+        assert_almost_equal(cm.b_auf_region_points,
+                            np.array([[131, -1], [132, -1], [133, -1], [134, -1],
+                                      [131, -1/3], [132, -1/3], [133, -1/3], [134, -1/3],
+                                      [131, 1/3], [132, 1/3], [133, 1/3], [134, 1/3],
+                                      [131, 1], [132, 1], [133, 1], [134, 1]]))
 
+        for kind in ['auf_region_', 'cf_region_']:
+            in_file = 'crossmatch_params' if 'cf' in kind else 'cat_a_params'
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}.txt'.format(in_file))).readlines()
+            # List of simple one line config file replacements for error message checking
+            for old_line, new_line, match_text in zip(
+                ['{}type = rectangle'.format(kind), '{}type = rectangle'.format(kind),
+                 '{}points = 131 134 4 -1 1 3'.format(kind),
+                 '{}points = 131 134 4 -1 1 3'.format(kind),
+                 '{}frame = equatorial'.format(kind), '{}points = 131 134 4 -1 1 3'.format(kind)],
+                ['', '{}type = triangle\n'.format(kind),
+                 '{}points = 131 134 4 -1 1 a\n'.format(kind),
+                 '{}points = 131 134 4 -1 1\n'.format(kind), '{}frame = ecliptic\n'.format(kind),
+                 '{}points = 131 134 4 -1 1 3.4\n'.format(kind)],
+                ['Missing key {}type'.format(kind),
+                 "{}{}type should either be 'rectangle' or".format('' if 'cf' in kind
+                                                                   else 'a_', kind),
+                 '{}{}points should be 6 numbers'.format('' if 'cf' in kind else 'a_', kind),
+                 '{}{}points should be 6 numbers'.format('' if 'cf' in kind else 'a_', kind),
+                 "{}{}frame should either be 'equatorial' or".format(
+                    '' if 'cf' in kind else 'a_', kind),
+                 'start and stop values for {}{}points'.format('' if 'cf' in kind
+                                                               else 'a_', kind)]):
+                idx = np.where([old_line in line for line in f])[0][0]
+                CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                         'data/{}.txt'.format(in_file)), idx, new_line,
+                                         out_file=os.path.join(os.path.dirname(__file__),
+                                                               'data/{}_.txt'.format(in_file)))
 
-def test_crossmatch_search_inputs():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.pos_corr_dist == 11
-    assert cm.b_dens_dist == 900
+                with pytest.raises(ValueError, match=match_text):
+                    cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                                 'data/crossmatch_params{}.txt'.format(
+                                                 '_' if 'cf' in kind else '')),
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'data/cat_a_params{}.txt'.format(
+                                                 '_' if 'cf' not in kind else '')),
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'data/cat_b_params.txt'))
 
-    # List of simple one line config file replacements for error message checking
-    for old_line, new_line, match_text, in_file in zip(
-            ['pos_corr_dist = 11', 'pos_corr_dist = 11', 'dens_dist = 900', 'dens_dist = 900'],
-            ['', 'pos_corr_dist = word\n', '', 'dens_dist = word\n'],
-            ['Missing key pos_corr_dist', 'pos_corr_dist must be a float',
-             'Missing key dens_dist from catalogue "b"', 'dens_dist in catalogue "a" must'],
-            ['crossmatch_params', 'crossmatch_params', 'cat_b_params', 'cat_a_params']):
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/{}.txt'.format(in_file))).readlines()
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
-                                 out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+            # Check correct and incorrect *_region_points when *_region_type is 'points'
+            idx = np.where(['{}type = rectangle'.format(kind) in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                                      'data/{}.txt'.format(in_file)),
+                                     idx, '{}type = points\n'.format(kind),
+                                     out_file=os.path.join(os.path.dirname(__file__),
+                                                           'data/{}_.txt'.format(in_file)))
 
-        with pytest.raises(ValueError, match=match_text):
+            idx = np.where(['{}points = 131 134 4 -1 1 3'.format(kind) in line for
+                            line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}_.txt'.format(in_file)), idx,
+                                     '{}points = (131, 0), (133, 0), (132, -1)\n'.format(kind),
+                                     out_file=os.path.join(os.path.dirname(__file__),
+                                                           'data/{}_2.txt'.format(in_file)))
+
             cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format(
-                            '_' if 'h_p' in in_file else '')),
+                            'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
                             os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                            'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind
+                                else 'a_', kind)), np.array([[131, 0], [133, 0], [132, -1]]))
+
+            old_line = '{}points = 131 134 4 -1 1 3'.format(kind)
+            for new_line in ['{}points = (131, 0), (131, )\n'.format(kind),
+                             '{}points = (131, 0), (131, 1, 2)\n'.format(kind),
+                             '{}points = (131, 0), (131, a)\n'.format(kind)]:
+                idx = np.where([old_line in line for line in f])[0][0]
+                CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                         'data/{}_.txt'.format(in_file)), idx, new_line,
+                                         out_file=os.path.join(
+                                         os.path.dirname(__file__),
+                                         'data/{}_2.txt'.format(in_file)))
+
+                with pytest.raises(ValueError):
+                    cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                                 'data/crossmatch_params{}.txt'.format(
+                                                 '_2' if 'cf' in kind else '')),
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'data/cat_a_params{}.txt'.format(
+                                                 '_2' if 'cf' not in kind else '')),
+                                    os.path.join(os.path.dirname(__file__),
+                                                 'data/cat_b_params.txt'))
+
+            # Check single-length point grids are fine
+            idx = np.where(['{}points = 131 134 4 -1 1 3'.format(kind) in line
+                            for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)),
+                                     idx, '{}points = 131 131 1 0 0 1\n'.format(kind),
+                                     out_file=os.path.join(os.path.dirname(__file__),
+                                                           'data/{}_.txt'.format(in_file)))
+
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                            'data/crossmatch_params{}.txt'.format('_' if 'cf' in kind else '')),
                             os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                            'data/cat_a_params{}.txt'.format('_' if 'cf' not in kind else '')),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind
+                                else 'a_', kind)), np.array([[131, 0]]))
 
+            idx = np.where(['{}type = rectangle'.format(kind) in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)),
+                                     idx, '{}type = points\n'.format(kind),
+                                     out_file=os.path.join(os.path.dirname(__file__),
+                                                           'data/{}_.txt'.format(in_file)))
 
-def test_crossmatch_fourier_inputs():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.real_hankel_points == 10000
-    assert cm.four_hankel_points == 10000
-    assert cm.four_max_rho == 100
+            idx = np.where(['{}points = 131 134 4 -1 1 3'.format(kind) in
+                            line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}_.txt'.format(in_file)),
+                                     idx, '{}points = (131, 0)\n'.format(kind),
+                                     out_file=os.path.join(os.path.dirname(__file__),
+                                                           'data/{}_2.txt'.format(in_file)))
 
-    # List of simple one line config file replacements for error message checking
-    for old_line, new_line, match_text in zip(
-            ['real_hankel_points = 10000', 'four_hankel_points = 10000', 'four_max_rho = 100'],
-            ['', 'four_hankel_points = 10000.1\n', 'four_max_rho = word\n'],
-            ['Missing key real_hankel_points', 'four_hankel_points should be an integer.',
-             'four_max_rho should be an integer.']):
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/crossmatch_params.txt')).readlines()
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                            'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
+                            os.path.join(os.path.dirname(__file__),
+                            'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind
+                                else 'a_', kind)), np.array([[131, 0]]))
+
+        # Check galactic run is also fine -- here we have to replace all 3 parameter
+        # options with "galactic", however.
+        for in_file in ['crossmatch_params', 'cat_a_params', 'cat_b_params']:
+            kind = 'cf_region_' if 'h_p' in in_file else 'auf_region_'
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}.txt'.format(in_file))).readlines()
+            idx = np.where(['{}frame = equatorial'.format(kind) in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)),
+                                     idx, '{}frame = galactic\n'.format(kind),
+                                     out_file=os.path.join(os.path.dirname(__file__),
+                                                           'data/{}_.txt'.format(in_file)))
+
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+        for kind in ['auf_region_', 'cf_region_']:
+            assert getattr(cm, '{}{}frame'.format('' if 'cf' in kind
+                                                  else 'a_', kind)) == 'galactic'
+            assert_almost_equal(getattr(cm, '{}{}points'.format('' if 'cf' in kind
+                                                                else 'a_', kind)),
+                                np.array([[131, -1], [132, -1], [133, -1], [134, -1],
+                                          [131, 0], [132, 0], [133, 0], [134, 0],
+                                          [131, 1], [132, 1], [133, 1], [134, 1]]))
+
+    def test_crossmatch_folder_path_inputs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.joint_folder_path == os.path.join(os.getcwd(), 'test_path')
+        assert os.path.isdir(os.path.join(os.getcwd(), 'test_path'))
+        assert cm.a_auf_folder_path == os.path.join(os.getcwd(), 'gaia_auf_folder')
+        assert cm.b_auf_folder_path == os.path.join(os.getcwd(), 'wise_auf_folder')
+
+        # List of simple one line config file replacements for error message checking
+        for old_line, new_line, match_text, error, in_file in zip(
+                ['joint_folder_path = test_path', 'joint_folder_path = test_path',
+                 'auf_folder_path = gaia_auf_folder', 'auf_folder_path = wise_auf_folder'],
+                ['', 'joint_folder_path = /User/test/some/path/\n', '',
+                 'auf_folder_path = /User/test/some/path\n'],
+                ['Missing key', 'Error when trying to create temporary',
+                 'Missing key auf_folder_path from catalogue "a"',
+                 'folder for catalogue "b" AUF outputs. Please ensure that b_auf_folder_path'],
+                [ValueError, OSError, ValueError, OSError],
+                ['crossmatch_params', 'crossmatch_params', 'cat_a_params', 'cat_b_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                     'data/{}.txt'.format(in_file))).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+
+            with pytest.raises(error, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params{}.txt'.format(
+                                '_' if 'h_p' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
+    def test_crossmatch_tri_inputs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert not hasattr(cm, 'a_tri_set_name')
+
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        old_line = 'include_perturb_auf = no'
+        new_line = 'include_perturb_auf = yes\n'
         idx = np.where([old_line in line for line in f])[0][0]
         CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
                                  'data/crossmatch_params.txt'), idx, new_line,
                                  out_file=os.path.join(
                                  os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
 
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.a_tri_set_name == 'gaiadr2'
+        assert np.all(cm.b_tri_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
+        assert cm.a_tri_filt_num == 1
+        assert not cm.b_download_tri
+
+        # List of simple one line config file replacements for error message checking
+        for old_line, new_line, match_text, in_file in zip(
+                ['tri_set_name = gaiadr2', 'tri_filt_num = 11', 'tri_filt_num = 11',
+                 'download_tri = no', 'download_tri = no'],
+                ['', 'tri_filt_num = a\n', 'tri_filt_num = 3.4\n', 'download_tri = aye\n',
+                 'download_tri = yes\n'],
+                ['Missing key tri_set_name from catalogue "a"',
+                 'tri_filt_num should be a single integer number in catalogue "b"',
+                 'tri_filt_num should be a single integer number in catalogue "b"',
+                 'Boolean flag key not set', 'a_download_tri is True and run_auf is False'],
+                ['cat_a_params', 'cat_b_params', 'cat_b_params', 'cat_a_params', 'cat_a_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}.txt'.format(in_file))).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
+    def test_crossmatch_psf_param_inputs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert not hasattr(cm, 'a_norm_scale_laws')
+        assert np.all(cm.b_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
+
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        old_line = 'include_perturb_auf = no'
+        new_line = 'include_perturb_auf = yes\n'
+        idx = np.where([old_line in line for line in f])[0][0]
+        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                 'data/crossmatch_params.txt'), idx, new_line,
+                                 out_file=os.path.join(
+                                 os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
+
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.a_psf_fwhms == np.array([0.12, 0.12, 0.12]))
+        assert np.all(cm.b_norm_scale_laws == np.array([2, 2, 2, 2]))
+
+        # List of simple one line config file replacements for error message checking
+        for old_line, new_line, match_text, in_file in zip(
+                ['filt_names = G G_BP G_RP', 'filt_names = G G_BP G_RP', 'norm_scale_laws = 2 2 2',
+                 'psf_fwhms = 6.08 6.84 7.36 11.99', 'psf_fwhms = 6.08 6.84 7.36 11.99'],
+                ['', 'filt_names = G G_BP\n', 'norm_scale_laws = 2 2 a\n',
+                 'psf_fwhms = 6.08 6.84 7.36\n', 'psf_fwhms = 6.08 6.84 7.36 word\n'],
+                ['Missing key filt_names from catalogue "a"',
+                 'a_tri_filt_names and a_filt_names should contain the same',
+                 'norm_scale_laws should be a list of floats in catalogue "a"',
+                 'b_psf_fwhms and b_filt_names should contain the same',
+                 'psf_fwhms should be a list of floats in catalogue "b".'],
+                ['cat_a_params', 'cat_a_params', 'cat_a_params', 'cat_b_params', 'cat_b_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}.txt'.format(in_file))).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
+    def test_crossmatch_cat_name_inputs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.b_cat_name == 'WISE'
+        assert os.path.exists('{}/test_path/WISE'.format(os.getcwd()))
+
+        f = open(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt')).readlines()
+        old_line = 'cat_name = Gaia'
+        new_line = ''
+        idx = np.where([old_line in line for line in f])[0][0]
+        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                 'data/cat_a_params.txt'), idx, new_line, out_file=os.path.join(
+                                 os.path.dirname(__file__), 'data/cat_a_params_.txt'))
+
+        match_text = 'Missing key cat_name from catalogue "a"'
         with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
 
+    def test_crossmatch_search_inputs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.pos_corr_dist == 11
+        assert cm.b_dens_dist == 900
 
-def test_crossmatch_frame_equality():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert cm.a_auf_region_frame == 'equatorial'
-    assert cm.b_auf_region_frame == 'equatorial'
-    assert cm.cf_region_frame == 'equatorial'
+        # List of simple one line config file replacements for error message checking
+        for old_line, new_line, match_text, in_file in zip(
+                ['pos_corr_dist = 11', 'pos_corr_dist = 11', 'dens_dist = 900', 'dens_dist = 900'],
+                ['', 'pos_corr_dist = word\n', '', 'dens_dist = word\n'],
+                ['Missing key pos_corr_dist', 'pos_corr_dist must be a float',
+                 'Missing key dens_dist from catalogue "b"', 'dens_dist in catalogue "a" must'],
+                ['crossmatch_params', 'crossmatch_params', 'cat_b_params', 'cat_a_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}.txt'.format(in_file))).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
-    # List of simple one line config file replacements for error message checking
-    match_text = 'Region frames for c/f and AUF creation must all be the same.'
-    for old_line, new_line, in_file in zip(
-            ['cf_region_frame = equatorial', 'auf_region_frame = equatorial',
-             'auf_region_frame = equatorial'],
-            ['cf_region_frame = galactic\n', 'auf_region_frame = galactic\n',
-             'auf_region_frame = galactic\n'],
-            ['crossmatch_params', 'cat_a_params', 'cat_b_params']):
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params{}.txt'.format(
+                                '_' if 'h_p' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
+    def test_crossmatch_fourier_inputs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.real_hankel_points == 10000
+        assert cm.four_hankel_points == 10000
+        assert cm.four_max_rho == 100
+
+        # List of simple one line config file replacements for error message checking
+        for old_line, new_line, match_text in zip(
+                ['real_hankel_points = 10000', 'four_hankel_points = 10000', 'four_max_rho = 100'],
+                ['', 'four_hankel_points = 10000.1\n', 'four_max_rho = word\n'],
+                ['Missing key real_hankel_points', 'four_hankel_points should be an integer.',
+                 'four_max_rho should be an integer.']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/crossmatch_params.txt')).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params.txt'), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+
+    def test_crossmatch_frame_equality(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.a_auf_region_frame == 'equatorial'
+        assert cm.b_auf_region_frame == 'equatorial'
+        assert cm.cf_region_frame == 'equatorial'
+
+        # List of simple one line config file replacements for error message checking
+        match_text = 'Region frames for c/f and AUF creation must all be the same.'
+        for old_line, new_line, in_file in zip(
+                ['cf_region_frame = equatorial', 'auf_region_frame = equatorial',
+                 'auf_region_frame = equatorial'],
+                ['cf_region_frame = galactic\n', 'auf_region_frame = galactic\n',
+                 'auf_region_frame = galactic\n'],
+                ['crossmatch_params', 'cat_a_params', 'cat_b_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}.txt'.format(in_file))).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params{}.txt'.format(
+                                '_' if 'h_p' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
+    def test_cross_match_extent(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.cross_match_extent == np.array([131, 138, -3, 3]))
+
+        # List of simple one line config file replacements for error message checking
+        in_file = 'crossmatch_params'
         f = open(os.path.join(os.path.dirname(__file__),
                               'data/{}.txt'.format(in_file))).readlines()
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
-                                 out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+        old_line = 'cross_match_extent = 131 138 -3 3'
+        for new_line, match_text in zip(
+                ['', 'cross_match_extent = 131 138 -3 word\n', 'cross_match_extent = 131 138 -3\n',
+                 'cross_match_extent = 131 138 -3 3 1'],
+                ['Missing key cross_match_extent', 'All elements of cross_match_extent should be',
+                 'cross_match_extent should contain.', 'cross_match_extent should contain']):
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
-        with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format(
-                            '_' if 'h_p' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params{}.txt'.format(
+                                '_' if 'h_p' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
+    def test_crossmatch_chunk_num(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.mem_chunk_num == 10)
 
-def test_cross_match_extent():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert np.all(cm.cross_match_extent == np.array([131, 138, -3, 3]))
+        # List of simple one line config file replacements for error message checking
+        in_file = 'crossmatch_params'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/{}.txt'.format(in_file))).readlines()
+        old_line = 'mem_chunk_num = 10'
+        for new_line, match_text in zip(
+                ['', 'mem_chunk_num = word\n', 'mem_chunk_num = 10.1\n'],
+                ['Missing key mem_chunk_num', 'mem_chunk_num should be a single integer',
+                 'mem_chunk_num should be a single integer']):
+            idx = np.where([old_line in line for line in f])[0][0]
+            CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
+                                     'data/{}.txt'.format(in_file)), idx, new_line,
+                                     out_file=os.path.join(
+                                     os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
-    # List of simple one line config file replacements for error message checking
-    in_file = 'crossmatch_params'
-    f = open(os.path.join(os.path.dirname(__file__),
-                          'data/{}.txt'.format(in_file))).readlines()
-    old_line = 'cross_match_extent = 131 138 -3 3'
-    for new_line, match_text in zip(
-            ['', 'cross_match_extent = 131 138 -3 word\n', 'cross_match_extent = 131 138 -3\n',
-             'cross_match_extent = 131 138 -3 3 1'],
-            ['Missing key cross_match_extent', 'All elements of cross_match_extent should be',
-             'cross_match_extent should contain.', 'cross_match_extent should contain']):
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
-                                 out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params{}.txt'.format(
+                                '_' if 'h_p' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
-        with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format(
-                            '_' if 'h_p' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+    def test_crossmatch_shared_data(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.r == np.linspace(0, 1.185 * 11.99, 10000))
+        assert_almost_equal(cm.dr, np.ones(9999, float) * 1.185*11.99/9999)
+        assert np.all(cm.rho == np.linspace(0, 100, 10000))
+        assert_almost_equal(cm.drho, np.ones(9999, float) * 100/9999)
 
+    def test_cat_folder_path(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert os.path.exists(self.a_cat_folder_path)
+        assert os.path.exists(self.b_cat_folder_path)
+        assert cm.a_cat_folder_path == self.a_cat_folder_path
+        assert np.all(np.load('{}/con_cat_astro.npy'.format(
+                      self.a_cat_folder_path)).shape == (2, 3))
+        assert np.all(np.load('{}/con_cat_photo.npy'.format(
+                      self.b_cat_folder_path)).shape == (2, 4))
+        assert np.all(np.load('{}/magref.npy'.format(
+                      self.b_cat_folder_path)).shape == (2,))
 
-def test_crossmatch_chunk_num():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert np.all(cm.mem_chunk_num == 10)
+        os.system('rm -rf {}'.format(self.a_cat_folder_path))
+        with pytest.raises(OSError, match="a_cat_folder_path does not exist."):
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        self.setup_class()
 
-    # List of simple one line config file replacements for error message checking
-    in_file = 'crossmatch_params'
-    f = open(os.path.join(os.path.dirname(__file__),
-                          'data/{}.txt'.format(in_file))).readlines()
-    old_line = 'mem_chunk_num = 10'
-    for new_line, match_text in zip(
-            ['', 'mem_chunk_num = word\n', 'mem_chunk_num = 10.1\n'],
-            ['Missing key mem_chunk_num', 'mem_chunk_num should be a single integer',
-             'mem_chunk_num should be a single integer']):
-        idx = np.where([old_line in line for line in f])[0][0]
-        CrossMatch._replace_line(cm, os.path.join(os.path.dirname(__file__),
-                                 'data/{}.txt'.format(in_file)), idx, new_line,
-                                 out_file=os.path.join(
-                                 os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+        os.system('rm -rf {}'.format(self.b_cat_folder_path))
+        with pytest.raises(OSError, match="b_cat_folder_path does not exist."):
+            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        self.setup_class()
 
-        with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format(
-                            '_' if 'h_p' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+        for catpath, file in zip([self.a_cat_folder_path, self.b_cat_folder_path],
+                                 ['con_cat_astro', 'magref']):
+            os.system('rm {}/{}.npy'.format(catpath, file))
+            with pytest.raises(FileNotFoundError,
+                               match='{} file not found in catalogue '.format(file)):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            self.setup_class()
 
-
-def test_crossmatch_shared_data():
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-    assert np.all(cm.r == np.linspace(0, 1.185 * 11.99, 10000))
-    assert_almost_equal(cm.dr, np.ones(9999, float) * 1.185*11.99/9999)
-    assert np.all(cm.rho == np.linspace(0, 100, 10000))
-    assert_almost_equal(cm.drho, np.ones(9999, float) * 100/9999)
+        for name, data, match in zip(['con_cat_astro', 'con_cat_photo', 'con_cat_astro',
+                                      'con_cat_photo', 'magref', 'con_cat_astro', 'con_cat_photo',
+                                      'magref'],
+                                     [np.zeros((2, 2), float), np.zeros((2, 5), float),
+                                      np.zeros((2, 3, 4), float), np.zeros(2, float),
+                                      np.zeros((2, 2), float), np.zeros((1, 3), float),
+                                      np.zeros((3, 4), float), np.zeros(3, float)],
+                                     ["Second dimension of con_cat_astro",
+                                      "Second dimension of con_cat_photo in",
+                                      "Incorrect number of dimensions",
+                                      "Incorrect number of dimensions",
+                                      "Incorrect number of dimensions",
+                                      'Consolidated catalogue arrays for catalogue "b"',
+                                      'Consolidated catalogue arrays for catalogue "b"',
+                                      'Consolidated catalogue arrays for catalogue "b"']):
+            np.save('{}/{}.npy'.format(self.b_cat_folder_path, name), data)
+            with pytest.raises(ValueError, match=match):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            self.setup_class()

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -1,0 +1,11 @@
+# Licensed under a 3-clause BSD style license - see LICENSE
+'''
+Tests for the "perturbation_auf" module.
+'''
+
+import pytest
+import os
+from numpy.testing import assert_almost_equal
+import numpy as np
+
+from ..matching import CrossMatch

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -5,7 +5,37 @@ Tests for the "perturbation_auf" module.
 
 import pytest
 import os
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 import numpy as np
 
 from ..matching import CrossMatch
+from ..perturbation_auf_fortran import perturbation_auf_fortran as paf
+
+
+def test_haversine_formula():
+    a, b, c, d = 0, 0, 0, 0
+    e = paf.haversine(a, b, c, d)
+    assert e == 0
+
+    a, b, c, d = 0.0, 1/3600, 0, 0
+    e = paf.haversine(a, b, c, d)
+    assert_allclose(e, 1/3600)
+
+    a, b, c, d = 0.0, 1/3600, 2.45734, 2.45734
+    e = paf.haversine(a, b, c, d)
+    assert_allclose(e, 1/3600*np.cos(np.radians(c)))
+
+    a, b, c, d = 25.10573, 25.30573, 15.48349, 15.48349
+    e = paf.haversine(b, a, c, d)
+    # Reduce tolerance with DeltaRA cos(Dec) a worse approximation at larger Dec.
+    assert_allclose(e, 0.2*np.cos(np.radians(c)), rtol=1e-5)
+
+    a, b, c, d = 51.45734, 51.45734, 0, 1/3600
+    e = paf.haversine(a, b, c, d)
+    assert_allclose(e, 1/3600)
+    e = paf.haversine(a, b, d, c)
+    assert_allclose(e, 1/3600)
+
+    c, d = 86.47239, 85.47239
+    e = paf.haversine(a, b, d, c)
+    assert_allclose(e, 1)

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -47,3 +47,127 @@ def test_closest_auf_point():
     inds = paf.find_nearest_auf_point(source_points[:, 0], source_points[:, 1],
                                       auf_points[:, 0], auf_points[:, 1])
     assert np.all(inds == np.array([0, 1, 1]))
+
+
+class TestCreatePerturbAUF:
+    def setup_class(self):
+        self.cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        self.cm.a_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
+        self.cm.b_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
+        self.cm.mem_chunk_num = 4
+        self.files_per_auf_sim = 7
+
+    @pytest.mark.filterwarnings("ignore:Incorrect number of files in")
+    def test_not_implemented_error(self):
+        # Reset any saved files from these tests
+        os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
+        os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
+        self.cm.include_perturb_auf = True
+        self.cm.a_psf_fwhms = np.array([0.1, 0.1, 0.1])
+        self.cm.a_download_tri = False
+        with pytest.raises(NotImplementedError, match="Perturbation AUF components are not "
+                           "currently included"):
+            self.cm.create_perturb_auf(self.files_per_auf_sim)
+
+    def test_no_perturb_outputs(self):
+        # Randomly generate two catalogues (x3 files) between coordinates
+        # 0, 0 and 50, 50.
+        rng = np.random.default_rng()
+        for path, Nf, size in zip([self.cm.a_cat_folder_path, self.cm.b_cat_folder_path], [3, 4],
+                                  [25, 54]):
+            cat = np.zeros((size, 3), float)
+            rand_inds = rng.permutation(cat.shape[0])[:size // 2 - 1]
+            cat[rand_inds, 0] = 50
+            cat[rand_inds, 1] = 50
+            cat += rng.uniform(-0.1, 0.1, cat.shape)
+            np.save('{}/con_cat_astro.npy'.format(path), cat)
+
+            cat = rng.uniform(10, 20, (size, Nf))
+            np.save('{}/con_cat_photo.npy'.format(path), cat)
+
+            cat = rng.choice(Nf, size=(size,))
+            np.save('{}/magref.npy'.format(path), cat)
+
+        self.cm.include_perturb_auf = False
+        self.cm.run_auf = True
+        self.cm.create_perturb_auf(self.files_per_auf_sim)
+        lenr = len(self.cm.r)
+        lenrho = len(self.cm.rho)
+        for coord in ['0.0', '50.0']:
+            for filt in ['W1', 'W2', 'W3', 'W4']:
+                path = '{}/{}/{}/{}'.format(self.cm.b_auf_folder_path, coord, coord, filt)
+                for filename, shape in zip(['frac', 'flux', 'offset', 'cumulative', 'fourier',
+                                            'N', 'mag'],
+                                           [(2, 1), (1,), (lenr-1, 1), (lenr-1, 1), (lenrho-1, 1),
+                                            (1, 1), (1, 1)]):
+                    assert os.path.isfile('{}/{}.npy'.format(path, filename))
+                    file = np.load('{}/{}.npy'.format(path, filename))
+                    assert np.all(file.shape == shape)
+                assert np.all(np.load('{}/frac.npy'.format(path)) == 0)
+                assert np.all(np.load('{}/cumulative.npy'.format(path)) == 1)
+                assert np.all(np.load('{}/fourier.npy'.format(path)) == 1)
+                assert np.all(np.load('{}/mag.npy'.format(path)) == 1)
+                file = np.load('{}/offset.npy'.format(path))
+                assert np.all(file[1:] == 0)
+                assert file[0] == 1/(2 * np.pi * (self.cm.r[0] + self.cm.dr[0]/2) * self.cm.dr[0])
+
+        file = np.load('{}/modelrefinds.npy'.format(self.cm.a_auf_folder_path))
+        assert np.all(file[0, :] == 0)
+        assert np.all(file[1, :] == np.load('{}/magref.npy'.format(self.cm.a_cat_folder_path)))
+
+        # Select AUF pointing index based on a 0 vs 50 cut in longitude.
+        cat = np.load('{}/con_cat_astro.npy'.format(self.cm.a_cat_folder_path))
+        inds = np.ones(file.shape[1], int)
+        inds[np.where(cat[:, 0] < 1)[0]] = 0
+        assert np.all(file[2, :] == inds)
+
+    def test_run_auf_file_number(self):
+        # Reset any saved files from the above tests
+        os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
+        os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
+        self.cm.run_auf = False
+        with pytest.warns(UserWarning, match='Incorrect number of files in catalogue "a"'):
+            self.cm.create_perturb_auf(self.files_per_auf_sim)
+
+        # Now create fake files to simulate catalogue "a" having the right files.
+        # For 2 AUF pointings this comes to 5 + 2*N_filt*files_per_auf_sim files.
+        os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
+        for i in range(5 + 2 * 3 * self.files_per_auf_sim):
+            np.save('{}/random_file_{}.npy'.format(self.cm.a_auf_folder_path, i), np.zeros(1))
+
+        # This should still return the same warning, just for catalogue "b" now.
+        with pytest.warns(UserWarning) as record:
+            self.cm.create_perturb_auf(self.files_per_auf_sim)
+        assert len(record) == 1
+        assert 'Incorrect number of files in catalogue "b"' in record[0].message.args[0]
+
+    @pytest.mark.filterwarnings("ignore:Incorrect number of files in")
+    def test_load_auf_print(self, capsys):
+        # Reset any saved files from the above tests
+        os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
+        os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
+
+        # Generate new dummy data for catalogue "b"'s AUF folder.
+        for i in range(5 + 2 * 4 * self.files_per_auf_sim):
+            np.save('{}/random_file_{}.npy'.format(self.cm.b_auf_folder_path, i), np.zeros(1))
+        capsys.readouterr()
+        # This test will create catalogue "a" files because of the wrong
+        # number of files (zero) in the folder.
+        self.cm.create_perturb_auf(self.files_per_auf_sim)
+        output = capsys.readouterr().out
+        assert 'Loading empirical crowding AUFs for catalogue "a"' not in output
+        assert 'Loading empirical crowding AUFs for catalogue "b"' in output
+
+        os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
+        os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
+        # Generate new dummy data for each catalogue's AUF folder.
+        for path, fn in zip([self.cm.a_auf_folder_path, self.cm.b_auf_folder_path], [3, 4]):
+            for i in range(5 + 2 * fn * self.files_per_auf_sim):
+                np.save('{}/random_file_{}.npy'.format(path, i), np.zeros(1))
+        capsys.readouterr()
+        self.cm.create_perturb_auf(self.files_per_auf_sim)
+        output = capsys.readouterr().out
+        assert 'Loading empirical crowding AUFs for catalogue "a"' in output
+        assert 'Loading empirical crowding AUFs for catalogue "b"' in output

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -39,3 +39,11 @@ def test_haversine_formula():
     c, d = 86.47239, 85.47239
     e = paf.haversine(a, b, d, c)
     assert_allclose(e, 1)
+
+
+def test_closest_auf_point():
+    auf_points = np.array([[1, 1], [50, 50]])
+    source_points = np.array([[3, 2], [80, 50], [40, 30]])
+    inds = paf.find_nearest_auf_point(source_points[:, 0], source_points[:, 1],
+                                      auf_points[:, 0], auf_points[:, 1])
+    assert np.all(inds == np.array([0, 1, 1]))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 from setuptools import find_packages
 from numpy.distutils.core import Extension, setup
 
-extension = []
+extension = [Extension(name='macauff.perturbation_auf_fortran',
+                       sources=['macauff/perturbation_auf_fortran.f90'], language='f90',
+                       extra_link_args=["-lgomp"],
+                       extra_f90_compile_args=["-Wall", "-Wextra", "-Werror", "-pedantic",
+                                               "-fbacktrace", "-O0", "-g", "-fcheck=all",
+                                               "-fopenmp"])]
 
 setup(name="macauff", packages=find_packages(),
       package_data={'macauff': ['tests/data/*']},


### PR DESCRIPTION
This PR sets up the limiting case of the extension to the AUF for perturbation by crowded sources, in the limit where no such crowding exists. This is handled in such a way as to be compatible with implementations going forwards, but creates such "dummy" parameters and variables as to reduce to the simpler case computationally.