### PR TITLE
Updated tox setup with positional arguments and coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [options.extras_require]
 test =
-    pytest
+	numpy
+	scipy
+    pytest-astropy
 docs =
     sphinx-astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py37-test
+	py37-test{,-cov}
 	build_docs
 
 isolated_build = true
@@ -12,13 +12,16 @@ deps =
 	numpy
 	scipy
 	pytest
+	cov: coverage
 
 extras =
 	test
 	build_docs: docs
 
 commands =
-    pytest --pyargs macauff
+    !cov: pytest --pyargs macauff {posargs}
+    cov: pytest --pyargs macauff --cov macauff {posargs}
+    cov: coverage html
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
Updated `tox.ini` to allow for positional arguments (such as `-x`) to be passed through to pytest, and added a test option to test the line coverage of the code.