### PR TITLE
Bug fix for generate_random_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Corrected an error in ``tests.generate_random_data``, where only one catalogue
+  had its source uncertainties simulated. [#23]
+
 - Correct typing of ``point_ind`` in ``misc_function_fortran``'s
   ``find_nearest_point``. [#18]
 

--- a/macauff/tests/test_full_match_process.py
+++ b/macauff/tests/test_full_match_process.py
@@ -79,10 +79,14 @@ def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_si
         # with magnitude
         raise ValueError("b_sig currently has to be an integer for all generated data.")
 
-    a_astro[:, 0] = a_astro[:, 0] + rng.normal(loc=0, scale=a_astro_sig, size=N_c) / 3600
-    a_astro[:, 1] = a_astro[:, 1] + rng.normal(loc=0, scale=a_astro_sig, size=N_c) / 3600
-    b_astro[:, 0] = b_astro[:, 0] + rng.normal(loc=0, scale=b_astro_sig, size=N_c) / 3600
-    b_astro[:, 1] = b_astro[:, 1] + rng.normal(loc=0, scale=b_astro_sig, size=N_c) / 3600
+    a_circ_dist = rng.normal(loc=0, scale=a_astro[:, 2], size=N_a) / 3600
+    a_circ_angle = rng.uniform(0, 2*np.pi, size=N_a)
+    a_astro[:, 0] = a_astro[:, 0] + a_circ_dist * np.cos(a_circ_angle)
+    a_astro[:, 1] = a_astro[:, 1] + a_circ_dist * np.sin(a_circ_angle)
+    b_circ_dist = rng.normal(loc=0, scale=b_astro[:, 2], size=N_b) / 3600
+    b_circ_angle = rng.uniform(0, 2*np.pi, size=N_b)
+    b_astro[:, 0] = b_astro[:, 0] + b_circ_dist * np.cos(b_circ_angle)
+    b_astro[:, 1] = b_astro[:, 1] + b_circ_dist * np.sin(b_circ_angle)
 
     # Currently all we do, given the only option available is a naive Bayes match,
     # is ignore the photometry -- but we still require its file to be present.
@@ -109,7 +113,7 @@ def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_si
 def test_naive_bayes_match():
     # Generate a small number of sources randomly, then run through the
     # cross-match process.
-    N_a, N_b, N_c = 20, 30, 15
+    N_a, N_b, N_c = 40, 50, 35
     n_a_filts, n_b_filts = 3, 4
     a_astro_sig, b_astro_sig = 0.3, 0.5
     r = 5 * np.sqrt(a_astro_sig**2 + b_astro_sig**2)

--- a/macauff/tests/test_full_match_process.py
+++ b/macauff/tests/test_full_match_process.py
@@ -67,10 +67,8 @@ def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_si
 
     a_pair_indices = np.arange(N_c)
     b_pair_indices = rng.choice(N_b, N_c, replace=False)
-    b_astro[b_pair_indices, 0] = a_astro[a_pair_indices, 0] + rng.normal(loc=0, scale=b_astro_sig,
-                                                                         size=N_c) / 3600
-    b_astro[b_pair_indices, 1] = a_astro[a_pair_indices, 1] + rng.normal(loc=0, scale=b_astro_sig,
-                                                                         size=N_c) / 3600
+    b_astro[b_pair_indices, 0] = a_astro[a_pair_indices, 0]
+    b_astro[b_pair_indices, 1] = a_astro[a_pair_indices, 1]
     inv_b_pair = np.delete(np.arange(N_b), b_pair_indices)
     b_astro[inv_b_pair, 0] = rng.uniform(extent[0], extent[1], size=N_b-N_c)
     b_astro[inv_b_pair, 1] = rng.uniform(extent[2], extent[3], size=N_b-N_c)
@@ -80,6 +78,11 @@ def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_si
         # Here we assume that astrometric uncertainty goes quadratically
         # with magnitude
         raise ValueError("b_sig currently has to be an integer for all generated data.")
+
+    a_astro[:, 0] = a_astro[:, 0] + rng.normal(loc=0, scale=a_astro_sig, size=N_c) / 3600
+    a_astro[:, 1] = a_astro[:, 1] + rng.normal(loc=0, scale=a_astro_sig, size=N_c) / 3600
+    b_astro[:, 0] = b_astro[:, 0] + rng.normal(loc=0, scale=b_astro_sig, size=N_c) / 3600
+    b_astro[:, 1] = b_astro[:, 1] + rng.normal(loc=0, scale=b_astro_sig, size=N_c) / 3600
 
     # Currently all we do, given the only option available is a naive Bayes match,
     # is ignore the photometry -- but we still require its file to be present.


### PR DESCRIPTION
``generate_random_data`` mistakenly only simulated sources of one of its generated catalogues, and thus was not comparable with the concept of the probability of two sources being detections of one object given the separation between them being the convolution of their respective uncertainty profiles.

This was fixed, and generalised so that all sources -- not just those common sources -- were given "noisy" positions, a more accurate and robust approach to simulating the data, especially for future versions where uncertainties might be magnitude-dependent.