### PR TITLE
Initial documentation for v0.1.1

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -23,3 +23,76 @@ jobs:
         run: tox -e test
       - name: Run documentation
         run: tox -e build_docs
+
+  build_docs_job:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install Tox and any other packages
+        run: |
+          sudo ln -sf /usr/bin/gfortran-9 /usr/bin/gfortran
+          pip install numpy
+          pip install tox
+
+      - name: Run documentation
+        run: tox -e build_docs
+
+      - name: Execute script to build our documentation and update pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+
+          cd docs
+          #######################
+          # Update GitHub Pages #
+          #######################
+           
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+           
+          docroot=`mktemp -d`
+          rsync -av "_build/html/" "${docroot}/"
+           
+          pushd "${docroot}"
+           
+          # don't bother maintaining history; just generate fresh
+          git init
+          git remote add deploy "https://token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -b gh-pages
+           
+          # add .nojekyll to the root so that github won't 404 on content added to dirs
+          # that start with an underscore (_), such as our "_content" dir..
+          touch .nojekyll
+           
+          # Add README
+          cat > README.md <<EOF
+          # GitHub Pages Cache
+           
+          Nothing to see here. The contents of this branch are essentially a cache that's not intended to be viewed on github.com.
+           
+           
+          If you're looking to update our documentation, check the relevant development branch's 'docs/' dir.
+          EOF
+           
+          # copy the resulting html pages built from sphinx above to our new git repo
+          git add .
+           
+          # commit all the new files
+          msg="Updating github pages documentation"
+          git commit -am "${msg}"
+           
+          # overwrite the contents of the gh-pages branch on our github.com repo
+          git push deploy gh-pages --force
+           
+          popd # return to main repo sandbox root
+           
+          # exit cleanly
+          exit 0
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.pyc
 
 docs/_build
-docs/_api
+docs/api
 .tox
 .tmp
 *.egg-info

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 General
 ^^^^^^^
 
+- Preliminary creation of user documentation. [#22]
+
 - Established changelog [#8]
 
 New Features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'macauff'
-copyright = '2020, Tom J Wilson'
+copyright = '2021, Tom J Wilson'
 author = 'Tom J Wilson'
 
 # Parts of this conf.py use settings from sphinx-astropy's v1.py,
@@ -46,7 +46,11 @@ extensions = [
     'sphinx_astropy.ext.doctest',
     'sphinx_astropy.ext.changelog_links',
     'sphinx_astropy.ext.missing_static',
-    'sphinx.ext.mathjax']
+    'sphinx.ext.mathjax',
+    'sphinxfortran.fortran_domain',
+    'sphinxfortran.fortran_autodoc']
+
+fortran_src = ['../macauff/*.f90']
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,48 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+#######
 macauff
-=======
-**The python package for Matching Across Catalogues using the Astrometric Uncertainty Function and Flux**
+#######
+**The Python package for Matching Across Catalogues using the Astrometric Uncertainty Function and Flux**
+
+``macauff`` is a package for cross-matching photometric catalogues. Using the positions, uncertainties, and flux measurements of sources, as well as modelling of the level to which objects are affected by hidden, blended contaminants, ``macauff`` provides posterior probabilities of "many-to-many" matches and non-matches between the two catalogues being merged. It also provides numerous secondary parameters, such as the level to which sources are flux contaminated, and the probability of their suffering blended by a source of a given flux ratio.
+
+.. _getting-started:
+
+************
+Installation
+************
+
+The instructions for installing ``macauff`` can be found :doc:`here<installation>`.
+
+.. _quick-start:
+
+***********
+Quick Start
+***********
+
+A quick-start guide is available :doc:`here<quickstart>`.
+
+******************
+User Documentation
+******************
 
 .. toctree::
    :maxdepth: 1
-   :titlesonly:
+
+   macauff
+
+*****
+Index
+*****
+
+* :ref:`genindex`
+* :ref:`search`
+
+.. toctree::
+   :hidden:
+
+   installation
+   quickstart
+   inputs

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -1,0 +1,159 @@
+****************
+Input Parameters
+****************
+
+This page details the various inputs expected by `~macauff.CrossMatch`.
+
+
+.. note::
+	Currently only a naive, pure Bayes match is implemented. Thus ``include_perturb_auf``, ``include_phot_like``, and ``use_phot_priors`` must all be set to ``False``, and any parameters only used when either of these parameters is ``True`` can be ignored.
+
+Catalogue-specific Parameters
+=============================
+
+These parameters are required in two separate files, one per catalogue to be cross-matched., the inputs ``cat_a_file_path`` and ``cat_b_file_path`` in `~macauff.CrossMatch`.
+
+Catalogue Parameter Description
+-------------------------------
+
+``cat_name``
+
+The name of the catalogue. This is used to generate intermediate folder structure within the cross-matching process, and during any output file creation process.
+
+``cat_folder_path``
+
+The folder containing the three files (see :doc:`quickstart` for more details) describing the given input catalogue. Can either be an absolute path, or relative to the folder from which the script was called.
+
+``auf_folder_path``
+
+The folder into which the Astrometric Uncertainty Function (AUF) related files will be, or have been, saved. Can also either be an absolute or relative path, like ``cat_folder_path``.
+
+``filt_names``
+
+The filter names of the photometric bandpasses used in this catalogue, in the order in which they are saved in ``con_cat_photo``. These will be used to describe any output data files generated after the matching process. Should be a space-separated list.
+
+``psf_fwhms``
+
+The Full-Width-At-Half-Maximum of each filter's Point Spread Function (PSF), in the same order as in ``filt_names``. These are used to simulate the PSF if ``include_perturb_auf`` is set to ``True``, and are unnecessary otherwise. Should be a space-separated list of floats.
+
+``norm_scale_laws``
+
+The scaling relations, number density of sources as a function of magnitude, for the bright end of the catalogue. Should be of the form :math:`N = N_0 z^m`, where :math:`z` is the scaling law parameter. Should be a space-separated list of floats. Optional if ``include_perturb_aufs`` is ``False``.
+
+``tri_set_name``
+The name of the filter set used to simulate the catalogue's sources in TRILEGAL [#]_. Used to interact with the TRILEGAL API; optional if ``include_perturb_aufs`` is ``False``.
+
+``tri_filt_names``
+
+The names of the filters, in the same order as ``filt_names``, as given in the data ``tri_set_name`` calls. Optional if ``include_perturb_aufs`` is ``False``.
+
+``tri_filt_num``
+
+The one-indexed column number of the magnitude, as determined by the column order of the saved data returned by the TRILEGAL API, to which to set the maximum magnitude limit for the simulation. Optional if ``include_perturb_aufs`` is ``False``.
+
+``download_tri``
+
+Boolean flag, indicating whether to re-download a TRILEGAL simulation in a given ``auf_region_points`` sky coordinate, once it has successfully been run, and to overwrite the original simulation data or not. Optional if ``include_perturb_aufs`` is ``False``.
+
+``auf_region_type``
+
+Flag indicating which definition to use for determining the pointings of the AUF simulations; accepts either ``rectangle`` or ``points``. If ``rectangle``, then ``auf_region_points`` will map out a rectangle of evenly spaced points, otherwise it accepts pairs of coordinates at otherwise random coordinates.
+
+``auf_region_frame``
+
+Flag to indicate which frame the data, and thus AUF simulations, are in. Can either be ``equatorial`` or ``galactic``, allowing for data to be input either in Right Ascension and Declination, or Galactic Longitude and Galactic Latitude.
+
+``auf_region_points``
+
+The list of pointings for which to run simulations of perturbations due to blended sources, if applicable. If ``auf_region_type`` is ``rectangle``, then ``auf_region_points`` accepts six numbers: ``start longitude, end longitude, number of longitude points, start latitude, end latitude, number of latitude points``; if ``points`` then tuples must be of the syntax ``(a, b), (c, d)`` where ``a`` and ``c`` and RA or Galactic Longitude, and ``b`` and ``d`` are Declination or Galactic Latitude.
+
+``dens_dist``
+
+The radius, in arcseconds, within which to count internal catalogue sources for each object, to calculate the local source density. Used to scale TRILEGAL simulated source counts to match smaller scale density fluctuations.
+
+
+Joint Parameters
+================
+
+These parameters are only provided in the single, common-parameter input file, and given as ``joint_file_path`` in `~macauff.CrossMatch`.
+
+Common Parameter Description
+----------------------------
+
+``include_perturb_auf``
+
+Flag for whether to include the simulated effects of blended sources on the measured astrometry in the two catalogues or not. Currently must be ``False``.
+
+
+``include_phot_like``
+
+Flag for the inclusion of the likelihood of match or non-match based on the photometric information in the two catalogues. Must be ``False``.
+
+``use_phot_priors``
+
+Flag to determine whether to calculate the priors on match or non-match using the photometry (if set to ``True``) or calculate them based on a naive asymmetric density argument (``False``). Currently should be ``False``.
+
+``joint_folder_path``
+
+The top-level folder location, into which all intermediate files and folders are placed, when created during the cross-match process.
+
+.. note::
+	The four ``run_`` parameters below are called in order. If an earlier stage flag is set to ``True``, an error will be raised in a subsequent flag is set to ``False``.
+
+``run_auf``
+
+Flag to determine if the AUF simulation stage of the cross-match process should be run, or if previously generated files should be used when present.
+
+``run_group``
+
+Flag dictating whether the source grouping -- and island creation -- stage of the process is run, or if previously created islands of sources should be used for this match.
+
+``run_cf``
+
+Flag controlling whether or not to calculate the photometric likelihood information, as determined by ``include_phot_like`` and ``use_phot_priors``, for this cross-match.
+
+``run_source``
+
+Boolean determining whether to run the final stage of the cross-match process, in which posterior probabilities of matches and non-matches for each island of sources are calculated.
+
+``cf_region_type``
+
+Similar to ``auf_region_type``, this flag controls whether the areas in which photometric likelihoods are calculated is determined by ``rectangle`` -- evenly spaced longitude/latitude pairings -- or ``points`` -- tuples of randomly placed coordinates.
+
+``cf_region_frame``
+
+As with ``auf_region_frame``, this allows either ``equatorial`` or ``galactic`` frame coordinates to be used in the match process.
+
+``cf_region_points``
+
+Based on ``cf_region_type``, this must either by six space-separated floats, controlling the start and end, and number of, longitude and latitude points in ``start lon end lon # steps start lat end lat #steps`` order (see ``auf_region_points``), or a series of comma-separated tuples cf. ``(a, b), (c, d)``.
+
+``pos_corr_dist``
+
+The floating point precision number determining the maximum possible separation between two sources in opposing catalogues.
+
+``real_hankel_points``
+
+The integer number of points, for Hankel (two-dimensional Fourier) transformations, in which to approximate the fourier transformation integral of the AUFs.
+
+``four_hankel_points``
+
+The integer number of points for approximating the inverse Hankel transformation, representing the convolution of two real-space AUFs.
+
+``four_max_rho``
+
+The largest fourier-space value, up to which inverse Hankel transformation integrals are considered. Should typically be larger than the inverse of the smallest typical centroiding Gaussian one-dimensional uncertainty.
+
+``cross_match_extent``
+
+The maximum extent of the matching process. When not matching all-sky catalogues, these extents are used to eliminate potential matches within "island" overlap range of the edge of the data, whose potential incompleteness renders the probabilities of match derived uncertain. Must be of the form ``lower longitude upper longitude lower latitude upper latitude``; accepts four space-separated floats.
+
+``mem_chunk_num``
+
+The number of smaller subsets into which to break various loops throughout the cross-match process. Used to reduce the memory usage of the process at any given time, in case of catalogues too large to fit into memory at once.
+
+
+
+.. rubric:: Footnotes
+
+.. [#] Please see `here <http://stev.oapd.inaf.it/~webmaster/trilegal_1.6/papers.html>`_ to view the TRILEGAL papers to cite, if you use this software in your publication.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,68 @@
+************
+Installation
+************
+
+Package Requirements
+====================
+
+Currently there are no strict criteria for installation; it is suggested that you use the most up-to-date package versions available. The one exception there is that development is currently focused on Python 3.7.
+
+The current package requirements are:
+
+* ``numpy``
+* ``scipy``
+
+and for running the test suite
+
+* ``tox``.
+
+Additionally, you will need the following to install ``macauff``:
+
+* ``gfortran`` -- at least version 8
+* ``git``
+
+Installing the Package
+======================
+
+As of now, the only way to install this package is by downloading it from the `GitHub repository <https://github.com/Onoddil/macauff>`_. We recommend using an `Anaconda Distribution <https://www.anaconda.com/distribution/>`_, or `miniconda <https://docs.conda.io/en/latest/miniconda.html>`_, to maintain specific, independent Python installations without the need for root permissions.
+
+Once you have installed your choice of conda, then you can create an initial conda environment::
+
+	conda create -n your_environment_name python=3.7 numpy scipy
+
+although you can drop the ``=3.7``, or chose another (later) Python version, if you desire to do so. Then activate this as our Python environment::
+
+	conda activate your_environment_name
+
+If you require the additional test packages listed above, for running tests, you can install them separately with::
+
+	conda install -c conda-forge tox
+
+You will also need to install ``gfortran`` in order to compile the fortran code in this package. Instructions for how to install this for Windows, MacOS, or Linux can be found `here <https://gcc.gnu.org/wiki/GFortranBinaries>`_. Finally, install ``git`` if you do not have it on your computer; `instructions <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ for installing it on your operating system are available.
+
+Once you have the required packages installed, you can clone the repository::
+
+	git clone git://github.com/onoddil/macauff.git
+
+which will place the repository in the folder from which you invoked the ``git`` command. Now, from inside the folder that was just created (``cd macauff`` or equivalent), you can either run::
+
+	pip install .
+
+which will install ``macauff`` such that you can ``import macauff`` from other folders on your computer. However, if this is to develop the software, your changes will not be reflected in the installed version of the code (and you must re-install using the above command); if you wish to have changes immediately reflected in your ``pip``-installed version of the software, you can install ``macauff`` using::
+
+	pip install -e .
+
+where ``-e`` is the "editable" flag.
+
+To confirm your installation was successful, you can ``import macauff`` in a Python terminal.
+
+Testing
+=======
+
+To run the main unit test suite, assuming you installed it during the above process, you can run::
+
+	tox -e test
+
+If you wish to locally build the documentation -- mostly likely if you are improving or extending the documentation, as the docs are available online -- you can run::
+
+	tox -e build_docs

--- a/docs/macauff.rst
+++ b/docs/macauff.rst
@@ -1,0 +1,32 @@
+*************************
+``macauff`` Documentation
+*************************
+
+Python
+======
+.. automodapi:: macauff
+	:no-inheritance-diagram:
+	:no-heading:
+
+.. automodapi:: macauff.tests
+	:no-inheritance-diagram:
+	:no-heading:
+
+Fortran
+=======
+
+Group Sources
+^^^^^^^^^^^^^
+.. f:automodule:: group_sources_fortran
+
+Counterpart Pairing
+^^^^^^^^^^^^^^^^^^^
+.. f:automodule:: counterpart_pairing_fortran
+
+Miscellaneous Functions
+^^^^^^^^^^^^^^^^^^^^^^^
+.. f:automodule:: misc_functions_fortran
+
+Shared Library
+^^^^^^^^^^^^^^
+.. f:autosrcfile:: ../macauff/shared_library.f90

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,77 @@
+***********
+Quick Start
+***********
+
+To get started quickly with ``macauff``, you will need nine items: three binary, ``.npy`` files for each of the two catalogues to be cross-matched, and three input plain text files.
+
+Input Data
+==========
+
+The three input files must be contained within a single folder, with the respective names:
+
+* ``con_cat_astro``, which must be of shape ``(N, 3)``, and contain, for each of the ``N`` objects to be matched in this catalogue, two astrometric position coordinates: the azimuthal angle (typically Right Ascension or Longitude) and polar angle (typically Declination or Latitude) -- both in degrees -- and a single, *circular* astrometric uncertainty, in arcseconds. If your data are described by covariance matrices for their uncertainty, then we require the average of the semi-major and semi-minor axes.
+
+* ``con_cat_photo``, of shape ``(N, F)`` for a catalogue with ``F`` filters available for use. If a detection is not available for any reason -- either the source is below the detection limit of the survey, or it was removed for any reason during the catalogue creation process -- it must be replaced with a ``NaN`` value.
+
+* ``magref``, of shape ``(N,)``. This "magnitude reference" array contains, for each of the ``N`` elements, the best available of the 1 to ``F`` detections of that object. Best is a subjective term, and left to the user, but general considerations to take into account are the closeness of the wavelength coverage to the opposing catalogue (where more similar wavelength ranges are better), quality of the detection, or if the source suffered any artefacts during its observation that may affect the photometry.
+
+These files should be present for each catalogue, in separate folders.
+
+An example function to create simple test catalogues is available :func:`here<macauff.tests.generate_random_data>`, and can be imported within Python as::
+
+	from macauff.tests import generate_random_data
+
+and called with
+
+.. code-block:: python
+
+	num_a_source, num_b_source, num_common = 50, 100, 40
+	extent = [0, 0.25, 50, 50.3]
+	num_filters_a, num_filters_b = 3, 2
+	a_uncert, b_uncert = 0.1, 0.3
+	a_cat_path, b_cat_path = 'name_of_a_folder', 'name_of_b_folder'
+	generate_random_data(num_a_source, num_b_source, num_common, extent, num_filters_a,
+	                     num_filters_b, a_uncert, b_uncert, a_cat_path, b_cat_path)
+
+This will save the appropriate three files -- ``con_cat_astro``, ``con_cat_photo``, and ``magref`` -- in the respective catalogue path folders. Additionally, it will save the (zero-indexed) indices in each catalogue that correspond to the counterpart sources in the two catalogues, for "ground truth" comparison.
+
+Input Parameters
+================
+
+Once you have your catalogue files, you will next require the files containing the input parameters. Examples of these files can be found in the ``macauff`` test data folder, for `catalogue "a" <https://raw.githubusercontent.com/Onoddil/macauff/master/macauff/tests/data/cat_a_params.txt>`_, `catalogue "b" <https://raw.githubusercontent.com/Onoddil/macauff/master/macauff/tests/data/cat_b_params.txt>`_, and the `common cross-match <https://raw.githubusercontent.com/Onoddil/macauff/master/macauff/tests/data/crossmatch_params.txt>`_ parameters.
+
+These files are the only inputs to `~macauff.CrossMatch`, the main class for performing a cross-match between the two catalogues.
+
+By default, the parameters in the files above are set up such that a cross-match will be performed in the equatorial coordinate frame region :math:`131 \leq \alpha \leq 138,\ -3 \leq \delta \leq 3`. Thus, depending on the coordinates you used when calling `~macauff.tests.generate_random_data`, you may wish to edit ``cross_match_extent`` and ``cf_region_points`` within ``crossmatch_params.txt``, to match your chosen sky coordinates.
+
+Discussion of the input parameters available in the catalogue-specific and joint match-specific input files is provided in more detail :doc:`here<inputs>`.
+
+Running the Matches
+===================
+
+With both your data and input files, you are now ready to perform your first cross-match! This should be as straightforward as running
+
+.. code-block:: python
+	
+	from macauff import CrossMatch
+	joint_file_path = 'some_location_here/common_match_parameters.txt'
+	cat_a_file, cat_b_file = 'loc_one/catalogue_a_params.txt', 'loc_two/catalogue_b_params.txt'
+	cross_match = CrossMatch(joint_folder_path, cat_a_file, cat_b_file)
+	cross_match()
+
+which will save all intermediate match data to the ``joint_folder_path`` parameter in ``joint_file_path``, and eventually produce a list of indices of matches for the two catalogues. Within Python these can be loaded by calling the original binary files::
+
+	import numpy as np
+	a = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path))
+	b = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path))
+	cat_a_match_inds = np.load('{}/pairing/ac.npy'.format(joint_folder_path))
+	cat_b_match_inds = np.load('{}/pairing/bc.npy'.format(joint_folder_path))
+
+	a_matches, b_matches = a[cat_a_match_inds], b[cat_b_match_inds]
+
+You can then, for example, calculate the on-sky separations between these sources::
+
+	import numpy as np
+	from macauff.misc_functions_fortran import misc_functions_fortan as mff
+	arcsec_seps = np.array([3600 * mff.haversine_wrapper(a_matches[i, 0], b_matches[i, 0],
+	                        a_matches[i, 1], b_matches[i, 1]) for i in range(len(a_matches))])

--- a/macauff/__init__.py
+++ b/macauff/__init__.py
@@ -2,4 +2,5 @@ from .matching import *
 from .perturbation_auf import *
 from .group_sources import *
 from .misc_functions import *
+from .photometric_likelihood import *
 from .counterpart_pairing import *

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -15,6 +15,8 @@ from .misc_functions import (create_auf_params_grid, load_small_ref_auf_grid)
 from .misc_functions_fortran import misc_functions_fortran as mff
 from .counterpart_pairing_fortran import counterpart_pairing_fortran as cpf
 
+__all__ = ['source_pairing']
+
 
 def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_auf_folder_path,
                    b_auf_folder_path, a_filt_names, b_filt_names, a_auf_pointings, b_auf_pointings,

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -6,6 +6,8 @@ framework.
 
 import numpy as np
 
+__all__ = []
+
 
 def create_auf_params_grid(auf_folder_path, auf_pointings, filt_names, array_name,
                            len_first_axis=None):

--- a/macauff/shared_library.f90
+++ b/macauff/shared_library.f90
@@ -30,10 +30,9 @@ subroutine haversine(lon1, lon2, lat1, lat2, hav_dist)
 end subroutine haversine
 
 subroutine jy01a (x, bj0)
-
-    !*************************************************************************80
+    ! JY01A computes Bessel functions J0(x).
     !
-    !! JY01A computes Bessel functions J0(x).
+    !
     !
     !  Licensing:
     !

--- a/macauff/tests/__init__.py
+++ b/macauff/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_full_match_process import *

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -5,7 +5,7 @@ cat_folder_path = gaia_folder
 auf_folder_path = gaia_auf_folder
 
 # Filter names are also used in any output file created
-filt_names = G G_BP G_RP
+filt_names = G_BP G G_RP
 
 # Catalogue PSF parameters
 # Full-width at half maximums for each filter, in order, in arcseconds
@@ -16,7 +16,7 @@ norm_scale_laws = 2 2 2
 # TRILEGAL Perturbation AUF parameters
 # Names of TRILEGAL filter sets for the catalogue
 tri_set_name = gaiadr2
-tri_filt_names = G G_BP G_RP
+tri_filt_names = G_BP G G_RP
 # Filter number to define limiting magnitude of TRILEGAL simulation in, based on output data file column (one-indexed) number
 tri_filt_num = 1
 # Flag to determine whether to re-download TRILEGAL simulations if they exist - must be "yes"/"no", "true"/"false", "t"/"f", or "1"/"0"

--- a/macauff/tests/test_full_match_process.py
+++ b/macauff/tests/test_full_match_process.py
@@ -9,6 +9,8 @@ import numpy as np
 from ..matching import CrossMatch
 from .test_matching import _replace_line
 
+__all__ = ['generate_random_data']
+
 
 def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_sig, b_astro_sig,
                          a_cat, b_cat, seed=None):

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -387,9 +387,9 @@ class TestInputs:
 
         # List of simple one line config file replacements for error message checking
         for old_line, new_line, match_text, in_file in zip(
-                ['filt_names = G G_BP G_RP', 'filt_names = G G_BP G_RP', 'norm_scale_laws = 2 2 2',
+                ['filt_names = G_BP G G_RP', 'filt_names = G_BP G G_RP', 'norm_scale_laws = 2 2 2',
                  'psf_fwhms = 6.08 6.84 7.36 11.99', 'psf_fwhms = 6.08 6.84 7.36 11.99'],
-                ['', 'filt_names = G G_BP\n', 'norm_scale_laws = 2 2 a\n',
+                ['', 'filt_names = G_BP G\n', 'norm_scale_laws = 2 2 a\n',
                  'psf_fwhms = 6.08 6.84 7.36\n', 'psf_fwhms = 6.08 6.84 7.36 word\n'],
                 ['Missing key filt_names from catalogue "a"',
                  'a_tri_filt_names and a_filt_names should contain the same',

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,5 @@ test =
     pytest-astropy
 docs =
     sphinx-astropy
+    sphinx-fortran
+    six

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
 	scipy
 	pytest
 	cov: coverage
+	build_docs: sphinx-fortran
 
 extras =
 	test


### PR DESCRIPTION
PR to establish minimal documentation for the v0.1.1 goal, a naive Bayes cross-match. Includes various minor fixes to docstrings and ``__all__`` lists, but mostly implements the documentation needed to get started with this package.

Homepage contains links to various sub-pages, currently the installation guide, quick-start page, and API. There is also a detailed page of input parameter descriptions, as this is the main aspect of the codebase most in need of description currently.

Also implemented is a (potentially temporary) workflow to push the documentation to the `gh-pages` branch, and thus use @onoddil's personal github pages -- this being a user repository, for the moment -- as the online presence for the documentation.