### PR TITLE
Implement full algorithm for simulating the perturbation component of the AUF

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -20,7 +20,11 @@ jobs:
           pip install numpy
           pip install tox
       - name: Run tests
+        if: github.event_name != 'push' || github.ref != 'refs/heads/master'
         run: tox -e test
+      - name: Run tests with remote
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: tox -e test -- --remote-data
       - name: Run documentation
         run: tox -e build_docs
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- Added option to include the full perturbation AUF component, based on
+  simulated Galactic source modelling. [#27]
+
 - Added options to photometric routines to create full photometry-based
   likelihood and prior, or just use the photometric prior and use the naive
   equal-probability likelihood. [#25]
@@ -20,11 +23,26 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Moved several functions (``_load_single_sky_slice``, ``_load_rectangular_slice``,
+  ``_lon_cut``, ``_lat_cut``) out of individual Python scripts into
+  ``misc_functions`` to generalise their use in the codebase. [#27]
+
+- Removed ``norm_scale_laws`` as an input to catalogue configuration files. [#27]
+
+- Added ``dens_mags``, ``num_trials``, ``dm_max``, ``d_mag``, and
+  ``compute_local_density`` as inputs to the joint and catalogue-specific
+  configuration files [#27]
+
 - Added ``int_fracs`` as an input to the joint configuration file for a
   cross-match. [#25]
 
 Other Changes
 ^^^^^^^^^^^^^
+
+- GitHub Actions will only run remote data dependent tests (those marked with
+  ``pytest.mark.remote_data``) on a pull request merge. [#27]
+
+- Added ``astropy`` as a dependency. [#27]
 
 
 

--- a/macauff/get_trilegal_wrapper.py
+++ b/macauff/get_trilegal_wrapper.py
@@ -1,0 +1,234 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2015 timothydmorton
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+
+# Licensed under a 3-clause BSD style license - see LICENSE
+'''
+Provides the code to query the online TRILEGAL API and download the results.
+'''
+
+
+import subprocess as sp
+import os
+import re
+import time
+
+from astropy.units import UnitsError
+from astropy.coordinates import SkyCoord
+
+
+__all__ = []
+
+
+def get_trilegal(filename, ra, dec, folder='.', galactic=False,
+                 filterset='kepler_2mass', area=1, magnum=1, maglim=27, binaries=False,
+                 trilegal_version='1.7', sigma_AV=0.1):
+    """
+    Calls the TRILEGAL web form simulation and downloads the file.
+
+    Parameters
+    ----------
+    filename : string
+        Output filename. If extension not provided, it will be added.
+    ra : float
+        Coordinate for line-of-sight simulation.
+    dec : float
+        Coordinate for line-of-sight simulation.
+    folder : string, optional
+        Folder to which to save file.
+    filterset : string, optional
+        Filter set for which to call TRILEGAL.
+    area : float, optional
+        Area of TRILEGAL simulation [sq. deg]
+    magnum : integer, optional
+        Bandpass number to limit source magnitudes in.
+    maglim : integer, optional
+        Limiting magnitude in ``magnum`` bandpass of the ``filterset``.
+    binaries : boolean, optional
+        Whether to have TRILEGAL include binary stars. Default ``False``.
+    trilegal_version : float, optional
+        Version of the TRILEGAL API to call. Default ``'1.7'``.
+    sigma_AV : float, optional
+        Fractional spread in A_V along the line of sight.
+    """
+    if galactic:
+        l, b = ra, dec
+    else:
+        try:
+            c = SkyCoord(ra, dec)
+        except UnitsError:
+            c = SkyCoord(ra, dec, unit='deg')
+        l, b = (c.galactic.l.value, c.galactic.b.value)
+
+    if os.path.isabs(filename):
+        folder = ''
+
+    if not re.search(r'\.dat$', filename):
+        outfile = '{}/{}.dat'.format(folder, filename)
+    else:
+        outfile = '{}/{}'.format(folder, filename)
+    AV = get_AV_infinity(l, b, frame='galactic')
+
+    trilegal_webcall(trilegal_version, l, b, area, binaries, AV, sigma_AV, filterset, magnum,
+                     maglim, outfile)
+
+
+def trilegal_webcall(trilegal_version, l, b, area, binaries, AV, sigma_AV, filterset, magnum,
+                     maglim, outfile):
+    """
+    Calls TRILEGAL webserver and downloads results file.
+
+    Parameters
+    ----------
+    trilegal_version : float
+        Version of TRILEGAL.
+    l : float
+        Galactic coordinate for line-of-sight simulation.
+    b : float
+        Galactic coordinate for line-of-sight simulation.
+    area : float
+        Area of TRILEGAL simulation in square degrees.
+    binaries : boolean
+        Whether to have TRILEGAL include binary stars.
+    AV : float
+        Extinction along the line of sight.
+    sigma_AV : float
+        Fractional spread in A_V along the line of sight.
+    filterset : string
+        Filter set for which to call TRILEGAL.
+    magnum : integer
+        Number of filter in given filterset to limit magnitudes to.
+    maglim : float
+        Limiting magnitude down to which to simulate sources.
+    :outfile : string
+        Output filename.
+    """
+    webserver = 'http://stev.oapd.inaf.it'
+    args = [l, b, area, AV, sigma_AV, filterset, maglim, magnum, binaries]
+    mainparams = ('imf_file=tab_imf%2Fimf_chabrier_lognormal.dat&binary_frac=0.3&'
+                  'binary_mrinf=0.7&binary_mrsup=1&extinction_h_r=100000&extinction_h_z='
+                  '110&extinction_kind=2&extinction_rho_sun=0.00015&extinction_infty={}&'
+                  'extinction_sigma={}&r_sun=8700&z_sun=24.2&thindisk_h_r=2800&'
+                  'thindisk_r_min=0&thindisk_r_max=15000&thindisk_kind=3&thindisk_h_z0='
+                  '95&thindisk_hz_tau0=4400000000&thindisk_hz_alpha=1.6666&'
+                  'thindisk_rho_sun=59&thindisk_file=tab_sfr%2Ffile_sfr_thindisk_mod.dat&'
+                  'thindisk_a=0.8&thindisk_b=0&thickdisk_kind=0&thickdisk_h_r=2800&'
+                  'thickdisk_r_min=0&thickdisk_r_max=15000&thickdisk_h_z=800&'
+                  'thickdisk_rho_sun=0.0015&thickdisk_file=tab_sfr%2Ffile_sfr_thickdisk.dat&'
+                  'thickdisk_a=1&thickdisk_b=0&halo_kind=2&halo_r_eff=2800&halo_q=0.65&'
+                  'halo_rho_sun=0.00015&halo_file=tab_sfr%2Ffile_sfr_halo.dat&halo_a=1&'
+                  'halo_b=0&bulge_kind=2&bulge_am=2500&bulge_a0=95&bulge_eta=0.68&'
+                  'bulge_csi=0.31&bulge_phi0=15&bulge_rho_central=406.0&'
+                  'bulge_cutoffmass=0.01&bulge_file=tab_sfr%2Ffile_sfr_bulge_zoccali_p03.dat&'
+                  'bulge_a=1&bulge_b=-2.0e9&object_kind=0&object_mass=1280&object_dist=1658&'
+                  'object_av=1.504&object_avkind=1&object_cutoffmass=0.8&'
+                  'object_file=tab_sfr%2Ffile_sfr_m4.dat&object_a=1&object_b=0&'
+                  'output_kind=1').format(AV, sigma_AV)
+    cmdargs = [trilegal_version, l, b, area, filterset, magnum, maglim, binaries, mainparams,
+               webserver, trilegal_version]
+    cmd = ("wget -o lixo -Otmpfile --post-data='submit_form=Submit&trilegal_version={}"
+           "&gal_coord=1&gc_l={}&gc_b={}&eq_alpha=0&eq_delta=0&field={}&photsys_file="
+           "tab_mag_odfnew%2Ftab_mag_{}.dat&icm_lim={}&mag_lim={}&mag_res=0.1&"
+           "binary_kind={}&{}' {}/cgi-bin/trilegal_{}").format(*cmdargs)
+    complete = False
+    while not complete:
+        notconnected = True
+        busy = True
+        print("TRILEGAL is being called with \n l={} deg, b={} deg, area={} sqrdeg\n "
+              "Av={} with {} fractional r.m.s. spread \n in the {} system, complete down to "
+              "mag={} in its {}th filter, use_binaries set to {}.".format(*args))
+        sp.Popen(cmd, shell=True).wait()
+        if os.path.exists('tmpfile') and os.path.getsize('tmpfile') > 0:
+            notconnected = False
+        else:
+            print("No communication with {}, will retry in 2 min".format(webserver))
+            time.sleep(120)
+        if not notconnected:
+            with open('tmpfile', 'r') as f:
+                lines = f.readlines()
+            for line in lines:
+                if 'The results will be available after about 2 minutes' in line:
+                    busy = False
+                    break
+            sp.Popen('rm -f lixo tmpfile', shell=True)
+            if not busy:
+                filenameidx = line.find('<a href=../tmp/') + 15
+                fileendidx = line[filenameidx:].find('.dat')
+                filename = line[filenameidx:filenameidx+fileendidx+4]
+                print("retrieving data from {} ...".format(filename))
+                while not complete:
+                    time.sleep(40)
+                    modcmd = 'wget -o lixo -O{} {}/tmp/{}'.format(filename, webserver, filename)
+                    sp.Popen(modcmd, shell=True).wait()
+                    if os.path.getsize(filename) > 0:
+                        with open(filename, 'r') as f:
+                            lastline = f.readlines()[-1]
+                        if 'normally' in lastline:
+                            complete = True
+                            print('model downloaded!..')
+                    if not complete:
+                        print('still running...')
+            else:
+                print('Server busy, trying again in 2 minutes')
+                time.sleep(120)
+    sp.Popen('mv {} {}'.format(filename, outfile), shell=True).wait()
+    print('results copied to {}'.format(outfile))
+
+
+def get_AV_infinity(ra, dec, frame='icrs'):
+    """
+    Gets the A_V exctinction at infinity for a given line of sight.
+    Queries the NED database using ``curl``.
+
+    Parameters
+    ----------
+    ra : float
+        Sky coordinate.
+    dec : float
+        Sky coordinate.
+    frame : string, optional
+        Frame of input coordinates (e.g., ``'icrs', 'galactic'``)
+    """
+    coords = SkyCoord(ra, dec, unit='deg', frame=frame).transform_to('icrs')
+
+    rah, ram, ras = coords.ra.hms
+    decd, decm, decs = coords.dec.dms
+    if decd > 0:
+        decsign = '%2B'
+    else:
+        decsign = '%2D'
+    url = (
+        'http://ned.ipac.caltech.edu/cgi-bin/nph-calc?'
+        'in_csys=Equatorial&in_equinox=J2000.0&obs_epoch=2010&lon='+'%i' % rah +
+        '%3A'+'%i' % ram + '%3A' + '%05.2f' % ras + '&lat=%s' % decsign + '%i' % abs(decd) +
+        '%3A' + '%i' % abs(decm) + '%3A' + '%05.2f' % abs(decs) +
+        '&pa=0.0&out_csys=Equatorial&out_equinox=J2000.0')
+
+    tmpfile = '/tmp/nedsearch%s%s.html' % (ra, dec)
+    cmd = 'curl -s \'%s\' -o %s' % (url, tmpfile)
+    sp.Popen(cmd, shell=True).wait()
+    AV = None
+    with open(tmpfile, 'r') as f:
+        for line in f:
+            m = re.search(r'V \(0.54\)\s+(\S+)', line)
+            if m:
+                AV = float(m.group(1))
+    if AV is None:
+        print('Error accessing NED, url={}'.format(url))
+        with open(tmpfile) as f:
+            for line in f:
+                print(line)
+
+    os.remove(tmpfile)
+    return AV

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -7,11 +7,11 @@ various photometric integral purposes.
 
 import sys
 import os
-import operator
 import numpy as np
 
 from .misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
-                             hav_dist_constant_lat, map_large_index_to_small_index)
+                             hav_dist_constant_lat, map_large_index_to_small_index,
+                             _load_rectangular_slice)
 from .group_sources_fortran import group_sources_fortran as gsf
 from .make_set_list import set_list
 
@@ -498,35 +498,9 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     '''
 
     lon1, lon2, lat1, lat2 = sky_rect_coords
-    # Slice the memmapped catalogue, with a memmapped slicing array to
-    # preserve memory.
-    sky_cut_1 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_1.npy'.format(
-        joint_folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
-    sky_cut_2 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_2.npy'.format(
-        joint_folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
-    sky_cut_3 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_3.npy'.format(
-        joint_folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
-    sky_cut_4 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_4.npy'.format(
-        joint_folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
-    sky_cut = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_combined.npy'.format(
-        joint_folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
 
-    di = max(1, len(a) // 20)
-    # Iterate over each small slice of the larger array, checking for upper
-    # and lower longitude, then latitude, criterion matching.
-    for i in range(0, len(a), di):
-        _lon_cut(i, a.shape[0], di, lon1, padding, sky_cut_1, cat_folder_path, operator.ge)
-    for i in range(0, len(a), di):
-        _lon_cut(i, a.shape[0], di, lon2, padding, sky_cut_2, cat_folder_path, operator.le)
-
-    for i in range(0, len(a), di):
-        _lat_cut(i, a.shape[0], di, lat1, padding, sky_cut_3, cat_folder_path, operator.ge)
-    for i in range(0, len(a), di):
-        _lat_cut(i, a.shape[0], di, lat2, padding, sky_cut_4, cat_folder_path, operator.le)
-
-    for i in range(0, len(a), di):
-        sky_cut[i:i+di] = (sky_cut_1[i:i+di] & sky_cut_2[i:i+di] &
-                           sky_cut_3[i:i+di] & sky_cut_4[i:i+di])
+    sky_cut = _load_rectangular_slice(joint_folder_path, cat_name, cat_folder_path, a, lon1, lon2,
+                                      lat1, lat2, padding)
 
     a_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path), mmap_mode='r')[sky_cut]
 
@@ -536,94 +510,6 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
                                                             ['fourier'])
 
     return a_cutout, fouriergrid, modrefindsmall, sky_cut
-
-
-def _lon_cut(i, lena, di, lon, padding, sky_cut, cat_folder_path, inequality):
-    '''
-    Function to calculate the longitude inequality criterion for astrometric
-    sources relative to a rectangle defining boundary limits.
-
-    Parameters
-    ----------
-    i : integer
-        Index into ``sky_cut`` for slicing.
-    lena : integer
-        Number of rows in main catalogue.
-    di : integer
-        Index stride value, for slicing.
-    lon : float
-        Longitude at which to cut sources, either above or below, in degrees.
-    padding : float
-        Maximum allowed sky separation the "wrong" side of ``lon``, to allow
-        for an increase in sky box size to ensure all overlaps are caught in
-        ``get_max_overlap`` or ``get_max_indices``.
-    sky_cut : numpy.ndarray
-        Array into which to store boolean flags for whether source meets the
-        sky position criterion.
-    cat_folder_path : string
-        Folder on disk where main catalogue being cross-matched is stored.
-    inequaility : ``operator.le`` or ``operator.ge``
-        Function to determine whether a source is either above or below the
-        given ``lon`` value.
-    '''
-    a = np.lib.format.open_memmap('{}/con_cat_astro.npy'.format(cat_folder_path), mode='r',
-                                  dtype=float, shape=(lena, 3))
-    # To check whether a source should be included in this slice or not if the
-    # "padding" factor is non-zero, add an extra caveat to check whether
-    # Haversine great-circle distance is less than the padding factor. For
-    # constant latitude this reduces to
-    # r = 2 arcsin(|cos(lat) * sin(delta-lon/2)|).
-    # However, in both zero and non-zero padding factor cases, we always require
-    # the source to be above or below the longitude for sky_cut_1 and sky_cut_2
-    # in load_fourier_grid_cutouts, respectively.
-    if padding > 0:
-        sky_cut[i:i+di] = (hav_dist_constant_lat(a[i:i+di, 0], a[i:i+di, 1], lon) <=
-                           padding) | inequality(a[i:i+di, 0], lon)
-    else:
-        sky_cut[i:i+di] = inequality(a[i:i+di, 0], lon)
-
-
-def _lat_cut(i, lena, di, lat, padding, sky_cut, cat_folder_path, inequality):
-    '''
-    Function to calculate the latitude inequality criterion for astrometric
-    sources relative to a rectangle defining boundary limits.
-
-    Parameters
-    ----------
-    i : integer
-        Index into ``sky_cut`` for slicing.
-    lena : integer
-        Number of rows in main catalogue.
-    di : integer
-        Index stride value, for slicing.
-    lat : float
-        Latitude at which to cut sources, either above or below, in degrees.
-    padding : float
-        Maximum allowed sky separation the "wrong" side of ``lat``, to allow
-        for an increase in sky box size to ensure all overlaps are caught in
-        ``get_max_overlap`` or ``get_max_indices``.
-    sky_cut : numpy.ndarray
-        Array into which to store boolean flags for whether source meets the
-        sky position criterion.
-    cat_folder_path : string
-        Folder on disk where main catalogue being cross-matched is stored.
-    inequaility : ``operator.le`` or ``operator.ge``
-        Function to determine whether a source is either above or below the
-        given ``lat`` value.
-    '''
-    a = np.lib.format.open_memmap('{}/con_cat_astro.npy'.format(cat_folder_path), mode='r',
-                                  dtype=float, shape=(lena, 3))
-    # The "padding" factor is easier to handle for constant longitude in the
-    # Haversine formula, being a straight comparison of delta-lat, and thus we
-    # can simply move the required latitude padding factor to within the
-    # latitude comparison.
-    if padding > 0:
-        if inequality is operator.le:
-            sky_cut[i:i+di] = inequality(a[i:i+di, 1] - padding, lat)
-        else:
-            sky_cut[i:i+di] = inequality(a[i:i+di, 1] + padding, lat)
-    else:
-        sky_cut[i:i+di] = inequality(a[i:i+di, 1], lat)
 
 
 def _clean_overlaps(inds, size, joint_folder_path, filename):

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -499,7 +499,7 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
 
     lon1, lon2, lat1, lat2 = sky_rect_coords
 
-    sky_cut = _load_rectangular_slice(joint_folder_path, cat_name, cat_folder_path, a, lon1, lon2,
+    sky_cut = _load_rectangular_slice(joint_folder_path, cat_name, a, lon1, lon2,
                                       lat1, lat2, padding)
 
     a_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path), mmap_mode='r')[sky_cut]

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -521,13 +521,14 @@ class CrossMatch():
                 if self.compute_local_density:
                     _kwargs = dict(_kwargs, **{'density_radius': self.a_dens_dist})
             else:
+                os.system("rm -rf {}/*".format(self.a_auf_folder_path))
                 _kwargs = {}
             perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
                              self.a_auf_region_points, self.r, self.dr,
                              self.rho, self.drho, 'a', self.include_perturb_auf,
                              self.mem_chunk_num, **_kwargs)
         else:
-            print('Loading empirical crowding AUFs for catalogue "a"...')
+            print('Loading empirical perturbation AUFs for catalogue "a"...')
             sys.stdout.flush()
 
         b_expected_files = 3 + len(self.b_auf_region_points) + (
@@ -566,7 +567,6 @@ class CrossMatch():
                                   ax_folder, ax_folder))
                 if self.compute_local_density:
                     _kwargs = dict(_kwargs, **{'density_radius': self.b_dens_dist})
-
             else:
                 os.system("rm -rf {}/*".format(self.b_auf_folder_path))
                 _kwargs = {}
@@ -575,7 +575,7 @@ class CrossMatch():
                              self.rho, self.drho, 'b', self.include_perturb_auf,
                              self.mem_chunk_num, **_kwargs)
         else:
-            print('Loading empirical crowding AUFs for catalogue "b"...')
+            print('Loading empirical perturbation AUFs for catalogue "b"...')
             sys.stdout.flush()
 
     def group_sources(self, files_per_grouping, group_func=make_island_groupings):

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -313,10 +313,13 @@ class CrossMatch():
         if self.include_perturb_auf:
             for config, catname in zip([cat_a_config, cat_b_config], ['"a"', '"b"']):
                 for check_flag in ['tri_set_name', 'tri_filt_names', 'psf_fwhms',
-                                   'norm_scale_laws', 'download_tri']:
+                                   'download_tri', 'dens_mags']:
                     if check_flag not in config:
                         raise ValueError("Missing key {} from catalogue {} metadata file.".format(
                                          check_flag, catname))
+            for check_flag in ['num_trials', 'dm_max', 'd_mag', 'compute_local_density']:
+                if check_flag not in joint_config:
+                    raise ValueError("Missing key {} from joint metadata file.".format(check_flag))
             self.a_download_tri = self._str2bool(cat_a_config['download_tri'])
             self.b_download_tri = self._str2bool(cat_b_config['download_tri'])
             self.a_tri_set_name = cat_a_config['tri_set_name']
@@ -346,16 +349,41 @@ class CrossMatch():
             # Perturbation AUF component.
             for config, catname, flag in zip([cat_a_config, cat_b_config], ['"a"', '"b"'],
                                              ['a_', 'b_']):
-                a = config['norm_scale_laws'].split()
+                a = config['dens_mags'].split()
                 try:
                     b = np.array([float(f) for f in a])
                 except ValueError:
-                    raise ValueError('norm_scale_laws should be a list of floats in '
+                    raise ValueError('dens_mags should be a list of floats in '
                                      'catalogue {} metadata file.'.format(catname))
                 if len(b) != len(getattr(self, '{}filt_names'.format(flag))):
-                    raise ValueError('{}norm_scale_laws and {}filt_names should contain the '
+                    raise ValueError('{}dens_mags and {}filt_names should contain the '
                                      'same number of entries.'.format(flag, flag))
-                setattr(self, '{}norm_scale_laws'.format(flag), b)
+                setattr(self, '{}dens_mags'.format(flag), b)
+
+            a = joint_config['num_trials']
+            try:
+                a = float(a)
+            except ValueError:
+                raise ValueError("num_trials should be an integer.")
+            if not a.is_integer():
+                raise ValueError("num_trials should be an integer.")
+            self.num_trials = int(a)
+
+            for flag in ['dm_max', 'd_mag']:
+                try:
+                    setattr(self, flag, float(joint_config[flag]))
+                except ValueError:
+                    raise ValueError("{} must be a float.".format(flag))
+
+            self.compute_local_density = self._str2bool(joint_config['compute_local_density'])
+
+            if self.compute_local_density:
+                for config, catname, flag in zip([cat_a_config, cat_b_config], ['"a"', '"b"'],
+                                                 ['a_', 'b_']):
+                    try:
+                        setattr(self, '{}dens_dist'.format(flag), float(config['dens_dist']))
+                    except ValueError:
+                        raise ValueError("dens_dist in catalogue {} must be a float.".format(catname))
 
         for config, catname, flag in zip([cat_a_config, cat_b_config], ['"a"', '"b"'],
                                          ['a_', 'b_']):
@@ -377,13 +405,6 @@ class CrossMatch():
             self.pos_corr_dist = float(joint_config['pos_corr_dist'])
         except ValueError:
             raise ValueError("pos_corr_dist must be a float.")
-
-        for config, catname, flag in zip([cat_a_config, cat_b_config], ['"a"', '"b"'],
-                                         ['a_', 'b_']):
-            try:
-                setattr(self, '{}dens_dist'.format(flag), float(config['dens_dist']))
-            except ValueError:
-                raise ValueError("dens_dist in catalogue {} must be a float.".format(catname))
 
         for flag in ['real_hankel_points', 'four_hankel_points', 'four_max_rho']:
             a = joint_config[flag]
@@ -457,8 +478,6 @@ class CrossMatch():
                                 os.walk(self.a_auf_folder_path)])
         a_correct_file_number = a_expected_files == a_file_number
 
-        a_n_sources = len(np.load('{}/magref.npy'.format(self.a_cat_folder_path), mmap_mode='r'))
-
         # Magnitude offsets corresponding to relative fluxes of perturbing sources; here
         # dm of 2.5 is 10% relative flux and dm = 5 corresponds to 1% relative flux. Used
         # to inform the fraction of simulations with a contaminant above these relative
@@ -467,23 +486,46 @@ class CrossMatch():
         self.delta_mag_cuts = np.array([2.5, 5])
 
         if self.run_auf or not a_correct_file_number:
+            if self.j0s is None:
+                self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
             # Only warn if we did NOT choose to run AUF, but DID hit wrong file
             # number.
             if not a_correct_file_number and not self.run_auf:
                 warnings.warn('Incorrect number of files in catalogue "a" perturbation'
                               'AUF simulation folder. Deleting all files and re-running '
                               'cross-match process.')
-                # Once run AUf flag is updated, all other flags need to be set to run
+                # Once run AUF flag is updated, all other flags need to be set to run
                 self.run_group, self.run_cf, self.run_source = True, True, True
-            os.system("rm -rf {}/*".format(self.a_auf_folder_path))
             if self.include_perturb_auf:
-                _kwargs = {'psf_fwhms': self.a_psf_fwhms, 'tri_download_flag': self.a_download_tri}
+                _kwargs = {'psf_fwhms': self.a_psf_fwhms, 'tri_download_flag': self.a_download_tri,
+                           'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
+                           'j0s': self.j0s, 'density_mags': self.a_dens_mags,
+                           'dm_max': self.dm_max, 'd_mag': self.d_mag,
+                           'tri_filt_names': self.a_tri_filt_names,
+                           'compute_local_density': self.compute_local_density}
+                if self.b_download_tri:
+                    _kwargs = dict(_kwargs,
+                                   **{'tri_set_name': self.a_tri_set_name,
+                                      'fri_filt_num': self.a_tri_filt_num,
+                                      'auf_region_frame': self.a_auf_region_frame})
+                    os.system("rm -rf {}/*".format(self.a_auf_folder_path))
+                else:
+                    for i in range(len(self.a_auf_region_points)):
+                        ax1, ax2 = self.a_auf_region_points[i]
+                        ax_folder = '{}/{}/{}'.format(self.a_auf_folder_path, ax1, ax2)
+                        os.system('mv {}/trilegal_auf_simulation.dat {}/..'.format(
+                                  ax_folder, ax_folder))
+                        os.system("rm -rf {}/*".format(ax_folder))
+                        os.system('mv {}/../trilegal_auf_simulation.dat {}'.format(
+                                  ax_folder, ax_folder))
+                if self.compute_local_density:
+                    _kwargs = dict(_kwargs, **{'density_radius': self.a_dens_dist})
             else:
                 _kwargs = {}
             perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
-                             self.a_auf_region_points, self.cross_match_extent, self.r, self.dr,
-                             self.rho, self.drho, 'a', self.include_perturb_auf, a_n_sources,
-                             self.mem_chunk_num, self.delta_mag_cuts, **_kwargs)
+                             self.a_auf_region_points, self.r, self.dr,
+                             self.rho, self.drho, 'a', self.include_perturb_auf,
+                             self.mem_chunk_num, **_kwargs)
         else:
             print('Loading empirical crowding AUFs for catalogue "a"...')
             sys.stdout.flush()
@@ -494,23 +536,44 @@ class CrossMatch():
                                 os.walk(self.b_auf_folder_path)])
         b_correct_file_number = b_expected_files == b_file_number
 
-        b_n_sources = len(np.load('{}/magref.npy'.format(self.b_cat_folder_path), mmap_mode='r'))
-
         if self.run_auf or not b_correct_file_number:
             if not b_correct_file_number and not self.run_auf:
                 warnings.warn('Incorrect number of files in catalogue "b" perturbation'
                               'AUF simulation folder. Deleting all files and re-running '
                               'cross-match process.')
                 self.run_group, self.run_cf, self.run_source = True, True, True
-            os.system("rm -rf {}/*".format(self.b_auf_folder_path))
             if self.include_perturb_auf:
-                _kwargs = {'psf_fwhms': self.b_psf_fwhms, 'tri_download_flag': self.b_download_tri}
+                _kwargs = {'psf_fwhms': self.b_psf_fwhms, 'tri_download_flag': self.b_download_tri,
+                           'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
+                           'j0s': self.j0s, 'density_mags': self.b_dens_mags,
+                           'dm_max': self.dm_max, 'd_mag': self.d_mag,
+                           'tri_filt_names': self.b_tri_filt_names,
+                           'compute_local_density': self.compute_local_density}
+                if self.b_download_tri:
+                    _kwargs = dict(_kwargs,
+                                   **{'tri_set_name': self.b_tri_set_name,
+                                      'fri_filt_num': self.b_tri_filt_num,
+                                      'auf_region_frame': self.b_auf_region_frame})
+                    os.system("rm -rf {}/*".format(self.b_auf_folder_path))
+                else:
+                    for i in range(len(self.b_auf_region_points)):
+                        ax1, ax2 = self.b_auf_region_points[i]
+                        ax_folder = '{}/{}/{}'.format(self.b_auf_folder_path, ax1, ax2)
+                        os.system('mv {}/trilegal_auf_simulation.dat {}/..'.format(
+                                  ax_folder, ax_folder))
+                        os.system("rm -rf {}/*".format(ax_folder))
+                        os.system('mv {}/../trilegal_auf_simulation.dat {}'.format(
+                                  ax_folder, ax_folder))
+                if self.compute_local_density:
+                    _kwargs = dict(_kwargs, **{'density_radius': self.b_dens_dist})
+
             else:
+                os.system("rm -rf {}/*".format(self.b_auf_folder_path))
                 _kwargs = {}
             perturb_auf_func(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
-                             self.b_auf_region_points, self.cross_match_extent, self.r, self.dr,
-                             self.rho, self.drho, 'b', self.include_perturb_auf, b_n_sources,
-                             self.mem_chunk_num, self.delta_mag_cuts, **_kwargs)
+                             self.b_auf_region_points, self.r, self.dr,
+                             self.rho, self.drho, 'b', self.include_perturb_auf,
+                             self.mem_chunk_num, **_kwargs)
         else:
             print('Loading empirical crowding AUFs for catalogue "b"...')
             sys.stdout.flush()

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -291,7 +291,7 @@ def _lat_cut(i, a, di, lat, padding, sky_cut, cat_folder_path, inequality):
         sky position criterion.
     cat_folder_path : string
         Folder on disk where main catalogue being cross-matched is stored.
-    inequaility : ``operator.le`` or ``operator.ge``
+    inequality : ``operator.le`` or ``operator.ge``
         Function to determine whether a source is either above or below the
         given ``lat`` value.
     '''

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -5,6 +5,7 @@ framework.
 '''
 
 import os
+import operator
 import numpy as np
 
 __all__ = []
@@ -144,3 +145,162 @@ def map_large_index_to_small_index(inds, length, folder):
     os.system('rm {}/map_array.npy'.format(folder))
 
     return inds_map, inds_unique_flat
+
+
+def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds):
+    '''
+    Function to, in a memmap-friendly way, return a sub-set of the nearest sky
+    indices of a given catalogue.
+
+    Parameters
+    ----------
+    folder_path : string
+        Folder in which to store the temporary memmap file.
+    cat_name : string
+        String defining whether this function was called on catalogue "a" or "b".
+    ind : float
+        The value of the sky indices, as defined in ``distribute_sky_indices``,
+        to return a sub-set of the larger catalogue. This value represents
+        the index of a given on-sky position, used to construct the "counterpart"
+        and "field" likelihoods.
+    sky_inds : numpy.ndarray
+        The given catalogue's ``distribute_sky_indices`` values, to compare
+        with ``ind``.
+
+    Returns
+    -------
+    sky_cut : numpy.ndarray
+        A boolean array, indicating whether each element in ``sky_inds`` matches
+        ``ind`` or not.
+    '''
+    sky_cut = np.lib.format.open_memmap('{}/{}_small_sky_slice.npy'.format(
+        folder_path, cat_name), mode='w+', dtype=bool, shape=(len(sky_inds),))
+
+    di = max(1, len(sky_inds) // 20)
+
+    for i in range(0, len(sky_inds), di):
+        sky_cut[i:i+di] = sky_inds[i:i+di] == ind
+
+    return sky_cut
+
+
+def _load_rectangular_slice(folder_path, cat_name, cat_folder_path, a, lon1, lon2, lat1, lat2,
+                            padding):
+    # Slice the memmapped catalogue, with a memmapped slicing array to
+    # preserve memory.
+    sky_cut_1 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_1.npy'.format(
+        folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
+    sky_cut_2 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_2.npy'.format(
+        folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
+    sky_cut_3 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_3.npy'.format(
+        folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
+    sky_cut_4 = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_4.npy'.format(
+        folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
+    sky_cut = np.lib.format.open_memmap('{}/{}_temporary_sky_slice_combined.npy'.format(
+        folder_path, cat_name), mode='w+', dtype=bool, shape=(len(a),))
+
+    a = np.load('{}/con_cat_astro.npy'.format(cat_folder_path), mmap_mode='r')
+
+    di = max(1, len(a) // 20)
+    # Iterate over each small slice of the larger array, checking for upper
+    # and lower longitude, then latitude, criterion matching.
+    for i in range(0, len(a), di):
+        _lon_cut(i, a, di, lon1, padding, sky_cut_1, cat_folder_path, operator.ge)
+    for i in range(0, len(a), di):
+        _lon_cut(i, a, di, lon2, padding, sky_cut_2, cat_folder_path, operator.le)
+
+    for i in range(0, len(a), di):
+        _lat_cut(i, a, di, lat1, padding, sky_cut_3, cat_folder_path, operator.ge)
+    for i in range(0, len(a), di):
+        _lat_cut(i, a, di, lat2, padding, sky_cut_4, cat_folder_path, operator.le)
+
+    for i in range(0, len(a), di):
+        sky_cut[i:i+di] = (sky_cut_1[i:i+di] & sky_cut_2[i:i+di] &
+                           sky_cut_3[i:i+di] & sky_cut_4[i:i+di])
+
+    return sky_cut
+
+
+def _lon_cut(i, a, di, lon, padding, sky_cut, cat_folder_path, inequality):
+    '''
+    Function to calculate the longitude inequality criterion for astrometric
+    sources relative to a rectangle defining boundary limits.
+
+    Parameters
+    ----------
+    i : integer
+        Index into ``sky_cut`` for slicing.
+    a : numpy.ndarray
+        The main astrometric catalogue to be sliced, loaded into memmap.
+    di : integer
+        Index stride value, for slicing.
+    lon : float
+        Longitude at which to cut sources, either above or below, in degrees.
+    padding : float
+        Maximum allowed sky separation the "wrong" side of ``lon``, to allow
+        for an increase in sky box size to ensure all overlaps are caught in
+        ``get_max_overlap`` or ``get_max_indices``.
+    sky_cut : numpy.ndarray
+        Array into which to store boolean flags for whether source meets the
+        sky position criterion.
+    cat_folder_path : string
+        Folder on disk where main catalogue being cross-matched is stored.
+    inequaility : ``operator.le`` or ``operator.ge``
+        Function to determine whether a source is either above or below the
+        given ``lon`` value.
+    '''
+    # To check whether a source should be included in this slice or not if the
+    # "padding" factor is non-zero, add an extra caveat to check whether
+    # Haversine great-circle distance is less than the padding factor. For
+    # constant latitude this reduces to
+    # r = 2 arcsin(|cos(lat) * sin(delta-lon/2)|).
+    # However, in both zero and non-zero padding factor cases, we always require
+    # the source to be above or below the longitude for sky_cut_1 and sky_cut_2
+    # in load_fourier_grid_cutouts, respectively.
+    if padding > 0:
+        sky_cut[i:i+di] = (hav_dist_constant_lat(a[i:i+di, 0], a[i:i+di, 1], lon) <=
+                           padding) | inequality(a[i:i+di, 0], lon)
+    else:
+        sky_cut[i:i+di] = inequality(a[i:i+di, 0], lon)
+
+
+def _lat_cut(i, a, di, lat, padding, sky_cut, cat_folder_path, inequality):
+    '''
+    Function to calculate the latitude inequality criterion for astrometric
+    sources relative to a rectangle defining boundary limits.
+
+    Parameters
+    ----------
+    i : integer
+        Index into ``sky_cut`` for slicing.
+    a : numpy.ndarray
+        The main astrometric catalogue to be sliced, loaded into memmap.
+    di : integer
+        Index stride value, for slicing.
+    lat : float
+        Latitude at which to cut sources, either above or below, in degrees.
+    padding : float
+        Maximum allowed sky separation the "wrong" side of ``lat``, to allow
+        for an increase in sky box size to ensure all overlaps are caught in
+        ``get_max_overlap`` or ``get_max_indices``.
+    sky_cut : numpy.ndarray
+        Array into which to store boolean flags for whether source meets the
+        sky position criterion.
+    cat_folder_path : string
+        Folder on disk where main catalogue being cross-matched is stored.
+    inequaility : ``operator.le`` or ``operator.ge``
+        Function to determine whether a source is either above or below the
+        given ``lat`` value.
+    '''
+
+    # The "padding" factor is easier to handle for constant longitude in the
+    # Haversine formula, being a straight comparison of delta-lat, and thus we
+    # can simply move the required latitude padding factor to within the
+    # latitude comparison.
+    if padding > 0:
+        if inequality is operator.le:
+            sky_cut[i:i+di] = inequality(a[i:i+di, 1] - padding, lat)
+        else:
+            sky_cut[i:i+di] = inequality(a[i:i+di, 1] + padding, lat)
+    else:
+        sky_cut[i:i+di] = inequality(a[i:i+di, 1], lat)

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -248,7 +248,7 @@ def _lon_cut(i, a, di, lon, padding, sky_cut, cat_folder_path, inequality):
         sky position criterion.
     cat_folder_path : string
         Folder on disk where main catalogue being cross-matched is stored.
-    inequaility : ``operator.le`` or ``operator.ge``
+    inequality : ``operator.le`` or ``operator.ge``
         Function to determine whether a source is either above or below the
         given ``lon`` value.
     '''

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -218,6 +218,9 @@ def _load_rectangular_slice(folder_path, cat_name, cat_folder_path, a, lon1, lon
         sky_cut[i:i+di] = (sky_cut_1[i:i+di] & sky_cut_2[i:i+di] &
                            sky_cut_3[i:i+di] & sky_cut_4[i:i+di])
 
+    for i in range(4):
+        os.system('rm {}/{}_temporary_sky_slice_{}.npy'.format(folder_path, cat_name, i+1))
+
     return sky_cut
 
 

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -116,7 +116,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         The astrometric distance, in degrees, within which to consider numbers
         of internal catalogue sources, from which to calculate local density.
         Must be given if both ``include_perturb_auf`` and
-        ``compute_local_density`` are both ``True.
+        ``compute_local_density`` are both ``True``.
     """
     if include_perturb_auf and tri_download_flag and tri_set_name is None:
         raise ValueError("tri_set_name must be given if include_perturb_auf and tri_download_flag "

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -8,14 +8,20 @@ import os
 import sys
 import numpy as np
 
+from .misc_functions import _load_single_sky_slice, _load_rectangular_slice
 from .misc_functions_fortran import misc_functions_fortran as mff
+from .get_trilegal_wrapper import get_trilegal
+from .perturbation_auf_fortran import perturbation_auf_fortran as paf
 
-__all__ = ['make_perturb_aufs']
+__all__ = ['make_perturb_aufs', 'create_single_perturb_auf']
 
 
-def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, dr, rho,
-                      drho, which_cat, include_perturb_auf, n_sources, mem_chunk_num,
-                      delta_mag_cuts, psf_fwhms=None, tri_download_flag=False):
+def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
+                      drho, which_cat, include_perturb_auf, mem_chunk_num,
+                      tri_download_flag=False, delta_mag_cuts=None, psf_fwhms=None,
+                      tri_set_name=None, tri_filt_num=None, tri_filt_names=None,
+                      auf_region_frame=None, num_trials=None, j0s=None, density_mags=None,
+                      dm_max=None, d_mag=None, compute_local_density=None, density_radius=None):
     """
     Function to perform the creation of the blended object perturbation component
     of the AUF.
@@ -34,8 +40,6 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
     auf_points : numpy.ndarray
         Two-dimensional array containing pairs of coordinates at which to evaluate
         the perturbation AUF components.
-    ax_lims : numpy.ndarray
-        Array containing the four sky coordinate limits of the cross-match region.
     r : numpy.ndarray
         The real-space coordinates for the Hankel transformations used in AUF-AUF
         convolution.
@@ -51,28 +55,126 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
     include_perturb_auf : boolean
         ``True`` or ``False`` flag indicating whether perturbation component of the
         AUF should be used or not within the cross-match process.
-    n_sources : int
-        Number of sources in the main catalogue to be simulated.
     mem_chunk_num : int
         Number of individual sub-sections to break catalogue into for memory
         saving purposes.
-    delta_mag_cuts : numpy.ndarray
-        Array of magnitude offsets corresponding to relative fluxes of perturbing
-        sources, for consideration of relative contamination chances.
-    psf_fwhms : numpy.ndarray, optional
-        Array of full width at half-maximums for each filter in ``filters``. Only
-        required if ``include_perturb_auf`` is True; defaults to ``None``.
     tri_download_flag : boolean, optional
         A ``True``/``False`` flag, whether to re-download TRILEGAL simulated star
         counts or not if a simulation already exists in a given folder. Only
         needed if ``include_perturb_auf`` is True.
+    delta_mag_cuts : numpy.ndarray, optional
+        Array of magnitude offsets corresponding to relative fluxes of perturbing
+        sources, for consideration of relative contamination chances. Must be given
+        if ``include_perturb_auf`` is ``True``.
+    psf_fwhms : numpy.ndarray, optional
+        Array of full width at half-maximums for each filter in ``filters``. Only
+        required if ``include_perturb_auf`` is True; defaults to ``None``.
+    tri_set_name : string, optional
+        Name of the filter set to generate simulated TRILEGAL Galactic source
+        counts from. If ``include_perturb_auf`` and ``tri_download_flag`` are
+        ``True``, this must be set.
+    tri_filt_num : string, optional
+        Column number of the filter defining the magnitude limit of simulated
+        TRILEGAL Galactic sources. If ``include_perturb_auf`` and
+        ``tri_download_flag`` are ``True``, this must be set.
+    tri_filt_names : list or array of strings, optional
+        List of filter names in the TRILEGAL filterset defined in ``tri_set_name``,
+        in the same order as provided in ``psf_fwhms``. If ``include_perturb_auf``
+        and ``tri_download_flag`` are ``True``, this must be set.
+    auf_region_frame : string, optional
+        Coordinate reference frame in which sky coordinates are defined, either
+        ``equatorial`` or ``galactic``, used to define the coordinates TRILEGAL
+        simulations are generated in. If ``include_perturb_auf`` and
+        ``tri_download_flag`` are ``True``, this must be set.
+    num_trials : integer, optional
+        The number of simulated PSFs to compute in the derivation of the
+        perturbation component of the AUF. Must be given if ``include_perturb_auf``
+        is ``True``.
+    j0s : numpy.ndarray, optional
+        The Bessel Function of First Kind of Zeroth Order evaluated at each
+        ``r``-``rho`` combination. Must be given if ``include_perturb_auf``
+        is ``True``.
+    density_mags : numpy.ndarray, optional
+        The faintest magnitude down to which to consider number densities of
+        objects for normalisation purposes, in each filter, in the same order
+        as ``psf_fwhms``. Must be given if ``include_perturb_auf`` is ``True``.
+        Must be the same as were used to calculate ``count_density`` in
+        ``calculate_local_density``, if ``compute_local_density`` is ``False``
+        and pre-computed densities are being used.
+    dm_max : float, optional
+        The maximum magnitude difference, or relative flux, down to which to
+        consider simulated blended sources. Must be given if
+        ``include_perturb_auf`` is ``True``.
+    d_mag : float, optional
+        The resolution at which to create the TRILEGAL source density distribution.
+        Must be provided if ``include_perturb_auf`` is ``True``.
+    compute_local_density : boolean, optional
+        Flag to indicate whether to calculate local source densities during
+        the cross-match process, or whether to use pre-calculated values. Must
+        be provided if ``include_perturb_auf`` is ``True``.
+    density_radius : float, optional
+        The astrometric distance, in degrees, within which to consider numbers
+        of internal catalogue sources, from which to calculate local density.
+        Must be given if both ``include_perturb_auf`` and
+        ``compute_local_density`` are both ``True.
     """
-    print('Creating empirical crowding AUFs for catalogue "{}"...'.format(which_cat))
+    if include_perturb_auf and tri_download_flag and tri_set_name is None:
+        raise ValueError("tri_set_name must be given if include_perturb_auf and tri_download_flag "
+                         "are both True.")
+    if include_perturb_auf and tri_download_flag and tri_filt_num is None:
+        raise ValueError("tri_filt_num must be given if include_perturb_auf and tri_download_flag "
+                         "are both True.")
+    if include_perturb_auf and tri_download_flag and auf_region_frame is None:
+        raise ValueError("auf_region_frame must be given if include_perturb_auf and "
+                         "tri_download_flag are both True.")
+
+    if include_perturb_auf and tri_filt_names is None:
+        raise ValueError("tri_filt_names must be given if include_perturb_auf is True.")
+    if include_perturb_auf and delta_mag_cuts is None:
+        raise ValueError("delta_mag_cuts must be given if include_perturb_auf is True.")
+    if include_perturb_auf and psf_fwhms is None:
+        raise ValueError("psf_fwhms must be given if include_perturb_auf is True.")
+    if include_perturb_auf and num_trials is None:
+        raise ValueError("num_trials must be given if include_perturb_auf is True.")
+    if include_perturb_auf and j0s is None:
+        raise ValueError("j0s must be given if include_perturb_auf is True.")
+    if include_perturb_auf and density_mags is None:
+        raise ValueError("density_mags must be given if include_perturb_auf is True.")
+    if include_perturb_auf and dm_max is None:
+        raise ValueError("dm_max must be given if include_perturb_auf is True.")
+    if include_perturb_auf and d_mag is None:
+        raise ValueError("d_mag must be given if include_perturb_auf is True.")
+    if include_perturb_auf and compute_local_density is None:
+        raise ValueError("compute_local_density must be given if include_perturb_auf is True.")
+    if include_perturb_auf and compute_local_density and density_radius is None:
+        raise ValueError("density_radius must be given if include_perturb_auf and "
+                         "compute_local_density are both True.")
+
+    print('Creating perturbation AUFs sky indices for catalogue "{}"...'.format(which_cat))
     sys.stdout.flush()
 
-    # TODO: assign as input arg.
-    # The number of simulated PSFs to create for statistical purposes
-    N_trials = 1000000
+    n_sources = len(np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r'))
+
+    modelrefinds = np.lib.format.open_memmap('{}/modelrefinds.npy'.format(auf_folder),
+                                             mode='w+', dtype=int, shape=(3, n_sources),
+                                             fortran_order=True)
+
+    for cnum in range(0, mem_chunk_num):
+        lowind = np.floor(n_sources*cnum/mem_chunk_num).astype(int)
+        highind = np.floor(n_sources*(cnum+1)/mem_chunk_num).astype(int)
+        a = np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r')[lowind:highind]
+        # As we chunk in even steps through the files this is simple for now,
+        # but could be replaced with a more complex mapping in the future.
+        indexmap = np.arange(lowind, highind, 1)
+
+        # Which sky position to use is more complex; this involves determining
+        # the smallest great-circle distance to each auf_point AUF mapping for
+        # each source.
+        modelrefinds[2, indexmap] = mff.find_nearest_point(a[:, 0], a[:, 1],
+                                                           auf_points[:, 0], auf_points[:, 1])
+
+    print('Creating empirical perturbation AUFs for catalogue "{}"...'.format(which_cat))
+    sys.stdout.flush()
 
     # Store the length of the density-magnitude combinations in each sky/filter
     # combination for future loading purposes.
@@ -80,15 +182,26 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
                                              dtype=int, shape=(len(filters), len(auf_points)),
                                              fortran_order=True)
 
+    if include_perturb_auf:
+        a_tot_photo = np.load('{}/con_cat_photo.npy'.format(cat_folder), mmap_mode='r')
+        if compute_local_density:
+            a_tot_astro = np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r')
+
     for i in range(len(auf_points)):
         ax1, ax2 = auf_points[i]
         ax_folder = '{}/{}/{}'.format(auf_folder, ax1, ax2)
         if not os.path.exists(ax_folder):
             os.makedirs(ax_folder, exist_ok=True)
+
+        if include_perturb_auf and tri_download_flag:
+            download_trilegal_simulation(ax_folder, tri_set_name, ax1, ax2, tri_filt_num,
+                                         auf_region_frame)
+
         if include_perturb_auf:
-            # TODO: download TRILEGAL simulation here
-            raise NotImplementedError("Perturbation AUF components are not currently "
-                                      "included in the cross-match process.")
+            sky_cut = _load_single_sky_slice(auf_folder, '', i, modelrefinds[2, :])
+            a_photo_cut = a_tot_photo[sky_cut]
+            if compute_local_density:
+                a_astro_cut = a_tot_astro[sky_cut]
 
         for j in range(len(filters)):
             filt = filters[j]
@@ -98,9 +211,21 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
                 os.makedirs(filt_folder, exist_ok=True)
 
             if include_perturb_auf:
-                # TODO: extend with create_single_auf
-                raise NotImplementedError("Perturbation AUF components are not currently "
-                                          "included in the cross-match process.")
+                good_mag_slice = ~np.isnan(a_photo_cut[:, j])
+                a_photo = a_photo_cut[good_mag_slice, j]
+                if len(a_photo) == 0:
+                    arraylengths[j, i] = 0
+                    continue
+                if compute_local_density:
+                    localN = calculate_local_density(
+                        a_astro_cut[good_mag_slice], a_tot_astro, a_tot_photo[:, j],
+                        auf_folder, cat_folder, density_radius, density_mags[j])
+                else:
+                    localN = np.load('{}/local_N.npy'.format(auf_folder),
+                                     mmap_mode='r')[sky_cut][good_mag_slice, j]
+                Narray = create_single_perturb_auf(
+                    ax_folder, filters, r, dr, rho, drho, j0s, num_trials, psf_fwhms,
+                    tri_filt_names, density_mags, a_photo, localN, dm_max, d_mag, delta_mag_cuts)
             else:
                 # Without the simulations to force local normalising density N or
                 # individual source brightness magnitudes, we can simply combine
@@ -112,7 +237,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
                 # "nothing" through the cross-match. Here we would use fortran
                 # subroutines to create the perturbation simulations, so we make
                 # f-ordered dummy parameters.
-                Frac = np.zeros((len(delta_mag_cuts), num_N_mag), float, order='F')
+                Frac = np.zeros((1, num_N_mag), float, order='F')
                 np.save('{}/frac.npy'.format(filt_folder), Frac)
                 Flux = np.zeros(num_N_mag, float, order='F')
                 np.save('{}/flux.npy'.format(filt_folder), Flux)
@@ -141,30 +266,56 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
                 np.save('{}/mag.npy'.format(filt_folder), magarray)
             arraylengths[j, i] = len(Narray)
 
+    if include_perturb_auf:
+        longestNm = np.amax(arraylengths)
+
+        Narrays = np.lib.format.open_memmap('{}/narrays.npy'.format(auf_folder), mode='w+',
+                                            dtype=float, shape=(longestNm, len(filters),
+                                            len(auf_points)), fortran_order=True)
+        Narrays[:, :, :] = -1
+        magarrays = np.lib.format.open_memmap('{}/magarrays.npy'.format(auf_folder), mode='w+',
+                                              dtype=float, shape=(longestNm, len(filters),
+                                              len(auf_points)), fortran_order=True)
+        magarrays[:, :, :] = -1
+        for i in range(len(auf_points)):
+            ax1, ax2 = auf_points[i]
+            ax_folder = '{}/{}/{}'.format(auf_folder, ax1, ax2)
+            for j in range(len(filters)):
+                if arraylengths[j, i] == 0:
+                    continue
+                filt = filters[j]
+                filt_folder = '{}/{}'.format(ax_folder, filt)
+                Narray = np.load('{}/N.npy'.format(filt_folder))
+                magarray = np.load('{}/mag.npy'.format(filt_folder))
+                Narrays[:arraylengths[j, i], j, i] = Narray
+                magarrays[:arraylengths[j, i], j, i] = magarray
+
     # Once the individual AUF simulations are saved, we also need to calculate
     # the indices each source references when slicing into the 4-D cubes
     # created by [1-D array] x N-m combination x filter x sky position iteration.
 
-    print('Creating crowding AUFs indices for catalogue "{}"...'.format(which_cat))
+    print('Creating perturbation AUFs filter indices for catalogue "{}"...'.format(which_cat))
     sys.stdout.flush()
-
-    modelrefinds = np.lib.format.open_memmap('{}/modelrefinds.npy'.format(auf_folder),
-                                             mode='w+', dtype=int, shape=(3, n_sources),
-                                             fortran_order=True)
 
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(n_sources*cnum/mem_chunk_num).astype(int)
         highind = np.floor(n_sources*(cnum+1)/mem_chunk_num).astype(int)
-        a = np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r')[lowind:highind]
+        if include_perturb_auf:
+            a = np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r')[lowind:highind]
         magref = np.load('{}/magref.npy'.format(cat_folder), mmap_mode='r')[lowind:highind]
         # As we chunk in even steps through the files this is simple for now,
         # but could be replaced with a more complex mapping in the future.
         indexmap = np.arange(lowind, highind, 1)
 
         if include_perturb_auf:
-            # TODO: load 3-D cube of N-m combinations for unique sky/filter pairs.
-            raise NotImplementedError("Perturbation AUF components are not currently "
-                                      "included in the cross-match process.")
+            for i in range(0, len(a)):
+                axind = modelrefinds[2, indexmap[i]]
+                filterind = magref[i]
+                Nmind = np.argmin((localN[indexmap[i]] - Narrays[:arraylengths[filterind, axind],
+                                                                 filterind, axind])**2 +
+                                  (a[i, magref[i]] - magarrays[:arraylengths[filterind, axind],
+                                                               filterind, axind])**2)
+                modelrefinds[0, indexmap[i]] = Nmind
         else:
             # For the case that we do not use the perturbation AUF component,
             # our dummy N-m files are all one-length arrays, so we can
@@ -175,8 +326,358 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, ax_lims, r, d
         # the filter index of the "best" filter for each source, from magref.
         modelrefinds[1, indexmap] = magref
 
-        # Which sky position to use is more complex; this involves determining
-        # the smallest great-circle distance to each auf_point AUF mapping for
-        # each source.
-        modelrefinds[2, indexmap] = mff.find_nearest_point(a[:, 0], a[:, 1],
-                                                           auf_points[:, 0], auf_points[:, 1])
+    if include_perturb_auf:
+        del Narrays, magarrays
+        os.remove('{}/narrays.npy'.format(auf_folder))
+        os.remove('{}/magarrays.npy'.format(auf_folder))
+
+
+def download_trilegal_simulation(tri_folder, tri_filter_set, ax1, ax2, mag_num, region_frame,
+                                 total_objs=1.5e6):
+    '''
+    Get a single Galactic sightline TRILEGAL simulation of an appropriate sky
+    size, and save it in a folder for use in the perturbation AUF simulations.
+
+    Parameters
+    ----------
+    tri_folder : string
+        The location of the folder into which to save the TRILEGAL file.
+    tri_filter_set : string
+        The name of the filterset, as given by the TRILEGAL input form.
+    ax1 : float
+        The first axis position of the sightline to be simulated, in the frame
+        determined by ``region_frame``.
+    ax2 : float
+        The second axis position of the TRILEGAL sightline.
+    mag_num : integer
+        The zero-indexed filter number in the ``tri_filter_set`` list of filters
+        which decides the limiting magnitude down to which tosimulate the
+        Galactic sources.
+    region_frame : string
+        Frame, either equatorial or galactic, of the cross-match being performed,
+        indicating whether ``ax1`` and ``ax2`` are in Right Ascension and
+        Declination or Galactic Longitude and Latitude.
+    total_objs : integer, optional
+        The approximate number of objects to simulate in a TRILEGAL sightline,
+        affecting how large an area to request a simulated Galactic region of.
+    '''
+    areaflag = 0
+    triarea = 0.001
+    tri_name = 'trilegal_auf_simulation'
+    mag_lim = 32
+    galactic_flag = True if region_frame == 'galactic' else False
+    while areaflag == 0:
+        get_trilegal(tri_name, ax1, ax2, folder=tri_folder, galactic=galactic_flag,
+                     filterset=tri_filter_set, area=triarea, maglim=mag_lim, magnum=mag_num)
+        f = open('{}/{}.dat'.format(tri_folder, tri_name), "r")
+        contents = f.readlines()
+        f.close()
+        # Two comment lines; one at the top and one at the bottom - we add a
+        # third in a moment, however
+        nobjs = len(contents) - 2
+        # If too few stars then increase by factor 10 and loop, or scale to give
+        # about 1.5 million stars and come out of area increase loop --
+        # simulations can't be more than 10 sq deg, so accept if that's as large
+        # as we can go.
+        if nobjs < 10000 and triarea < 10:
+            triarea = min(10, triarea*10)
+        else:
+            triarea = min(10, triarea / nobjs * total_objs)
+            areaflag = 1
+        os.system('rm {}/{}.dat'.format(tri_folder, tri_name))
+    get_trilegal(tri_name, ax1, ax2, folder=tri_folder, galactic=galactic_flag,
+                 filterset=tri_filter_set, area=triarea, maglim=mag_lim, magnum=mag_num)
+    f = open('{}/{}.dat'.format(tri_folder, tri_name), "r")
+    contents = f.readlines()
+    f.close()
+    contents.insert(0, '#area = {} sq deg\n'.format(triarea))
+    f = open('{}/{}.dat'.format(tri_folder, tri_name), "w")
+    contents = "".join(contents)
+    f.write(contents)
+    f.close()
+
+
+def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_folder,
+                            density_radius, density_mag):
+    '''
+    Calculates the number of sources above a given brightness within a specified
+    radius of each source in a catalogue, to provide a local density for
+    normalisation purposes.
+
+    Parameters
+    ----------
+    a_astro : numpy.ndarray
+        Sub-set of astrometric portion of total catalogue, for which local
+        densities are to be calculated.
+    a_tot_astro : numpy.ndarray
+        Full astrometric catalogue, from which all potential sources above
+        ``density_mag`` and coeval with ``a_astro`` sources are to be extracted.
+    a_tot_photo : numpy.ndarray
+        The photometry of the full catalogue, matching ``a_tot_astro``.
+    auf_folder : string
+        The folder designated to contain the perturbation AUF component related
+        data for this catalogue.
+    cat_folder : string
+        The location of the catalogue files for this dataset.
+    density_radius : float
+        The radius, in degrees, out to which to consider the number of sources
+        for the normalising density.
+    density_mag : float
+        The brightness, in magnitudes, above which to count sources for density
+        purposes.
+
+    Returns
+    -------
+    count_density : numpy.ndarray
+        The number of sources per square degree near to each source in
+        ``a_astro`` that are above ``density_mag`` in ``a_tot_astro``.
+    '''
+    min_lon, max_lon = np.amin(a_astro[:, 0]), np.amax(a_astro[:, 0])
+    min_lat, max_lat = np.amin(a_astro[:, 1]), np.amax(a_astro[:, 1])
+
+    overlap_sky_cut = _load_rectangular_slice(auf_folder, '', cat_folder, a_tot_astro, min_lon,
+                                              max_lon, min_lat, max_lat, density_radius)
+    cut = np.lib.format.open_memmap('{}/_temporary_slice.npy'.format(
+        auf_folder), mode='w+', dtype=bool, shape=(len(a_tot_astro),))
+    di = max(1, len(cut) // 20)
+    for i in range(0, len(a_tot_astro), di):
+        cut[i:i+di] = overlap_sky_cut[i:i+di] & (a_tot_photo[i:i+di] <= density_mag)
+    a_astro_overlap_cut = a_tot_astro[cut]
+    os.system('rm {}/_temporary_slice.npy'.format(auf_folder))
+
+    counts = paf.get_density(a_astro[:, 0], a_astro[:, 1], a_astro_overlap_cut[:, 0],
+                             a_astro_overlap_cut[:, 1], density_radius)
+    min_lon, max_lon = np.amin(a_astro_overlap_cut[:, 0]), np.amax(a_astro_overlap_cut[:, 0])
+    min_lat, max_lat = np.amin(a_astro_overlap_cut[:, 1]), np.amax(a_astro_overlap_cut[:, 1])
+    circle_overlap_area = np.empty(len(a_astro), float)
+    for i in range(len(a_astro)):
+        circle_overlap_area[i] = get_circle_overlap_area(
+            density_radius, [min_lon, max_lon], [min_lat, max_lat], a_astro[i, [0, 1]])
+    count_density = counts / circle_overlap_area
+
+    return count_density
+
+
+def get_circle_overlap_area(r, x_edges, y_edges, coords):
+    '''
+    Calculates the overlap between a circle of given radius and rectangle
+    defined by four edge coordinates.
+
+    Parameters
+    ----------
+    r : float
+        The radius of the circle.
+    x_edges : list or numpy.ndarray
+        Upper and lower limits of the rectangle.
+    y_edges : list or numpy.ndarray
+        Limits of the rectangle in the second orthogonal axis.
+    coords : numpy.ndarray or list
+        The (x, y) coordinates of the center of each circle to consider
+        overlap area with rectangle for.
+
+    Returns
+    -------
+    area : float
+        The area of circle of radius ``r`` which overlaps the rectangle
+        defined by ``x_edges`` and ``y_edges``.
+    '''
+    area = np.pi * r**2
+    has_overlapped_edge = [0, 0, 0, 0]
+    edges = np.array([x_edges[0], y_edges[0], x_edges[1], y_edges[1]])
+    coords = np.array([coords[0], coords[1], coords[0], coords[1]])
+    for i, (edge, coord) in enumerate(zip(edges, coords)):
+        h = np.abs(coord - edge)
+        if h < r:
+            # The first chord integration is "free", and does not have
+            # truncated limits based on overlaps; the final chord integration,
+            # however, cares about truncation on both sides. The "middle two"
+            # integrations only truncate to the previous side.
+            a = -np.sqrt(r**2 - h**2)
+            b = +np.sqrt(r**2 - h**2)
+
+            if i == 1 and has_overlapped_edge[0]:
+                a = max(a, x_edges[0] - coords[0])
+            if i == 2 and has_overlapped_edge[1]:
+                a = max(a, y_edges[0] - coords[1])
+            if i == 3 and has_overlapped_edge[0]:
+                a = max(a, x_edges[0] - coords[0])
+            if i == 3 and has_overlapped_edge[2]:
+                b = min(b, x_edges[1] - coords[0])
+
+            chord_area_overlap = chord_integral_eval(b, r, h) - chord_integral_eval(a, r, h)
+            has_overlapped_edge[i] = 1
+
+            area -= chord_area_overlap
+
+    return area
+
+
+def chord_integral_eval(x, r, h):
+    '''
+    Calculates the indefinite integral of the distance between a given circle
+    chord and the circumference of the circle, to calculate the chord area.
+
+    Parameters
+    ----------
+    x : float
+        The integrable coordinate, orthogonal to the line between the center
+        of the circle and the chord at height ``h``.
+    r : float
+        The radius of the circle.
+    h : float
+        The height of the chord inside the circle of radius ``r``.
+
+    Returns
+    -------
+    integral : float
+        The result of the indefinite integral of the chord area.
+    '''
+    d = np.sqrt(r**2 - x**2)
+
+    if d == 0:
+        x_div_d = np.sign(x) * np.inf
+    else:
+        x_div_d = x / d
+
+    integral = 0.5 * (x * d + r**2 * np.arctan(x_div_d)) - h * x
+    return integral
+
+
+def create_single_perturb_auf(tri_folder, filters, r, dr, rho, drho, j0s, num_trials, psf_fwhms,
+                              headers, density_mags, a_photo, localN, dm_max, d_mag, mag_cut):
+    '''
+    Creates the associated parameters for describing a single perturbation AUF
+    component, for a single sky position.
+
+    Parameters
+    ----------
+    tri_folder : string
+        Folder where the TRILEGAL datafile is stored, and where the individual
+        filter-specific perturbation AUF simulations should be saved.
+    filters : list of floats or numpy.ndarray
+        List of the filters for which to simulate the AUF component.
+    r : numpy.ndarray
+        Array of real-space positions.
+    dr : numpy.ndarray
+        Array of the bin sizes of each ``r`` position.
+    rho : numpy.ndarray
+        Fourier-space coordinates at which to sample the fourier transformation
+        of the distribution of perturbations due to blended sources.
+    drho : numpy.ndarray
+        Bin widths of each ``rho`` coordinate.
+    j0s : numpy.ndarray
+        The Bessel Function of First Kind of Zeroth Order, evaluated at all
+        ``r``-``rho`` combinations.
+    num_trials : integer
+        The number of realisations of blended contaminant sources to draw
+        when simulating perturbations of source positions.
+    psf_fwhms : list of floats or numpy.ndarray
+        The full-width at half maxima of each ``filters`` filter.
+    headers : list of floats or numpy.ndarray
+        The filter names as given by the TRILEGAL datafiles, in ``filters`` order.
+    density_mags : list of floats or numpy.ndarray
+        The limiting magnitude above which to consider local normalising densities,
+        corresponding to each ``filters`` bandpass.
+    a_photo : numpy.ndarray
+        The photometry of each source for which simulated perturbations should be
+        made.
+    localN : numpy.ndarray
+        The local normalising densities for each source.
+    dm_max : float
+        The maximum magnitude down to which to simulate blended objects, limiting
+        the smallest possible perturbation considered.
+    d_mag : float
+        The interval at which to bin the magnitudes of a given set of objects,
+        for the creation of the appropriate brightness/density combinations to
+        simulate.
+    mag_cut : numpy.ndarray or list of floats
+        The magnitude offsets -- or relative fluxes -- above which to keep track of
+        the fraction of objects suffering from a contaminating source.
+
+    Returns
+    -------
+    count_array : numpy.ndarray
+        The simulated local normalising densities that were used to simulate
+        potential perturbation distributions.
+    '''
+    tri_name = 'trilegal_auf_simulation'
+    f = open('{}/{}.dat'.format(tri_folder, tri_name), "r")
+    line = f.readline()
+    f.close()
+    bits = line.split(' ')
+    tri_area = float(bits[2])
+    tri = np.genfromtxt('{}/{}.dat'.format(tri_folder, tri_name), delimiter=None,
+                        names=True, comments='#', skip_header=1)
+
+    # TODO: extend to allow a Galactic source model that doesn't depend on TRILEGAL
+    tri_counts = np.empty(len(filters), int)
+    model_mags_list = []
+    model_mags_interval_list = []
+    log10y_tris = []
+    log10y_gals = []
+    for k in range(len(filters)):
+        tri_mags = tri[:][headers[k]]
+        tri_counts[k] = np.sum(tri_mags <= density_mags[k]) / tri_area
+
+        minmag = d_mag * np.floor(np.amin(tri_mags)/d_mag)
+        maxmag = d_mag * np.ceil(np.amax(tri_mags)/d_mag)
+        hist, model_mags = np.histogram(tri_mags, bins=np.arange(minmag, maxmag+1e-10, d_mag))
+        hc = np.where(hist > 3)[0]
+
+        hist = hist[hc]
+        model_mags_interval = np.diff(model_mags)[hc]
+        model_mags = model_mags[hc]
+
+        hist = hist / model_mags_interval / tri_area
+        log10y = np.log10(hist)
+
+        log10y_tris.append(log10y)
+        model_mags_list.append(model_mags)
+        model_mags_interval_list.append(model_mags_interval)
+
+    # TODO: add the step to get density and counts of extra-galactic sources.
+    gal_counts = np.zeros_like(tri_counts)
+    for k in range(len(filters)):
+        log10y_gals.append(-np.inf * np.ones_like(log10y_tris[k]))
+
+    for k in range(len(filters)):
+        model_count = tri_counts[k] + gal_counts[k]
+
+        log10y = np.log10(10**log10y_tris[k] + 10**log10y_gals[k])
+        model_mags = model_mags_list[k]
+        model_mags_interval = model_mags_interval_list[k]
+
+        # Set a magnitude bin width of 0.25 mags, to avoid oversampling.
+        dmag = 0.25
+        mag_min = dmag * np.floor(np.amin(a_photo)/dmag)
+        mag_max = dmag * np.ceil(np.amax(a_photo)/dmag)
+        magbins = np.arange(mag_min, mag_max+1e-10, dmag)
+        # For local densities, we want a percentage offset, given that we're in
+        # logarithmic bins, accepting a log-difference maximum. This is slightly
+        # lop-sided, but for 20% results in +18%/-22% limits, which is fine.
+        dlogN = 0.2
+        logNvals = np.log(localN)
+        logN_min = dlogN * np.floor(np.amin(logNvals)/dlogN)
+        logN_max = dlogN * np.ceil(np.amax(logNvals)/dlogN)
+        logNbins = np.arange(logN_min, logN_max+1e-10, dlogN)
+
+        counts, logNbins, magbins = np.histogram2d(logNvals, a_photo, bins=[logNbins, magbins])
+        Ni, magi = np.where(counts > 0)
+        mag_array = 0.5*(magbins[1:]+magbins[:-1])[magi]
+        count_array = np.exp(0.5*(logNbins[1:]+logNbins[:-1])[Ni])
+
+        R = 1.185 * psf_fwhms[k]
+        seed = np.random.default_rng().choice(100000, size=paf.get_random_seed_size())
+        Frac, Flux, fourieroffset, offset, cumulative = paf.perturb_aufs(
+            count_array, mag_array, r[:-1]+dr/2, dr, r, j0s.T,
+            model_mags+model_mags_interval/2, model_mags_interval, log10y, model_count,
+            int(dm_max/d_mag) * np.ones_like(count_array), mag_cut, R, num_trials, seed)
+        np.save('{}/{}/frac.npy'.format(tri_folder, filters[k]), Frac)
+        np.save('{}/{}/flux.npy'.format(tri_folder, filters[k]), Flux)
+        np.save('{}/{}/offset.npy'.format(tri_folder, filters[k]), offset)
+        np.save('{}/{}/cumulative.npy'.format(tri_folder, filters[k]), cumulative)
+        np.save('{}/{}/fourier.npy'.format(tri_folder, filters[k]), fourieroffset)
+        np.save('{}/{}/N.npy'.format(tri_folder, filters[k]), count_array)
+        np.save('{}/{}/mag.npy'.format(tri_folder, filters[k]), mag_array)
+
+    return count_array

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -435,7 +435,7 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
     min_lon, max_lon = np.amin(a_astro[:, 0]), np.amax(a_astro[:, 0])
     min_lat, max_lat = np.amin(a_astro[:, 1]), np.amax(a_astro[:, 1])
 
-    overlap_sky_cut = _load_rectangular_slice(auf_folder, '', cat_folder, a_tot_astro, min_lon,
+    overlap_sky_cut = _load_rectangular_slice(auf_folder, '', a_tot_astro, min_lon,
                                               max_lon, min_lat, max_lat, density_radius)
     cut = np.lib.format.open_memmap('{}/_temporary_slice.npy'.format(
         auf_folder), mode='w+', dtype=bool, shape=(len(a_tot_astro),))

--- a/macauff/perturbation_auf_fortran.f90
+++ b/macauff/perturbation_auf_fortran.f90
@@ -1,0 +1,333 @@
+! Licensed under a 3-clause BSD style license - see LICENSE
+
+module perturbation_auf_fortran
+! This module provides the Fortran code for the handling of the creation of perturbation
+! component of the Astrometric Uncertainty Function.
+
+implicit none
+
+integer, parameter :: dp = kind(0.0d0)  ! double precision
+real(dp), parameter :: pi = 4.0_dp*atan(1.0_dp)
+
+contains
+
+subroutine get_density(a_ax1, a_ax2, b_ax1, b_ax2, maxdist, counts)
+    ! Calculate the number of sources in a given catalogue within a specified radius of each source.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Sky coordinates for catalogues a and b.
+    real(dp), intent(in) :: a_ax1(:), a_ax2(:), b_ax1(:), b_ax2(:)
+    ! Separation to consider the number of objects within.
+    real(dp), intent(in) :: maxdist
+    ! Number of objects within maxdist of each catalogue a source.
+    integer, intent(out) :: counts(size(a_ax1))
+    ! Loop counters.
+    integer :: i, j
+    ! Sky separations.
+    real(dp) :: dist, dx, d_ax1, d_ax2
+
+    counts = 0
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i, j, dist, dx, d_ax1, d_ax2) SHARED(a_ax1, a_ax2, b_ax1, b_ax2, counts, maxdist)
+    do j = 1, size(a_ax1)
+        do i = 1, size(b_ax1)
+            ! Difference in latitude is always just the absolute difference
+            d_ax2 = abs(a_ax2(j) - b_ax2(i))
+            if (d_ax2 <= maxdist) then
+                ! Need reduction of Haversine formula for longitude difference, remembering to convert to degrees:
+                d_ax1 = 2.0_dp * asin(abs(cos(a_ax2(j) / 180.0_dp * pi) * &
+                                      sin((a_ax1(j) - b_ax1(i))/2.0_dp / 180.0_dp * pi))) * 180.0_dp / pi
+                if (d_ax1 <= maxdist) then
+                    call haversine(a_ax1(j), b_ax1(i), a_ax2(j), b_ax2(i), dist)
+                    if (dist <= maxdist) then
+                        counts(j) = counts(j) + 1
+                    end if
+                end if
+            end if
+        end do
+    end do
+!$OMP END PARALLEL DO
+
+end subroutine get_density
+
+subroutine perturb_aufs(Narray, magarray, r, dr, rbins, j0s, mag_D, dmag_D, Ds, N_norm, num_int, dmcut, psfr, &
+    lentrials, seed, Fracgrid, Fluxav, fouriergrid, rgrid, intrgrid)
+    ! Fortran wrapper for the perturbation AUF component calculation for a set of density-magnitude
+    ! combinations, creating the various parameters needed to use the distribution of perturbations.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Number of simulated PSFs to generate.
+    integer, intent(in) :: lentrials
+    ! Number of bins to draw simulated perturbers from, below the brightness of the central source.
+    integer, intent(in) :: num_int(:)
+    ! RNG seed.
+    integer, intent(in) :: seed(:)
+    ! Arrays of local densities and central source brightnesses to generate simulated PSFs for.
+    real(dp), intent(in) :: Narray(:), magarray(:)
+    ! Real space coordinates: middle of bins, bin widths, and bin edges (hence size(r)+1 == size(rbins)).
+    real(dp), intent(in) :: r(:), dr(:), rbins(:)
+    ! Bessel Function of First Kind of Zeroth Order, evaluated at various r-rho combinations.
+    real(dp), intent(in) :: j0s(:, :)
+    ! Magnitudes, magnitude bin widths, and logarithmic source number densities, from which to draw
+    ! Poissonian average sources per PSF circle.
+    real(dp), intent(in) :: mag_D(:), dmag_D(:), Ds(:)
+    ! Normalising density of simulated sources.
+    real(dp), intent(in) :: N_norm
+    ! Relative fluxes, in magnitude offset, above which to record whether a central object suffers
+    ! a contaminating source or not.
+    real(dp), intent(in) :: dmcut(:)
+    ! Radius of PSF for given filter, used to define the PSF circle inside which to draw contaminants.
+    real(dp), intent(in) :: psfr
+    ! Fraction of sources with contaminant above dmcut, and average contamination of, density-magnitude
+    ! combinations to consider for this filter-sightline pair.
+    real(dp), intent(out) :: Fracgrid(size(dmcut), size(Narray)), Fluxav(size(Narray))
+    ! Fourier, real, and cumulative integral of real, representations of the distribution of perturbations
+    ! simulated for the lentrials number of PSFs.
+    real(dp), intent(out) :: fouriergrid(size(j0s, 2), size(Narray)), rgrid(size(r), size(Narray)), intrgrid(size(r), size(Narray))
+    ! Loop counters.
+    integer :: j, k
+    ! Variables to define the sizes and positions of various arrays: defines allocatable length of dm;
+    ! position in mag_D; and maximum number of simulated perturbers in a single PSF.
+    integer :: lendm, mag_Dindex, maxk
+    ! Temporary storage of various parameters: individual perturbations of a given density-brightness
+    ! combination, fractions of PSF realisations for one N-m pair that have contaminants above dmcut
+    ! relative fluxes, and the average flux within each PSF realisation for the given PSF setup.
+    real(dp) :: offsets(lentrials), fraccontam(size(dmcut)), fluxcontam(lentrials)
+    ! Individual PSF setup distribution functions: histogram of perturbations, cumulative integral of
+    ! perturbations, and Fourier-space representation of perturbation distribution.
+    real(dp) :: hist(size(r)), cumulathist(size(r)), fourierhist(size(j0s, 2))
+    ! Central source magnitude and local normalising density at which to simulate PSF contaminations.
+    real(dp) :: mag, N_b
+    ! Define the number of sources per PSF circle in each magnitude bin range (from central source
+    ! brightness to num_int bins fainter), the magnitude offsets (relative fluxes) of those bins,
+    ! and the widths of those magnitude offset bins.
+    real(dp), allocatable :: dNs(:), dms(:), ddms(:)
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(j, k, N_b, mag, mag_Dindex, lendm, dms, dNs, ddms, offsets, fraccontam, maxk, &
+!$OMP& fluxcontam, hist, cumulathist, fourierhist) &
+!$OMP& SHARED(Narray, magarray, mag_D, psfr, dmcut, lentrials, num_int, Ds, dmag_D, N_norm, rbins, r, dr, j0s, rgrid, &
+!$OMP& seed, fouriergrid, intrgrid, Fracgrid, Fluxav) SCHEDULE(guided)
+    do j = 1, size(Narray)
+        N_b = Narray(j)
+        mag = magarray(j)
+        mag_Dindex = minloc(mag_D, mask=(mag_D >= mag), dim=1)
+        lendm = min(num_int(j), size(mag_D)-mag_Dindex+1)
+        allocate(dms(lendm))
+        allocate(ddms(lendm))
+        allocate(dNs(lendm))
+        do k = 1, lendm
+            dNs(k) = 10**Ds(mag_Dindex+k-1) * dmag_D(mag_Dindex+k-1) * pi * (psfr/3600.0_dp)**2 * N_b / N_norm
+            dms(k) = mag_D(mag_Dindex+k-1) - mag
+            ddms(k) = dmag_D(mag_Dindex+k-1)
+        end do
+        maxk = max(5, int(10*maxval(dNs)))
+        call scatter_perturbers(dNs, dms, psfr, maxk, dmcut, offsets, fraccontam, fluxcontam, ddms, lentrials, seed)
+        call histogram(offsets, rbins, hist, size(r)+1, lentrials)
+
+        ! r is middle of bins, which are represented by rbins; there's a shift of dr/2 between the two (minus rbins(lenr+1))
+        hist = hist / (pi * ((r + dr/2.0_dp)**2 - (r - dr/2.0_dp)**2) * sum(hist))
+        cumulathist(1) = hist(1) * pi * ((r(1) + dr(1)/2.0_dp)**2 - (r(1) - dr(1)/2.0_dp)**2)
+        do k = 2, size(r)
+            cumulathist(k) = cumulathist(k-1) + hist(k) * pi * ((r(k) + dr(k)/2.0_dp)**2 - (r(k) - dr(k)/2.0_dp)**2)  
+        end do
+        call fourier_transform(hist, r, dr, j0s, fourierhist)
+        fouriergrid(:, j) = fourierhist
+        rgrid(:, j) = hist
+
+        intrgrid(:, j) = cumulathist
+        Fracgrid(:, j) = fraccontam
+        Fluxav(j) = sum(fluxcontam) / real(lentrials, dp)
+
+        deallocate(dms)
+        deallocate(dNs)
+    end do
+!$OMP END PARALLEL DO
+
+end subroutine perturb_aufs
+
+subroutine scatter_perturbers(dNs, dms, psfr, maxk, dmcut, offsets, fraccontam, fluxcontam, ddms, lentrials, seed)
+    ! Given a set of average numbers of sources per PSF circle for a series of relative fluxes, populate
+    ! a bright, central source's PSF with randomly placed sources, and calculate the flux brightening
+    ! and expected PSF centroid shift.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Number of simulated PSFs to generate.
+    integer, intent(in) :: lentrials
+    ! Maximum allowed number of sources of a given magnitude offset in a PSF circle.
+    integer, intent(in) :: maxk
+    ! RNG seed.
+    integer, intent(in) :: seed(:)
+    ! Average numbers of sources per PSF circle for each magnitude offset; magnitude offsets (or
+    ! relative fluxes) to be populated within the PSF, and the bin width of the magnitude offsets.
+    real(dp), intent(in) :: dNs(:), dms(:), ddms(:)
+    ! PSF radius, defined by the Rayleigh criterion based on the full-width at half-maximum.
+    real(dp), intent(in) :: psfr
+    ! Magnitude offsets above which to consider if a PSF has been contaminated by a source of
+    ! this relative flux.
+    real(dp), intent(in) :: dmcut(:)
+
+    real(dp), intent(out) :: offsets(lentrials), fraccontam(size(dmcut)), fluxcontam(lentrials)
+    ! Loop counters, and number of sources to be populated within a given PSF for a small dm slice.
+    integer :: i, j, k, loopk
+    ! Flag to indicate whether each PSF realisation has been contaminated by a source brighter
+    ! than each dmcut relative flux.
+    integer :: ncontams(size(dmcut), lentrials)
+    ! Variables related to position within the PSF circle for each object in a dm slice.
+    real(dp) :: x(maxk), y(maxk), xav, yav, t(maxk), r(maxk)
+    ! Poissonian-related values, defining the randomly drawn number of small magnitude range objects
+    ! in a given PSF.
+    real(dp) :: factorial(maxk+1), powercounter, numchance, expdns(size(dNs)), cumulativepoisson(maxk+1, size(dNs))
+    ! Variables related to the relative flux of each simulated perturbing source, and the total flux
+    ! within a PSF.
+    real(dp) :: fluxes(size(dNs)), dfluxes(2, size(dNs)), df(maxk), f0, normf
+
+    factorial(1) = 1.0_dp
+    do i = 1, maxk
+        factorial(i+1) = factorial(i) * real(i, dp)
+    end do
+
+    call random_seed(put=seed)
+
+    fluxes = 10**(-dms/2.5_dp)
+    ! Asymmetric bins in flux space (for symmetric mag bins) needs an upper and lower bin width
+    dfluxes(1, :) = 10**(-(dms-ddms/2.0_dp)/2.5_dp) - 10**(-dms/2.5_dp)
+    dfluxes(2, :) = 10**(-dms/2.5_dp) - 10**(-(dms+ddms/2.0_dp)/2.5_dp)
+    expdns = exp(-dNs)
+
+    ncontams = 0
+    offsets = 0.0_dp
+    fluxcontam = 0.0_dp
+    ! Cumulative poisson = exp(-l) sum_i=0^floor(k) l^i / i!; l^0 / 0! = 1
+    cumulativepoisson(1, :) = 1.0_dp
+    do j = 1, size(dNs)
+        powercounter = dNs(j)
+        do k = 1, maxk
+            cumulativepoisson(k+1, j) = cumulativepoisson(k, j) + powercounter / factorial(k+1) 
+            powercounter = powercounter * dNs(j)
+        end do
+    end do
+    do i = 1, lentrials
+        xav = 0.0_dp
+        yav = 0.0_dp
+        normf = 1.0_dp
+        do j = 1, size(dNs)
+            call random_number(numchance)
+            numchance = numchance / expdns(j)
+            if (cumulativepoisson(1, j) > numchance) then
+                loopk = 0
+            else
+                if (cumulativepoisson(maxk, j) < numchance) then
+                    loopk = maxk
+                else
+                    loopk = maxk
+                    do k = 1, maxk
+                        if (cumulativepoisson(k+1, j) > numchance) then
+                            loopk = k
+                            exit
+                        end if
+                    end do
+                end if
+                do k = 1, size(dmcut)
+                    if (ncontams(k, i) == 0 .and. dms(j) < dmcut(k)) then
+                        ncontams(k, i) = 1
+                    end if
+                end do
+                call random_number(t(:loopk))
+                call random_number(r(:loopk))
+                call random_number(df(:loopk))
+                t(:loopk) = t(:loopk) * 2.0_dp * pi
+                r(:loopk) = sqrt(r(:loopk)) * psfr
+
+                ! fluxes is middle of bin
+                df(:loopk) = df(:loopk) * (dfluxes(1, j) + dfluxes(2, j))
+                f0 = fluxes(j) - dfluxes(2, j)
+
+                x(:loopk) = r(:loopk) * sin(t(:loopk))
+                y(:loopk) = r(:loopk) * cos(t(:loopk))
+
+                xav = xav + sum(x(:loopk) * (f0+df(:loopk)))
+                yav = yav + sum(y(:loopk) * (f0+df(:loopk)))
+                normf = normf + sum(f0+df(:loopk))
+            end if
+        end do
+        xav = xav / normf
+        yav = yav / normf
+        offsets(i) = sqrt(xav**2 + yav**2)
+        fluxcontam(i) = normf - 1.0_dp
+    end do
+    ! TODO: update with mean/median/model/percentiles
+    do k = 1, size(dmcut)
+        fraccontam(k) = real(sum(ncontams(k, :)), dp) / real(lentrials, dp)
+    end do
+
+end subroutine scatter_perturbers
+
+subroutine histogram(x, range, c, M, N)
+    ! Generates a histogram of values, counting the number within each of a given set of bin ranges.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Sizes of the data to be binned, and the number of bins, respectively.
+    integer, intent(in) :: N, M
+    ! The input data to be binned, and values of bin edges, respectively.
+    real(dp), intent(in) :: x(N), range(M)
+    ! The histogram counts. Note that range is left hand bins plus one right hand bin, and hence
+    ! c has length M-1.
+    real(dp), intent(out) :: c(M-1)
+    integer :: i, j  
+
+    c(:) = 0
+
+    do i = 1, N                       ! for each input score
+        do j = 1, M-1                    ! determine the bucket
+            if (x(i) < range(1) .or. x(i) > range(M)) then
+                exit
+            end if
+            if (x(i) < range(j+1) .and. x(i) >= range(j)) then
+                c(j) = c(j) + 1
+                exit
+            end if               
+        end do    
+        if (x(i) >= range(M)) then
+            c(M-1) = c(M-1) + 1
+        end if                    
+    end do
+
+end subroutine histogram
+
+subroutine fourier_transform(pr, r, dr, j0s, G)
+    ! Calculates the Fourier-Bessel transform, or Hankel transform of zeroth order, of a function.
+    ! This is equivalent to a two-dimensional Fourier transform in the limiting case of circular
+    ! symmetry.
+    integer, parameter :: dp = kind(0.0d0)  ! double precision
+    ! Function to be fourier transformed, in units of per area.
+    real(dp), intent(in) :: pr(:)
+    ! Real space coordinates and bin widths.
+    real(dp), intent(in) :: r(:), dr(:)
+    ! Bessel function of first kind of zeroth order, evaluated at 2 * pi * r * rho, where rho
+    ! is the fourier space coordinates of interest to capture the fourier transformation.
+    real(dp), intent(in) :: j0s(:, :)
+    ! The Fourier-Bessel transform of pr, evaluated at the appropriate fourier space coordinates
+    ! rho, as desired.
+    real(dp), intent(out) :: G(size(j0s, 2))
+    ! Loop counters.
+    integer :: i, j
+    G(:) = 0.0_dp
+    ! Following notation of J. W. Goodman, Introduction to Fourier Optics (1996), equation 2-31,
+    ! G0 is the Hankel transform of gR, and the inverse is the opposite.
+    ! For a Hankel transform (of zero order; or Fourier-Bessel transform) the "r" variable is r, with
+    ! rho along the other axis of j0s, but for an inverse transformation "r" becomes rho with r
+    ! represented along the second axis of j0s, because the two transformations are symmetric.
+    
+    do i = 1, size(j0s, 2)
+        do j = 1, size(j0s, 1)
+            G(i) = G(i) + r(j) * pr(j) * j0s(j, i) * dr(j)
+        end do
+        G(i) = G(i) * 2.0_dp * pi
+    end do
+
+end subroutine fourier_transform
+
+subroutine get_random_seed_size(size)
+    ! Number of initial seeds expected by random_seed, to be initialised for a specified RNG setup.
+    integer, intent(out) :: size
+
+    call random_seed(size=size)
+
+end subroutine get_random_seed_size
+
+end module perturbation_auf_fortran

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -10,8 +10,6 @@ filt_names = G_BP G G_RP
 # Catalogue PSF parameters
 # Full-width at half maximums for each filter, in order, in arcseconds
 psf_fwhms = 0.12 0.12 0.12
-# The source count vs magnitude scaling relations z for bright sources, following the geometric series z^mag
-norm_scale_laws = 2 2 2
 
 # TRILEGAL Perturbation AUF parameters
 # Names of TRILEGAL filter sets for the catalogue
@@ -32,3 +30,5 @@ auf_region_points = 131 134 4 -1 1 3
 
 # Local density calculation radius, in arcseconds
 dens_dist = 900
+# Magnitudes, in each bandpass, down to which to count nearby local sources when calculating local density
+dens_mags = 20 20 20

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -28,7 +28,7 @@ auf_region_frame = equatorial
 # For "rectangle" this should be 6 numbers: start coordinate, end coordinate, integer number of data points from start to end (inclusive of both start and end), first for ra/l, then for dec/b (depending on auf_region_type), all separated by spaces
 auf_region_points = 131 134 4 -1 1 3
 
-# Local density calculation radius, in arcseconds
-dens_dist = 900
+# Local density calculation radius, in degrees
+dens_dist = 0.25
 # Magnitudes, in each bandpass, down to which to count nearby local sources when calculating local density
 dens_mags = 20 20 20

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -15,7 +15,7 @@ norm_scale_laws = 2 2 2
 
 # TRILEGAL Perturbation AUF parameters
 # Names of TRILEGAL filter sets for the catalogue
-tri_set_name = gaiadr2
+tri_set_name = gaiaDR2
 tri_filt_names = G_BP G G_RP
 # Filter number to define limiting magnitude of TRILEGAL simulation in, based on output data file column (one-indexed) number
 tri_filt_num = 1

--- a/macauff/tests/data/cat_b_params.txt
+++ b/macauff/tests/data/cat_b_params.txt
@@ -10,8 +10,6 @@ filt_names = W1 W2 W3 W4
 # Catalogue PSF parameters
 # Full-width at half maximums for each filter, in order, in arcseconds
 psf_fwhms = 6.08 6.84 7.36 11.99
-# The source count vs magnitude scaling relations z for bright sources, following the geometric series z^mag
-norm_scale_laws = 2 2 2 2
 
 # TRILEGAL Perturbation AUF parameters
 # Names of TRILEGAL filter sets for the catalogue
@@ -32,3 +30,5 @@ auf_region_points = 131 134 4 -1 1 4
 
 # Local density calculation radius, in arcseconds
 dens_dist = 900
+# Magnitudes, in each bandpass, down to which to count nearby local sources when calculating local density
+dens_mags = 20 20 20 20

--- a/macauff/tests/data/cat_b_params.txt
+++ b/macauff/tests/data/cat_b_params.txt
@@ -28,7 +28,7 @@ auf_region_frame = equatorial
 # For "rectangle" this should be 6 numbers: start coordinate, end coordinate, integer number of data points from start to end (inclusive of both start and end), first for ra/l, then for dec/b (depending on auf_region_type), all separated by spaces
 auf_region_points = 131 134 4 -1 1 4
 
-# Local density calculation radius, in arcseconds
-dens_dist = 900
+# Local density calculation radius, in degrees
+dens_dist = 0.25
 # Magnitudes, in each bandpass, down to which to count nearby local sources when calculating local density
 dens_mags = 20 20 20 20

--- a/macauff/tests/data/crossmatch_params.txt
+++ b/macauff/tests/data/crossmatch_params.txt
@@ -40,3 +40,12 @@ mem_chunk_num = 10
 
 # Integral fractions for various error circle cutouts used during the cross-match process. Should be space-separated floats, in the order of <bright error circle fraction>, <field error circle fraction>, <potential counterpart integral limit>
 int_fracs = 0.63 0.9 0.99
+
+# Number of PSF realisations to draw when simulating perturbation component of AUF
+num_trials = 10000
+# Magnitude offset, or relative flux, down to which to draw blended sources inside PSFs
+dm_max = 10
+# Bin size of magnitudes for number density distributions for perturbation AUF considersation
+d_mag = 0.1
+# Flag to indicate whether to use pre-computed local normalising densities for simulating PSFs
+compute_local_density = no

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -333,14 +333,14 @@ class TestInputs:
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert cm.a_tri_set_name == 'gaiadr2'
+        assert cm.a_tri_set_name == 'gaiaDR2'
         assert np.all(cm.b_tri_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
         assert cm.a_tri_filt_num == 1
         assert not cm.b_download_tri
 
         # List of simple one line config file replacements for error message checking
         for old_line, new_line, match_text, in_file in zip(
-                ['tri_set_name = gaiadr2', 'tri_filt_num = 11', 'tri_filt_num = 11',
+                ['tri_set_name = gaiaDR2', 'tri_filt_num = 11', 'tri_filt_num = 11',
                  'download_tri = no', 'download_tri = no'],
                 ['', 'tri_filt_num = a\n', 'tri_filt_num = 3.4\n', 'download_tri = aye\n',
                  'download_tri = yes\n'],

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -368,7 +368,6 @@ class TestInputs:
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert not hasattr(cm, 'a_norm_scale_laws')
         assert np.all(cm.b_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
 
         f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
@@ -383,20 +382,18 @@ class TestInputs:
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.a_psf_fwhms == np.array([0.12, 0.12, 0.12]))
-        assert np.all(cm.b_norm_scale_laws == np.array([2, 2, 2, 2]))
 
         # List of simple one line config file replacements for error message checking
         for old_line, new_line, match_text, in_file in zip(
-                ['filt_names = G_BP G G_RP', 'filt_names = G_BP G G_RP', 'norm_scale_laws = 2 2 2',
+                ['filt_names = G_BP G G_RP', 'filt_names = G_BP G G_RP',
                  'psf_fwhms = 6.08 6.84 7.36 11.99', 'psf_fwhms = 6.08 6.84 7.36 11.99'],
-                ['', 'filt_names = G_BP G\n', 'norm_scale_laws = 2 2 a\n',
+                ['', 'filt_names = G_BP G\n',
                  'psf_fwhms = 6.08 6.84 7.36\n', 'psf_fwhms = 6.08 6.84 7.36 word\n'],
                 ['Missing key filt_names from catalogue "a"',
                  'a_tri_filt_names and a_filt_names should contain the same',
-                 'norm_scale_laws should be a list of floats in catalogue "a"',
                  'b_psf_fwhms and b_filt_names should contain the same',
                  'psf_fwhms should be a list of floats in catalogue "b".'],
-                ['cat_a_params', 'cat_a_params', 'cat_a_params', 'cat_b_params', 'cat_b_params']):
+                ['cat_a_params', 'cat_a_params', 'cat_b_params', 'cat_b_params']):
             f = open(os.path.join(os.path.dirname(__file__),
                                   'data/{}.txt'.format(in_file))).readlines()
             idx = np.where([old_line in line for line in f])[0][0]
@@ -438,30 +435,112 @@ class TestInputs:
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.pos_corr_dist == 11
-        assert cm.b_dens_dist == 900
+        assert not hasattr(cm, 'a_dens_dist')
+        assert not hasattr(cm, 'b_dens_mags')
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        old_line = 'include_perturb_auf = no'
+        new_line = 'include_perturb_auf = yes\n'
+        idx = np.where([old_line in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__),
+                      'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
+                      os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.a_dens_mags == np.array([20, 20, 20]))
+        assert not hasattr(cm, 'b_dens_dist')
+
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        old_line = 'compute_local_density = no'
+        new_line = 'compute_local_density = yes\n'
+        idx = np.where([old_line in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__),
+                      'data/crossmatch_params_.txt'), idx, new_line, out_file=os.path.join(
+                      os.path.dirname(__file__), 'data/crossmatch_params_2.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_2.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert np.all(cm.a_dens_mags == np.array([20, 20, 20]))
+        assert cm.b_dens_dist == 0.25
 
         # List of simple one line config file replacements for error message checking
         for old_line, new_line, match_text, in_file in zip(
-                ['pos_corr_dist = 11', 'pos_corr_dist = 11', 'dens_dist = 900', 'dens_dist = 900'],
-                ['', 'pos_corr_dist = word\n', '', 'dens_dist = word\n'],
+                ['pos_corr_dist = 11', 'pos_corr_dist = 11', 'dens_dist = 0.25',
+                 'dens_dist = 0.25', 'dens_mags = 20 20 20 20', 'dens_mags = 20 20 20 20',
+                 'dens_mags = 20 20 20'],
+                ['', 'pos_corr_dist = word\n', '', 'dens_dist = word\n', '',
+                 'dens_mags = 20 20 20\n', 'dens_mags = word word word\n'],
                 ['Missing key pos_corr_dist', 'pos_corr_dist must be a float',
-                 'Missing key dens_dist from catalogue "b"', 'dens_dist in catalogue "a" must'],
-                ['crossmatch_params', 'crossmatch_params', 'cat_b_params', 'cat_a_params']):
+                 'Missing key dens_dist from catalogue "b"', 'dens_dist in catalogue "a" must',
+                 'Missing key dens_mags from catalogue "b"',
+                 'b_dens_mags and b_filt_names should contain the same number',
+                 'dens_mags should be a list of floats in catalogue "a'],
+                ['crossmatch_params', 'crossmatch_params', 'cat_b_params', 'cat_a_params',
+                 'cat_b_params', 'cat_b_params', 'cat_a_params']):
             f = open(os.path.join(os.path.dirname(__file__),
                                   'data/{}.txt'.format(in_file))).readlines()
             idx = np.where([old_line in line for line in f])[0][0]
             _replace_line(os.path.join(os.path.dirname(__file__),
-                          'data/{}.txt'.format(in_file)), idx, new_line, out_file=os.path.join(
-                          os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
+                          'data/{}{}.txt'.format(in_file, '_2' if 'h_p' in in_file else '')), idx,
+                          new_line, out_file=os.path.join(os.path.dirname(__file__),
+                          'data/{}_{}.txt'.format(in_file, '3' if 'h_p' in in_file else '')))
 
             with pytest.raises(ValueError, match=match_text):
                 cm = CrossMatch(os.path.join(os.path.dirname(__file__),
                                 'data/crossmatch_params{}.txt'.format(
-                                '_' if 'h_p' in in_file else '')),
+                                '_3' if 'h_p' in in_file else '_2')),
                                 os.path.join(os.path.dirname(__file__),
                                 'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
                                 os.path.join(os.path.dirname(__file__),
                                 'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+
+    def test_crossmatch_perturb_auf_inputs(self):
+        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
+        old_line = 'include_perturb_auf = no'
+        new_line = 'include_perturb_auf = yes\n'
+        idx = np.where([old_line in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__),
+                      'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
+                      os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
+
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        assert cm.num_trials == 10000
+        assert not cm.compute_local_density
+        assert cm.dm_max == 10
+        assert cm.d_mag == 0.1
+
+        for old_line, new_line, match_text in zip(
+                ['num_trials = 10000', 'num_trials = 10000', 'num_trials = 10000', 'dm_max = 10',
+                 'dm_max = 10', 'd_mag = 0.1', 'd_mag = 0.1', 'compute_local_density = no',
+                 'compute_local_density = no', 'compute_local_density = no'],
+                ['', 'num_trials = word\n', 'num_trials = 10000.1\n', '', 'dm_max = word\n', '',
+                 'd_mag = word\n', '', 'compute_local_density = word\n',
+                 'compute_local_density = 10\n'],
+                ['Missing key num_trials from joint', 'num_trials should be an integer',
+                 'num_trials should be an integer', 'Missing key dm_max from joint',
+                 'dm_max must be a float', 'Missing key d_mag from joint', 'd_mag must be a float',
+                 'Missing key compute_local_density from joint',
+                 'Boolean flag key not set to allowed', 'Boolean flag key not set to allowed']):
+            # Make sure to keep the first edit of crossmatch_params, adding each
+            # second change in turn.
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/crossmatch_params_.txt')).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__),
+                          'data/crossmatch_params_.txt'), idx, new_line, out_file=os.path.join(
+                          os.path.dirname(__file__), 'data/crossmatch_params_2.txt'))
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/crossmatch_params_2.txt')).readlines()
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_2.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params.txt'))
 
     def test_crossmatch_fourier_inputs(self):
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -110,15 +110,17 @@ def test_load_rectangular_slice():
     padding = 0.05
     sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2, padding)
     for i in range(len(a)):
-        within_range = (((hav_dist_constant_lat(a[i, 0], a[i, 1], lon1) <= padding) |
-                         (a[i, 0] > lon1)) &
-                        ((hav_dist_constant_lat(a[i, 0], a[i, 1], lon2) <= padding) |
-                         (a[i, 0] < lon2)) &
-                        (a[i, 1] >= lat1-padding) & (a[i, 1] <= lat2+padding))
+        within_range = np.empty(4, bool)
+        within_range[0] = ((hav_dist_constant_lat(a[i, 0], a[i, 1], lon1) <= padding) |
+                           (a[i, 0] > lon1))
+        within_range[1] = ((hav_dist_constant_lat(a[i, 0], a[i, 1], lon2) <= padding) |
+                           (a[i, 0] < lon2))
+        within_range[2] = (a[i, 1] >= lat1-padding)
+        within_range[3] = (a[i, 1] <= lat2+padding)
         if sky_cut[i]:
-            assert within_range
+            assert np.all(within_range)
         else:
-            assert not within_range
+            assert not np.all(within_range)
 
 
 def test_load_single_sky_slice():

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -9,9 +9,9 @@ from numpy.testing import assert_allclose
 import scipy.special
 
 from ..misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
-                              hav_dist_constant_lat, map_large_index_to_small_index)
+                              hav_dist_constant_lat, map_large_index_to_small_index,
+                              _load_rectangular_slice, _load_single_sky_slice)
 from ..misc_functions_fortran import misc_functions_fortran as mff
-# from .test_shared_library_fortran import haversine_wrapper
 
 
 def test_closest_auf_point():
@@ -101,3 +101,32 @@ def test_large_small_index():
     a, b = map_large_index_to_small_index(inds, 40, '.')
     assert np.all(a == np.array([0, 1, 2, 1, 3]))
     assert np.all(b == np.array([0, 10, 15, 35]))
+
+
+def test_load_rectangular_slice():
+    rng = np.random.default_rng(4324324432)
+    a = rng.uniform(2, 3, size=(5000, 2))
+    lon1, lon2, lat1, lat2 = 2.2, 2.4, 2.1, 2.3
+    padding = 0.05
+    sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2, padding)
+    for i in range(len(a)):
+        within_range = (((hav_dist_constant_lat(a[i, 0], a[i, 1], lon1) <= padding) |
+                         (a[i, 0] > lon1)) &
+                        ((hav_dist_constant_lat(a[i, 0], a[i, 1], lon2) <= padding) |
+                         (a[i, 0] < lon2)) &
+                        (a[i, 1] >= lat1-padding) & (a[i, 1] <= lat2+padding))
+        if sky_cut[i]:
+            assert within_range
+        else:
+            assert not within_range
+
+
+def test_load_single_sky_slice():
+    folder_path = '.'
+    cat_name = ''
+    ind = 3
+
+    rng = np.random.default_rng(6123123)
+    sky_inds = rng.choice(5, size=5000)
+    sky_cut = _load_single_sky_slice(folder_path, cat_name, ind, sky_inds)
+    assert np.all(sky_cut == (sky_inds == ind))

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -6,12 +6,22 @@ Tests for the "perturbation_auf" module.
 import pytest
 import os
 import numpy as np
+from numpy.testing import assert_allclose
+from scipy.special import j0, j1
 
 from ..matching import CrossMatch
+from ..misc_functions_fortran import misc_functions_fortran as mff
+from ..perturbation_auf import (make_perturb_aufs, get_circle_overlap_area,
+                                download_trilegal_simulation)
+from ..perturbation_auf_fortran import perturbation_auf_fortran as paf
+
+from .test_matching import _replace_line
 
 
 class TestCreatePerturbAUF:
     def setup_class(self):
+        os.makedirs('gaia_auf_folder', exist_ok=True)
+        os.makedirs('wise_auf_folder', exist_ok=True)
         self.cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -19,18 +29,6 @@ class TestCreatePerturbAUF:
         self.cm.b_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
         self.cm.mem_chunk_num = 4
         self.files_per_auf_sim = 7
-
-    @pytest.mark.filterwarnings("ignore:Incorrect number of files in")
-    def test_not_implemented_error(self):
-        # Reset any saved files from these tests
-        os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
-        os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
-        self.cm.include_perturb_auf = True
-        self.cm.a_psf_fwhms = np.array([0.1, 0.1, 0.1])
-        self.cm.a_download_tri = False
-        with pytest.raises(NotImplementedError, match="Perturbation AUF components are not "
-                           "currently included"):
-            self.cm.create_perturb_auf(self.files_per_auf_sim)
 
     def test_no_perturb_outputs(self):
         # Randomly generate two catalogues (x3 files) between coordinates
@@ -61,7 +59,7 @@ class TestCreatePerturbAUF:
                 path = '{}/{}/{}/{}'.format(self.cm.b_auf_folder_path, coord, coord, filt)
                 for filename, shape in zip(['frac', 'flux', 'offset', 'cumulative', 'fourier',
                                             'N', 'mag'],
-                                           [(2, 1), (1,), (lenr-1, 1), (lenr-1, 1), (lenrho-1, 1),
+                                           [(1, 1), (1,), (lenr-1, 1), (lenr-1, 1), (lenrho-1, 1),
                                             (1, 1), (1, 1)]):
                     assert os.path.isfile('{}/{}.npy'.format(path, filename))
                     file = np.load('{}/{}.npy'.format(path, filename))
@@ -118,8 +116,8 @@ class TestCreatePerturbAUF:
         # number of files (zero) in the folder.
         self.cm.create_perturb_auf(self.files_per_auf_sim)
         output = capsys.readouterr().out
-        assert 'Loading empirical crowding AUFs for catalogue "a"' not in output
-        assert 'Loading empirical crowding AUFs for catalogue "b"' in output
+        assert 'Loading empirical perturbation AUFs for catalogue "a"' not in output
+        assert 'Loading empirical perturbation AUFs for catalogue "b"' in output
 
         os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
         os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
@@ -130,5 +128,529 @@ class TestCreatePerturbAUF:
         capsys.readouterr()
         self.cm.create_perturb_auf(self.files_per_auf_sim)
         output = capsys.readouterr().out
-        assert 'Loading empirical crowding AUFs for catalogue "a"' in output
-        assert 'Loading empirical crowding AUFs for catalogue "b"' in output
+        assert 'Loading empirical perturbation AUFs for catalogue "a"' in output
+        assert 'Loading empirical perturbation AUFs for catalogue "b"' in output
+
+
+def test_perturb_aufs():
+    # Poisson distribution with mean 0.08 gives 92.3% zero, 7.4% one, and 0.3% two draws.
+    mean = 0.08
+    prob_0_draw = mean**0 * np.exp(-mean) / np.math.factorial(0)
+    prob_1_draw = mean**1 * np.exp(-mean) / np.math.factorial(1)
+    prob_2_draw = mean**2 * np.exp(-mean) / np.math.factorial(2)
+
+    N = np.array([1.0])
+    m = np.array([0.0])
+    R = 1.185*6.1
+    r = np.linspace(0, R, 1500)
+    dr = np.diff(r)
+    rho = np.linspace(0, 100, 10000)
+    drho = np.diff(rho)
+    j0s = mff.calc_j0(r[:-1]+dr/2, rho[:-1]+drho/2)
+
+    model_count = 1.0
+    num_trials = 100000
+    mag_cut = np.array([5.0])
+    model_mags = np.array([0])
+    model_mags_interval = np.array([1.0e-8])
+
+    log10y = np.log10(mean / model_mags_interval / np.pi / (R / 3600)**2)
+
+    track_sp_hist = np.zeros(len(r)-1, float)
+    track_pa_hist = np.zeros(len(r)-1, float)
+    # Have to keep track of the uncertainty in the counts, to compare fairly
+    # with expected Poissonian counting statistics scatter.
+    track_pa_hist_err_sq = np.zeros(len(r)-1, float)
+
+    track_pa_fourier = np.zeros(len(rho)-1, float)
+
+    seed_size = paf.get_random_seed_size()
+    rng = np.random.default_rng(seed=123124)
+
+    # Limit the size of each simulation, but run many to aggregate
+    # better counting statistics.
+    num = 100
+    for _ in range(num):
+        seed = rng.choice(1000000, size=seed_size)
+        offsets, fracs, fluxs = paf.scatter_perturbers(np.array([mean]), m, R, 5, mag_cut,
+                                                       model_mags_interval, num_trials, seed)
+        hist, _ = np.histogram(offsets, bins=r)
+        assert_allclose(fracs[0], 1-prob_0_draw, rtol=0.05)
+        assert_allclose(np.mean(fluxs), prob_0_draw*0+prob_1_draw*1+prob_2_draw*2, rtol=0.05)
+
+        Frac, Flux, fourieroffset, offsets, cumulative = paf.perturb_aufs(
+            N, m, r[:-1]+dr/2, dr, r, j0s,
+            model_mags+model_mags_interval/2, model_mags_interval, log10y, model_count,
+            np.array([1]), mag_cut, R, num_trials, seed)
+
+        assert_allclose(Frac, 1-prob_0_draw, rtol=0.05)
+        assert_allclose(Flux, prob_0_draw*0+prob_1_draw*1+prob_2_draw*2, rtol=0.05)
+
+        track_sp_hist += hist / np.sum(hist) / (np.pi * (r[1:]**2 - r[:-1]**2)) / num
+
+        track_pa_hist += offsets[:, 0] / num
+        track_pa_hist_err_sq += (np.sqrt(
+            offsets[:, 0] * np.sum(hist) * (np.pi * (r[1:]**2 - r[:-1]**2))) / (
+            np.sum(hist) * (np.pi * (r[1:]**2 - r[:-1]**2))) / num)**2
+
+        track_pa_fourier += fourieroffset[:, 0] / num
+
+    # Here we assume that the direct and wrapper calls had the same seed for
+    # each call, and identical results, and hence should basically agree perfectly.
+    assert_allclose(track_pa_hist, track_sp_hist, atol=1e-6)
+
+    offsets_fake = np.zeros_like(r[:-1])
+    offsets_fake[0] += prob_0_draw / (np.pi * (r[1]**2 - r[0]**2))
+    # Given that we force equal-brightness "binaries", we expect a maximum
+    # perturbation of half the total radius.
+    q = np.where(r[1:] > R/2)[0]
+    offsets_fake[:q[0]] += prob_1_draw / np.pi / (R/2)**2
+    final_bin_frac = (R/2 - r[q[0]]) / (r[q[0]+1] - r[q[0]])
+    offsets_fake[q[0]] += final_bin_frac * prob_1_draw / np.pi / (R/2)**2
+
+    track_pa_hist_err_sq[track_pa_hist_err_sq == 0] = 1e-8
+    for i in range(len(r)-1):
+        assert_allclose(track_pa_hist[i], offsets_fake[i], rtol=0.05,
+                        atol=1e-5 + 4 * np.sqrt(track_pa_hist_err_sq[i]))
+
+    # Take the average fourier representation of the offsets and compare. The
+    # first expression is the integral of the constant 1/(pi (R/2)^2) probability
+    # for the randomly placed, single-draw perturbations.
+    fake_fourier = (1-prob_0_draw) * 2 / (np.pi * R * (rho[:-1]+drho/2)) * j1(
+        np.pi * R * (rho[:-1]+drho/2))
+    # The second necessary half of the fourier representation should be a delta
+    # function, which becomes the unity function, but since we do numerical
+    # integrations, is in practice just the fraction of zero-draw "perturbations"
+    # in an annulus of the first radial bin, Fourier-Bessel transformed. This
+    # gives f(r) = P / (2 pi r dr), which then cancels everything except J0.
+    fake_fourier += prob_0_draw * j0(2 * np.pi * (r[0]+dr[0]/2) * (rho[:-1]+drho/2))
+
+    # Quickly verify fourier_transform by comparing the theoretical
+    # real-space distribution, fourier transformed, to the theoretical
+    # fourier transformation as well.
+    another_fake_fourier = paf.fourier_transform(offsets_fake, r[:-1]+dr/2, dr, j0s)
+
+    assert_allclose(fake_fourier, another_fake_fourier, rtol=5e-3)
+    assert_allclose(fake_fourier, track_pa_fourier, rtol=5e-3)
+
+
+def test_histogram():
+    rng = np.random.default_rng(11111)
+    x = rng.uniform(0, 1, 10000)
+    bins = np.linspace(0, 1, 15)
+
+    counts_f = paf.histogram(x, bins)
+    counts_p, _ = np.histogram(x, bins=bins)
+    assert np.all(counts_f == counts_p)
+
+
+def test_circle_area():
+    rng = np.random.default_rng(123897123)
+    R = 0.1
+
+    x_edges = [0, 1]
+    y_edges = [0, 1]
+
+    # If circle is inside rectangle, get full area:
+    done = 0
+    while done < 10:
+        [x, y] = rng.uniform(0, 1, size=2)
+        if (x - R >= x_edges[0] and x + R <= x_edges[1] and
+                y - R >= y_edges[0] and y + R <= y_edges[1]):
+            calc_area = get_circle_overlap_area(R, x_edges, y_edges, [x, y])
+            assert_allclose(calc_area, np.pi * R**2)
+            done += 1
+
+    # Now, if the circle is exactly on the corners of the rectangle
+    # we should have a quarter the area:
+    for x, y in zip([0, 0, 1, 1], [0, 1, 0, 1]):
+        calc_area = get_circle_overlap_area(R, x_edges, y_edges, [x, y])
+        assert_allclose(calc_area, np.pi * R**2 / 4)
+
+    # In the middle of an edge we should have half the circle area:
+    for x, y in zip([0, 0.5, 1, 0.5], [0.5, 0, 0.5, 1]):
+        calc_area = get_circle_overlap_area(R, x_edges, y_edges, [x, y])
+        assert_allclose(calc_area, np.pi * R**2 / 2)
+
+    # Verify a few randomly placed circles too:
+    done = 0
+    xp = np.linspace(*x_edges, 100)
+    yp = np.linspace(*y_edges, 100)
+    dx, dy = xp[1] - xp[0], yp[1] - yp[0]
+    while done < 20:
+        [x, y] = rng.uniform(0, 1, size=2)
+        if np.any([x - R < x_edges[0], x + R > x_edges[1],
+                   y - R < y_edges[0], y + R > y_edges[1]]):
+            calc_area = get_circle_overlap_area(R, x_edges, y_edges, [x, y])
+            manual_area = 0
+            for i in range(len(xp)):
+                for j in range(len(yp)):
+                    if np.sqrt((xp[i] - x)**2 + (yp[j] - y)**2) <= R:
+                        manual_area += dx*dy
+            assert_allclose(calc_area, manual_area, rtol=0.05)
+        done += 1
+
+
+class TestMakePerturbAUFs():
+    def setup_class(self):
+        self.auf_folder = 'auf_folder'
+        self.cat_folder = 'cat_folder'
+        os.system('rm -r {}'.format(self.auf_folder))
+        os.system('rm -r {}'.format(self.cat_folder))
+        os.makedirs(self.auf_folder)
+        os.makedirs(self.cat_folder)
+
+        self.filters = np.array(['W1'])
+        self.tri_filt_names = np.copy(self.filters)
+        self.auf_points = np.array([[0.0, 0.0]])
+        self.ax_lims = np.array([0, 1, 0, 1])
+
+        self.psf_fwhms = np.array([6.1])
+        self.r = np.linspace(0, 1.185 * self.psf_fwhms[0], 2500)
+        self.dr = np.diff(self.r)
+        self.rho = np.linspace(0, 100, 10000)
+        self.drho = np.diff(self.rho)
+        self.which_cat = 'b'
+        self.include_perturb_auf = True
+        self.num_trials = 100000
+
+        self.mem_chunk_num = 1
+        self.delta_mag_cuts = np.array([2.5, 5])
+
+        self.args = [self.auf_folder, self.cat_folder, self.filters, self.auf_points,
+                     self.r, self.dr, self.rho, self.drho, self.which_cat,
+                     self.include_perturb_auf, self.mem_chunk_num]
+
+        self.files_per_auf_sim = 7
+
+    def test_raise_value_errors(self):
+        with pytest.raises(ValueError, match='tri_set_name must be given if include_perturb_auf ' +
+                           'and tri_download_flag are both True'):
+            make_perturb_aufs(*self.args, tri_download_flag=True)
+        with pytest.raises(ValueError, match='tri_filt_num must be given if include_perturb_auf ' +
+                           'and tri_download_flag are both True'):
+            make_perturb_aufs(*self.args, tri_download_flag=True, tri_set_name='WISE')
+        with pytest.raises(ValueError, match='auf_region_frame must be given if ' +
+                           'include_perturb_auf and tri_download_flag are both True'):
+            make_perturb_aufs(*self.args, tri_download_flag=True, tri_set_name='WISE',
+                              tri_filt_num=1)
+
+        with pytest.raises(ValueError, match='tri_filt_names must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args)
+        with pytest.raises(ValueError, match='delta_mag_cuts must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1)
+        with pytest.raises(ValueError, match='psf_fwhms must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1)
+        with pytest.raises(ValueError, match='num_trials must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1)
+        with pytest.raises(ValueError, match='j0s must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+                              num_trials=1)
+        with pytest.raises(ValueError, match='density_mags must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+                              num_trials=1, j0s=1)
+        with pytest.raises(ValueError, match='dm_max must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+                              num_trials=1, j0s=1, density_mags=1)
+        with pytest.raises(ValueError, match='d_mag must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+                              num_trials=1, j0s=1, density_mags=1, dm_max=1)
+        with pytest.raises(ValueError, match='compute_local_density must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+                              num_trials=1, j0s=1, density_mags=1, dm_max=1, d_mag=1)
+        with pytest.raises(ValueError, match='density_radius must be given if ' +
+                           'include_perturb_auf and compute_local_density are both True'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=True, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1)
+
+    def test_without_compute_local_density(self):
+        # Number of sources per PSF circle, on average, solved backwards to ensure
+        # that local density ends up exactly in the middle of a count_array bin.
+        # This should be approximately 0.076 sources per PSF circle.
+        psf_mean = np.exp(8.7) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
+        # Local density is the controllable variable to ensure that we get
+        # the expected sources per PSF circle, with most variables cancelling
+        # mean divided by circle area sets the density needed.
+        local_dens = psf_mean / (np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2)
+        np.save('{}/local_N.npy'.format(self.auf_folder), np.array([[local_dens]]))
+
+        np.save('{}/con_cat_astro.npy'.format(self.cat_folder), np.array([[0.3, 0.3, 0.1]]))
+        np.save('{}/con_cat_photo.npy'.format(self.cat_folder), np.array([[14.99]]))
+        np.save('{}/magref.npy'.format(self.cat_folder), np.array([0]))
+
+        num_trials = 100000
+        j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
+        cutoff_mags = np.array([20])
+        dm_max = np.array([10])
+        d_mag = 0.1
+
+        # Fake up a TRILEGAL simulation data file. Need to paste the same source
+        # four times to pass a check for more than three sources in a histogram.
+        text = ('#area = 4.0 sq deg\n#Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
+                'm2/m1 mbol   J      H      Ks     IRAC_3.6 IRAC_4.5 IRAC_5.8 IRAC_8.0 MIPS_24 ' +
+                'MIPS_70 MIPS_160 W1     W2     W3     W4       Mact\n 1   6.65 -0.39  0.02415 ' +
+                '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
+                '22.387 22.292 22.015 21.144 19.380 20.878 15.001 22.391 21.637 21.342  0.024\n ' +
+                '1   6.65 -0.39  0.02415 -2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 ' +
+                '24.409 23.524 22.583 22.387 22.292 22.015 21.144 19.380 20.878 15.002 22.391 ' +
+                '21.637 21.342  0.024\n 1   6.65 -0.39  0.02415 -2.701 3.397  4.057 14.00  ' +
+                '8.354 0.00 25.523 25.839 24.409 23.524 22.583 22.387 22.292 22.015 21.144 ' +
+                '19.380 20.878 15.003 22.391 21.637 21.342  0.024\n 1   6.65 -0.39  0.02415 ' +
+                '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
+                '22.387 22.292 22.015 21.144 19.380 20.878 15.004 22.391 21.637 21.342  0.024')
+        os.makedirs('{}/{}/{}'.format(
+            self.auf_folder, self.auf_points[0][0], self.auf_points[0][1]), exist_ok=True)
+        with open('{}/{}/{}/trilegal_auf_simulation.dat'.format(
+                  self.auf_folder, self.auf_points[0][0], self.auf_points[0][1]), "w") as f:
+            f.write(text)
+
+        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / np.math.factorial(0)
+        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / np.math.factorial(1)
+        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / np.math.factorial(2)
+
+        ax1, ax2 = self.auf_points[0]
+
+        keep_frac = np.zeros((len(self.delta_mag_cuts), 1), float)
+        keep_flux = np.zeros((1,), float)
+        track_fourier = np.zeros(len(self.rho)-1, float)
+
+        # Catalogue bins for the source:
+        a_photo = np.load('{}/con_cat_photo.npy'.format(self.cat_folder))
+        dmag = 0.25
+        mag_min = dmag * np.floor(np.amin(a_photo)/dmag)
+        mag_max = dmag * np.ceil(np.amax(a_photo)/dmag)
+        mag_bins = np.arange(mag_min, mag_max+1e-10, dmag)
+        mag_bin = 0.5 * (mag_bins[1:]+mag_bins[:-1])
+        # Model magnitude bins:
+        tri_mags = np.array([15.001, 15.002, 15.003, 15.004])
+        minmag = d_mag * np.floor(np.amin(tri_mags)/d_mag)
+        maxmag = d_mag * np.ceil(np.amax(tri_mags)/d_mag)
+        mod_bins = np.arange(minmag, maxmag+1e-10, d_mag)
+        mod_bin = mod_bins[:-1] + np.diff(mod_bins)/2
+        mag_offset = mod_bin - mag_bin
+        rel_flux = 10**(-1/2.5 * mag_offset)
+
+        N = 25
+        for i in range(N):
+            make_perturb_aufs(*self.args, psf_fwhms=self.psf_fwhms, num_trials=num_trials, j0s=j0s,
+                              density_mags=cutoff_mags, dm_max=dm_max, d_mag=d_mag,
+                              delta_mag_cuts=self.delta_mag_cuts, compute_local_density=False,
+                              tri_filt_names=self.tri_filt_names)
+
+            if i == 0:
+                for name, size in zip(
+                        ['frac', 'flux', 'offset', 'cumulative', 'fourier', 'N', 'mag'],
+                        [(len(self.delta_mag_cuts), 1), (1,), (len(self.r)-1, 1),
+                         (len(self.r)-1, 1), (len(self.rho)-1, 1), (1,), (1,)]):
+                    var = np.load('{}/{}/{}/{}/{}.npy'.format(
+                                  self.auf_folder, ax1, ax2, self.filters[0], name))
+                    assert np.all(var.shape == size)
+
+            fracs = np.load('{}/{}/{}/{}/frac.npy'.format(
+                self.auf_folder, ax1, ax2, self.filters[0]))
+            fluxs = np.load('{}/{}/{}/{}/flux.npy'.format(
+                self.auf_folder, ax1, ax2, self.filters[0]))
+            fourier = np.load('{}/{}/{}/{}/fourier.npy'.format(
+                self.auf_folder, ax1, ax2, self.filters[0]))
+
+            keep_frac += fracs / N
+            keep_flux += fluxs / N
+            track_fourier += fourier[:, 0] / N
+
+        # Have more relaxed conditions on assertion than in test_perturb_aufs
+        # above, as we can't arbitrarily force the magnitude bin widths to be
+        # very small, and hence have a blur on relative fluxes allowed.
+        assert_allclose(keep_frac[0, 0], 1-prob_0_draw, rtol=0.1)
+        assert_allclose(keep_flux[0], (prob_0_draw*0 + prob_1_draw*rel_flux +
+                        prob_2_draw*2*rel_flux), rtol=0.1)
+
+        R = 1.185 * self.psf_fwhms[0]
+        small_R = R * rel_flux / (1 + rel_flux)
+
+        fake_fourier = (1-prob_0_draw) / (np.pi * small_R * (self.rho[:-1]+self.drho/2)) * j1(
+            2 * np.pi * small_R * (self.rho[:-1]+self.drho/2))
+        fake_fourier += prob_0_draw * j0(2 * np.pi * (self.r[0]+self.dr[0]/2) *
+                                         (self.rho[:-1]+self.drho/2))
+
+        assert_allclose(fake_fourier, track_fourier, rtol=0.05)
+
+    def test_with_compute_local_density(self):
+        # Number of sources per PSF circle, on average, solved backwards to ensure
+        # that local density ends up exactly in the middle of a count_array bin.
+        # This should be approximately 0.076 sources per PSF circle.
+        psf_mean = np.exp(8.7) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
+        # This time we want to calculate the local density on the fly, but still
+        # get the same value we did in the without compute local density test. We
+        # therefore have to choose our "density radius" to set the appropriate
+        # local density for our single source.
+        density_mags = np.array([20])
+        density_radius = np.sqrt(1 / np.pi / np.exp(8.7))
+
+        new_auf_points = np.vstack((self.auf_points, np.array([[10, 10]])))
+
+        # Have to fudge extra sources to keep our 15th mag source in the local
+        # density cutout.
+        np.save('{}/con_cat_astro.npy'.format(self.cat_folder),
+                np.array([[0.3, 0.3, 0.1], [0.1, 0.1, 0.1], [0.9, 0.9, 0.1]]))
+        np.save('{}/con_cat_photo.npy'.format(self.cat_folder), np.array([[14.99], [10], [10]]))
+        np.save('{}/magref.npy'.format(self.cat_folder), np.array([0, 0, 0]))
+
+        # Fake up a TRILEGAL simulation data file. Need to paste the same source
+        # four times to pass a check for more than three sources in a histogram.
+        text = ('#area = 4.0 sq deg\n#Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
+                'm2/m1 mbol   J      H      Ks     IRAC_3.6 IRAC_4.5 IRAC_5.8 IRAC_8.0 MIPS_24 ' +
+                'MIPS_70 MIPS_160 W1     W2     W3     W4       Mact\n 1   6.65 -0.39  0.02415 ' +
+                '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
+                '22.387 22.292 22.015 21.144 19.380 20.878 15.001 22.391 21.637 21.342  0.024\n ' +
+                '1   6.65 -0.39  0.02415 -2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 ' +
+                '24.409 23.524 22.583 22.387 22.292 22.015 21.144 19.380 20.878 15.002 22.391 ' +
+                '21.637 21.342  0.024\n 1   6.65 -0.39  0.02415 -2.701 3.397  4.057 14.00  ' +
+                '8.354 0.00 25.523 25.839 24.409 23.524 22.583 22.387 22.292 22.015 21.144 ' +
+                '19.380 20.878 15.003 22.391 21.637 21.342  0.024\n 1   6.65 -0.39  0.02415 ' +
+                '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
+                '22.387 22.292 22.015 21.144 19.380 20.878 15.004 22.391 21.637 21.342  0.024')
+        for i in range(len(new_auf_points)):
+            os.makedirs('{}/{}/{}'.format(
+                self.auf_folder, new_auf_points[i][0], new_auf_points[i][1]), exist_ok=True)
+            with open('{}/{}/{}/trilegal_auf_simulation.dat'.format(
+                      self.auf_folder, new_auf_points[i][0], new_auf_points[i][1]), "w") as f:
+                f.write(text)
+
+        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / np.math.factorial(0)
+        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / np.math.factorial(1)
+        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / np.math.factorial(2)
+
+        ax1, ax2 = self.auf_points[0]
+
+        d_mag = 0.1
+        # Catalogue bins for the source, only keeping the single
+        # source currently under consideration, and ignoring the two extra objects
+        # used to force the local density to be calculated properly.
+        a_photo = np.load('{}/con_cat_photo.npy'.format(self.cat_folder))[0, :]
+        dmag = 0.25
+        mag_min = dmag * np.floor(np.amin(a_photo)/dmag)
+        mag_max = dmag * np.ceil(np.amax(a_photo)/dmag)
+        mag_bins = np.arange(mag_min, mag_max+1e-10, dmag)
+        mag_bin = 0.5 * (mag_bins[1:]+mag_bins[:-1])
+        # Model magnitude bins:
+        tri_mags = np.array([15.001, 15.002, 15.003, 15.004])
+        minmag = d_mag * np.floor(np.amin(tri_mags)/d_mag)
+        maxmag = d_mag * np.ceil(np.amax(tri_mags)/d_mag)
+        mod_bins = np.arange(minmag, maxmag+1e-10, d_mag)
+        mod_bin = mod_bins[:-1] + np.diff(mod_bins)/2
+        mag_offset = mod_bin - mag_bin
+        rel_flux = 10**(-1/2.5 * mag_offset)
+
+        ol, nl = 'include_perturb_auf = no', 'include_perturb_auf = yes\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/crossmatch_params.txt')).readlines()
+        idx = np.where([ol in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                      idx, nl, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/crossmatch_params_.txt'))
+
+        ol, nl = 'filt_names = G_BP G G_RP', 'filt_names = G\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/cat_a_params.txt')).readlines()
+        idx = np.where([ol in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                      idx, nl, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/cat_a_params_.txt'))
+        for ol, nl in zip(['psf_fwhms = 0.12 0.12 0.12', 'cat_folder_path = gaia_folder',
+                           'auf_folder_path = gaia_auf_folder', 'tri_filt_names = G_BP G G_RP',
+                           'dens_mags = 20 20 20'],
+                          ['psf_fwhms = 0.12\n', 'cat_folder_path = cat_folder\n',
+                           'auf_folder_path = auf_folder\n', 'tri_filt_names = W1\n',
+                           'dens_mags = 20\n']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/cat_a_params.txt')).readlines()
+            idx = np.where([ol in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                          idx, nl)
+
+        ol, nl = 'filt_names = W1 W2 W3 W4', 'filt_names = W1\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/cat_b_params.txt')).readlines()
+        idx = np.where([ol in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'),
+                      idx, nl, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/cat_b_params_.txt'))
+        for ol, nl in zip(['psf_fwhms = 6.08 6.84 7.36 11.99', 'cat_folder_path = wise_folder',
+                           'auf_folder_path = wise_auf_folder', 'tri_filt_names = W1 W2 W3 W4',
+                           'dens_mags = 20 20 20 20'],
+                          ['psf_fwhms = 6.08\n', 'cat_folder_path = cat_folder\n',
+                           'auf_folder_path = auf_folder\n', 'tri_filt_names = W1\n',
+                           'dens_mags = 20\n']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/cat_b_params.txt')).readlines()
+            idx = np.where([ol in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'),
+                          idx, nl)
+
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+
+        cm.a_auf_region_points = new_auf_points
+        cm.b_auf_region_points = new_auf_points
+        cm.cross_match_extent = self.ax_lims
+        cm.a_dens_mags = density_mags
+        cm.b_dens_mags = density_mags
+        cm.a_dens_dist = density_radius
+        cm.b_dens_dist = density_radius
+        cm.compute_local_density = True
+        cm.run_auf = True
+        cm.run_group = True
+        cm.run_cf = True
+        cm.run_source = True
+        cm.num_trials = self.num_trials
+
+        cm.create_perturb_auf(self.files_per_auf_sim)
+
+        fracs = np.load('{}/{}/{}/{}/frac.npy'.format(
+            self.auf_folder, ax1, ax2, self.filters[0]))
+        fluxs = np.load('{}/{}/{}/{}/flux.npy'.format(
+            self.auf_folder, ax1, ax2, self.filters[0]))
+        fourier = np.load('{}/{}/{}/{}/fourier.npy'.format(
+            self.auf_folder, ax1, ax2, self.filters[0]))
+
+        assert_allclose(fracs[0, 0], 1-prob_0_draw, rtol=0.1)
+        assert_allclose(fluxs[0], (prob_0_draw*0 + prob_1_draw*rel_flux +
+                        prob_2_draw*2*rel_flux), rtol=0.1)
+
+        R = 1.185 * self.psf_fwhms[0]
+        small_R = R * rel_flux / (1 + rel_flux)
+
+        fake_fourier = (1-prob_0_draw) / (np.pi * small_R * (cm.rho[:-1]+cm.drho/2)) * j1(
+            2 * np.pi * small_R * (cm.rho[:-1]+cm.drho/2))
+        fake_fourier += prob_0_draw * j0(2 * np.pi * (cm.r[0]+cm.dr[0]/2) *
+                                         (cm.rho[:-1]+cm.drho/2))
+
+        assert_allclose(fake_fourier, fourier[:, 0], rtol=0.05)
+
+
+@pytest.mark.remote_data
+def test_trilegal_download():
+    tri_folder = '.'
+    download_trilegal_simulation(tri_folder, 'gaiaDR2', 180, 20, 1, 'galactic', total_objs=10000)
+    tri_name = 'trilegal_auf_simulation'
+    f = open('{}/{}.dat'.format(tri_folder, tri_name), "r")
+    line = f.readline()
+    f.close()
+    bits = line.split(' ')
+    tri_area = float(bits[2])
+    tri = np.genfromtxt('{}/{}.dat'.format(tri_folder, tri_name), delimiter=None,
+                        names=True, comments='#', skip_header=1)
+    assert np.all(tri[:]['G'] <= 32)
+    assert tri_area <= 10

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from numpy.distutils.core import Extension, setup
 
 names = ['group_sources_fortran', 'misc_functions_fortran', 'counterpart_pairing_fortran',
-         'photometric_likelihood_fortran']
+         'photometric_likelihood_fortran', 'perturbation_auf_fortran']
 f90_args = ["-Wall", "-Wextra", "-Werror", "-pedantic", "-fbacktrace", "-O0", "-g", "-fcheck=all",
             "-fopenmp"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
 	numpy
 	scipy
 	pytest
+	astropy
 	cov: coverage
 	build_docs: sphinx-fortran
 


### PR DESCRIPTION
This PR extends the code to include the full calculation of perturbations due to blended sources within a PSF. This uses the TRILEGAL dataset to simulate number densities of sources in the Galaxy to use in the input distribution from which to simulate perturbing objects within a PSF, and hence the distribution of center-of-light shifts in the centroid of a given object.