### PR TITLE
Implementation of photometry-based likelihood and prior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- Added options to photometric routines to create full photometry-based
+  likelihood and prior, or just use the photometric prior and use the naive
+  equal-probability likelihood. [#25]
+
 - Created ``generate_random_data``, to create simulated catalogues for testing
   full end-to-end matches. [#20]
 
@@ -39,6 +43,9 @@ Bug Fixes
 
 API Changes
 ^^^^^^^^^^^
+
+- Added ``int_fracs`` as an input to the joint configuration file for a
+  cross-match. [#25]
 
 - Moved ``delta_mag_cut`` from ``make_perturb_aufs`` to an input variable, defined
   in ``create_perturb_auf``. [#19]

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -4,6 +4,7 @@ This module provides miscellaneous scripts, called in other parts of the cross-m
 framework.
 '''
 
+import os
 import numpy as np
 
 __all__ = []
@@ -131,3 +132,15 @@ def hav_dist_constant_lat(x_lon, x_lat, lon):
                                            np.sin(np.radians((x_lon - lon)/2)))))
 
     return dist
+
+
+def map_large_index_to_small_index(inds, length, folder):
+    inds_unique_flat = np.unique(inds[inds > -1])
+    map_array = np.lib.format.open_memmap('{}/map_array.npy'.format(folder), mode='w+', dtype=int,
+                                          shape=(length,))
+    map_array[:] = -1
+    map_array[inds_unique_flat] = np.arange(0, len(inds_unique_flat), dtype=int)
+    inds_map = np.asfortranarray(map_array[inds.flatten()].reshape(inds.shape))
+    os.system('rm {}/map_array.npy'.format(folder))
+
+    return inds_map, inds_unique_flat

--- a/macauff/photometric_likelihood_fortran.f90
+++ b/macauff/photometric_likelihood_fortran.f90
@@ -1,0 +1,159 @@
+! Licensed under a 3-clause BSD style license - see LICENSE
+
+module photometric_likelihood_fortran
+! This module provides the Fortran code for the handling of the creation of photometric
+! likelihood and priors based on a bandpass-bandpass pairing between catalogues.
+
+implicit none
+
+integer, parameter :: dp = kind(0.0d0)  ! double precision
+real(dp), parameter :: pi = 4.0_dp*atan(1.0_dp)
+
+contains
+
+subroutine get_field_dists(a_ax1, a_ax2, b_ax1, b_ax2, a_indices, a_overlap, b_err_circ, a_flags, b_flags, b_mag, low_mag, &
+    upp_mag, a_mask_ind, a_area_cut)
+    ! Derive the distribution of "field" sources, those with no counterpart in the opposing
+    ! catalogue, by removing any source within the "field" integral fraction radius of any object.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Indices into opposing catalogue from the "primary" catalogue, and the number of
+    ! overlaps for a source.
+    integer, intent(in) :: a_indices(:, :), a_overlap(:)
+    ! Boolean flags indicating whether a given object in a catalogue is detected in its bandpass.
+    logical, intent(in) :: a_flags(:), b_flags(:)
+    ! Orthogonal sky coordinates, and "secondary" catalogue error circle radius.
+    real(dp), intent(in) :: a_ax1(:), a_ax2(:), b_ax1(:), b_ax2(:), b_err_circ(:)
+    ! Second catalogue magnitude for this bandpass, and limits between which to consider removing
+    ! sources from the field source distribution.
+    real(dp), intent(in) :: b_mag(:), low_mag, upp_mag
+    ! Integer representation of boolean flag determining whether a source remains as a potential
+    ! field source, or if it is too close to a primary catalogue object and thus not used to
+    ! construct the "unmatched" distribution.
+    integer, intent(out) :: a_mask_ind(size(a_overlap))
+    ! Area of error ellipses cut out of the distribution.
+    real(dp), intent(out) :: a_area_cut
+    ! Loop counters.
+    integer :: i, j, k
+    ! Haversine on-sky distance.
+    real(dp) :: dist
+
+    a_mask_ind = 1
+    ! Note that the cut areas are reversed, so we get the areas of any sources of catalogue b and cut
+    ! them out of catalogue a.
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i, j, k, dist) SHARED(a_ax1, a_ax2, b_ax1, b_ax2, &
+!$OMP& a_mask_ind, b_err_circ, a_indices, a_overlap, a_flags, b_flags, b_mag, low_mag, upp_mag) REDUCTION(+:a_area_cut)
+    do j = 1, size(a_overlap)
+        if (a_flags(j)) then
+            do k = 1, a_overlap(j)
+                ! Index arrays have come from python and are zero-indexed, so correct offset here.
+                i = a_indices(k, j) + 1
+                if (i > 0) then
+                    if (b_flags(i) .and. (b_mag(i) >= low_mag .and. b_mag(i) <= upp_mag)) then
+                        call haversine(a_ax1(j), b_ax1(i), a_ax2(j), b_ax2(i), dist)
+                        if (b_err_circ(i) >= dist) then
+                            a_mask_ind(j) = 0
+                            a_area_cut = a_area_cut + pi*b_err_circ(i)**2
+                            exit
+                        end if
+                    end if
+                end if
+            end do
+        else
+            a_mask_ind(j) = 0
+        end if
+    end do
+!$OMP END PARALLEL DO
+
+end subroutine get_field_dists
+
+subroutine brightest_mag(a_ax1, a_ax2, b_ax1, b_ax2, a_mag, b_mag, a_indices, a_overlap, a_err_circ, a_flags, b_flags, a_bin, &
+    mag_mask, av_area)
+    ! Derive the distribution of brightest sources of one catalogue inside "error circles" of
+    ! another catalogue.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Indices into opposing catalogue from the "primary" catalogue, and the number of
+    ! overlaps for a source.
+    integer, intent(in) :: a_indices(:, :), a_overlap(:)
+    ! Boolean flags indicating whether a given object in a catalogue is detected in its bandpass.
+    logical, intent(in) :: a_flags(:), b_flags(:)
+    ! Orthogonal sky coordinates, and "primary" catalogue error circle radius.
+    real(dp), intent(in) :: a_ax1(:), a_ax2(:), b_ax1(:), b_ax2(:), a_err_circ(:)
+    ! Catalogue magnitude for these bandpasses, and bins into which to divide the "a" catalogue
+    ! magnitudes.
+    real(dp), intent(in) :: a_mag(:), b_mag(:), a_bin(:)
+    ! Integer representation of boolean array, indicating the brightest sources in catalogue "b"
+    ! for all sources within bin sizes set by a_bin.
+    integer, intent(out) :: mag_mask(size(b_mag), size(a_bin)-1)
+    ! The average error circle size of sources in each a_bin magnitude range.
+    real(dp), intent(out) :: av_area(size(a_bin)-1)
+    ! Loop counters.
+    integer :: i, j, k
+    ! Indices keeping track of the various bins sources are assigned in this subroutine.
+    integer :: brightindex, m, r
+    ! Counter for the number of sources in each a_bin magnitude range.
+    integer :: n(size(a_bin)-1)
+    ! Variables keeping track of various parameters: the brightest magnitude inside an error circle,
+    ! and the Haversine distance between sources.
+    real(dp) :: brightmag, dist
+
+    mag_mask = 0
+    n = 0
+    av_area = 0
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i, m, r) SHARED(a_err_circ, a_bin, a_mag, a_flags) REDUCTION(+: n, av_area)
+    do i = 1, size(a_overlap)
+        if (a_err_circ(i) > 0 .and. a_flags(i)) then
+            r = 1
+            do m = 2, size(a_bin)
+                if ((a_bin(m) >= a_mag(i)) .and. (a_bin(m-1) < a_mag(i))) then
+                    r = m-1
+                    exit
+                end if
+            end do
+            av_area(r) = av_area(r) + a_err_circ(i)**2
+            n(r) = n(r) + 1
+        end if
+    end do
+!$OMP END PARALLEL DO
+    do i = 1, size(a_bin)-1
+        if (n(i) > 0) then
+            av_area(i) = pi*av_area(i)/n(i)
+        end if
+    end do
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i, j, brightindex, brightmag, dist, m, r) SHARED(a_ax1, a_ax2, b_ax1, &
+!$OMP& b_ax2, b_mag, mag_mask, a_indices, a_overlap, a_err_circ, a_flags, b_flags, a_bin, a_mag)
+    do i = 1, size(a_overlap)
+        if (a_flags(i)) then
+            r = 1
+            do m = 2, size(a_bin)
+                if ((a_bin(m) >= a_mag(i)) .and. (a_bin(m-1) < a_mag(i))) then
+                    r = m-1
+                    exit
+                end if
+            end do
+            brightindex = -1
+            brightmag = 999
+            do k = 1, a_overlap(i)
+                j = a_indices(k, i) + 1
+                if (j > 0) then
+                    if (b_flags(j)) then
+                        call haversine(a_ax1(i), b_ax1(j), a_ax2(i), b_ax2(j), dist)
+                        if (a_err_circ(i) > dist .and. b_mag(j) < brightmag) then
+                            brightindex = j
+                            brightmag = b_mag(j)
+                        end if
+                    end if
+                end if
+            end do
+            if (brightindex /= -1) then
+                mag_mask(brightindex, r) = 1
+            end if
+        end if
+    end do
+!$OMP END PARALLEL DO
+
+end subroutine brightest_mag
+
+end module photometric_likelihood_fortran

--- a/macauff/tests/data/crossmatch_params.txt
+++ b/macauff/tests/data/crossmatch_params.txt
@@ -37,3 +37,6 @@ cross_match_extent = 131 138 -3 3
 
 # Number of chunks to break each catalogue into when splitting larger catalogues up for memory reasons
 mem_chunk_num = 10
+
+# Integral fractions for various error circle cutouts used during the cross-match process. Should be space-separated floats, in the order of <bright error circle fraction>, <field error circle fraction>, <potential counterpart integral limit>
+int_fracs = 0.63 0.9 0.99

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -552,6 +552,35 @@ class TestInputs:
                                 os.path.join(os.path.dirname(__file__),
                                 'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
+    def test_int_fracs(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.int_fracs == np.array([0.63, 0.9, 0.99]))
+
+        # List of simple one line config file replacements for error message checking
+        in_file = 'crossmatch_params'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/{}.txt'.format(in_file))).readlines()
+        old_line = 'int_fracs = 0.63 0.9 0.99'
+        for new_line, match_text in zip(
+                ['', 'int_fracs = 0.63 0.9 word\n', 'int_fracs = 0.63 0.9\n'],
+                ['Missing key int_fracs', 'All elements of int_fracs should be',
+                 'int_fracs should contain.']):
+            idx = np.where([old_line in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__),
+                          'data/{}.txt'.format(in_file)), idx, new_line, out_file=os.path.join(
+                          os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params{}.txt'.format(
+                                '_' if 'h_p' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
     def test_crossmatch_chunk_num(self):
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 import scipy.special
 
 from ..misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
-                              hav_dist_constant_lat)
+                              hav_dist_constant_lat, map_large_index_to_small_index)
 from ..misc_functions_fortran import misc_functions_fortran as mff
 # from .test_shared_library_fortran import haversine_wrapper
 
@@ -94,3 +94,10 @@ def test_hav_dist_constant_lat():
             a = mff.haversine_wrapper(lon1, lon2, lat, lat)
             b = hav_dist_constant_lat(lon1, lat, lon2)
             assert_allclose(a, b)
+
+
+def test_large_small_index():
+    inds = np.array([0, 10, 15, 10, 35])
+    a, b = map_large_index_to_small_index(inds, 40, '.')
+    assert np.all(a == np.array([0, 1, 2, 1, 3]))
+    assert np.all(b == np.array([0, 10, 15, 35]))

--- a/macauff/tests/test_photometric_likelihood.py
+++ b/macauff/tests/test_photometric_likelihood.py
@@ -363,6 +363,44 @@ def test_brightest_mag_fortran():
     assert_allclose(area, np.sum(np.pi * aerr[d <= aerr]**2) / np.sum(d <= aerr))
 
 
+def test_make_bins():
+    # Test a few combinations of input magnitude arrays to ensure make_bins
+    # returns expected bins.
+
+    dm = 0.1/251
+    m = np.arange(10+1e-10, 15, dm)
+    bins = make_bins(m)
+    assert_allclose(bins, np.arange(10, 15+1e-10, 0.1))
+    h, _ = np.histogram(m, bins=bins)
+    assert np.all(h == 251)
+
+    dm = 0.1/2500
+    m = np.arange(10+1e-10, 15, dm)
+    bins = make_bins(m)
+    assert_allclose(bins, np.arange(10, 15+1e-10, 0.1))
+    h, _ = np.histogram(m, bins=bins)
+    assert np.all(h == 2500)
+
+    dm = 0.1/249
+    m = np.arange(10+1e-10, 15, dm)
+    bins = make_bins(m)
+    assert_allclose(bins, np.arange(10, 15+1e-10, 0.2))
+    h, _ = np.histogram(m, bins=bins)
+    assert np.all(h == 2*249)
+
+    dm = 0.1/124
+    m = np.arange(10+1e-10, 15, dm)
+    bins = make_bins(m)
+    fake_bins = np.arange(10, 15.11, 0.3)
+    fake_bins[-1] = 15
+    assert_allclose(bins, fake_bins)
+    h, _ = np.histogram(m, bins=bins)
+    # With this bin size not quite being exactly able to fit into
+    # 10 -> 15 exactly, the final bin is only 0.2 wide, and hence
+    # not a "triple" sized bin like the others.
+    assert np.all(h[:-1] == 3*124) & (h[-1] == 2*124)
+
+
 class TestFullPhotometricLikelihood:
     def setup_class(self):
         self.cf_points = np.array([[131.5, -0.5]])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import find_packages
 from numpy.distutils.core import Extension, setup
 
-names = ['group_sources_fortran', 'misc_functions_fortran', 'counterpart_pairing_fortran']
+names = ['group_sources_fortran', 'misc_functions_fortran', 'counterpart_pairing_fortran',
+         'photometric_likelihood_fortran']
 f90_args = ["-Wall", "-Wextra", "-Werror", "-pedantic", "-fbacktrace", "-O0", "-g", "-fcheck=all",
             "-fopenmp"]
 


### PR DESCRIPTION
This PR adds the algorithmic implementation of photometric likelihood/prior, based on Wilson & Naylor (2018, MNRAS, 473, 5570). Here we use the statistical coevality of sources in filter-filter pairings across the two photometric catalogues to establish the colours of objects that are "counterparts" between the two datasets, and those objects with no sources near them in the opposing catalogue, the "field" sources.