### PR TITLE
Updated documentation for new algorithm options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,10 @@ API Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Updates to documentation to reflect the relaxing of photometric likelihood and
+  perturbation AUF component options. Other minor changes to documentation
+  layout. [#30]
+
 - GitHub Actions will only run remote data dependent tests (those marked with
   ``pytest.mark.remote_data``) on a pull request merge. [#27]
 

--- a/docs/f90_docs/group_sources_docs.rst
+++ b/docs/f90_docs/group_sources_docs.rst
@@ -1,0 +1,5 @@
+*********************************
+Group Sources Fortran Subroutines
+*********************************
+
+.. f:automodule:: group_sources_fortran

--- a/docs/f90_docs/misc_func_docs.rst
+++ b/docs/f90_docs/misc_func_docs.rst
@@ -1,0 +1,5 @@
+*******************************************
+Miscellaneous Functions Fortran Subroutines
+*******************************************
+
+.. f:automodule:: misc_functions_fortran

--- a/docs/f90_docs/pairing_docs.rst
+++ b/docs/f90_docs/pairing_docs.rst
@@ -1,0 +1,5 @@
+***************************************
+Counterpart Pairing Fortran Subroutines
+***************************************
+
+.. f:automodule:: counterpart_pairing_fortran

--- a/docs/f90_docs/perturb_auf_docs.rst
+++ b/docs/f90_docs/perturb_auf_docs.rst
@@ -1,0 +1,5 @@
+************************************
+Perturbation AUF Fortran Subroutines
+************************************
+
+.. f:automodule:: perturbation_auf_fortran

--- a/docs/f90_docs/phot_like_docs.rst
+++ b/docs/f90_docs/phot_like_docs.rst
@@ -1,0 +1,5 @@
+******************************************
+Photometric Likelihood Fortran Subroutines
+******************************************
+
+.. f:automodule:: photometric_likelihood_fortran

--- a/docs/f90_docs/shared_library_docs.rst
+++ b/docs/f90_docs/shared_library_docs.rst
@@ -1,0 +1,5 @@
+**********************************
+Shared Library Fortran Subroutines
+**********************************
+
+.. f:autosrcfile:: ../../macauff/shared_library.f90

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,3 +48,9 @@ Index
    installation
    quickstart
    inputs
+   f90_docs/perturb_auf_docs
+   f90_docs/group_sources_docs
+   f90_docs/phot_like_docs
+   f90_docs/pairing_docs
+   f90_docs/misc_func_docs
+   f90_docs/shared_library_docs

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -5,9 +5,6 @@ Input Parameters
 This page details the various inputs expected by `~macauff.CrossMatch`.
 
 
-.. note::
-	Currently only a naive, pure Bayes match is implemented. Thus ``include_perturb_auf``, ``include_phot_like``, and ``use_phot_priors`` must all be set to ``False``, and any parameters only used when either of these parameters is ``True`` can be ignored.
-
 Catalogue-specific Parameters
 =============================
 
@@ -35,10 +32,6 @@ The filter names of the photometric bandpasses used in this catalogue, in the or
 ``psf_fwhms``
 
 The Full-Width-At-Half-Maximum of each filter's Point Spread Function (PSF), in the same order as in ``filt_names``. These are used to simulate the PSF if ``include_perturb_auf`` is set to ``True``, and are unnecessary otherwise. Should be a space-separated list of floats.
-
-``norm_scale_laws``
-
-The scaling relations, number density of sources as a function of magnitude, for the bright end of the catalogue. Should be of the form :math:`N = N_0 z^m`, where :math:`z` is the scaling law parameter. Should be a space-separated list of floats. Optional if ``include_perturb_aufs`` is ``False``.
 
 ``tri_set_name``
 The name of the filter set used to simulate the catalogue's sources in TRILEGAL [#]_. Used to interact with the TRILEGAL API; optional if ``include_perturb_aufs`` is ``False``.
@@ -71,6 +64,10 @@ The list of pointings for which to run simulations of perturbations due to blend
 
 The radius, in arcseconds, within which to count internal catalogue sources for each object, to calculate the local source density. Used to scale TRILEGAL simulated source counts to match smaller scale density fluctuations.
 
+``dens_mags``
+
+The magnitude, in each bandpass -- the same order as ``filt_names`` -- down to which to count the number of nearby sources when deriving the local normalising density of each object. Should be space-separated floats, of the same number as those given in ``filt_names``.
+
 
 Joint Parameters
 ================
@@ -87,11 +84,11 @@ Flag for whether to include the simulated effects of blended sources on the meas
 
 ``include_phot_like``
 
-Flag for the inclusion of the likelihood of match or non-match based on the photometric information in the two catalogues. Must be ``False``.
+Flag for the inclusion of the likelihood of match or non-match based on the photometric information in the two catalogues.
 
 ``use_phot_priors``
 
-Flag to determine whether to calculate the priors on match or non-match using the photometry (if set to ``True``) or calculate them based on a naive asymmetric density argument (``False``). Currently should be ``False``.
+Flag to determine whether to calculate the priors on match or non-match using the photometry (if set to ``True``) or calculate them based on a naive asymmetric density argument (``False``).
 
 ``joint_folder_path``
 
@@ -152,7 +149,25 @@ The maximum extent of the matching process. When not matching all-sky catalogues
 
 The number of smaller subsets into which to break various loops throughout the cross-match process. Used to reduce the memory usage of the process at any given time, in case of catalogues too large to fit into memory at once.
 
+``int_fracs``
 
+The integral fractions of the various so-called "error circles" used in the cross-match process. Should be space-separated floats, in the order of: bright error circle fraction, "field" error circle fraction, and potential counterpart cutoff limit.
+
+``num_trials``
+
+The number of PSF realisations to draw when simulating the perturbation component of the AUF. Should be an integer.
+
+``dm_max``
+
+The magnitude offset (or relative flux in magnitude space) down to which to draw blended sources to potentially perturb a given PSF realisation of the perturbation AUF component. Should be a single float.
+
+``d_mag``
+
+Bin sizes for magnitudes used to represent the source number density used in the random drawing of perturbation AUF component PSFs. Should be a single float.
+
+``compute_local_density``
+
+Boolean flag, ``yes`` or ``no``, to indicate whether to on-the-fly compute the local densities of sources in each catalogue for use in its perturbation AUF component, or to use pre-computed values. ``yes`` indicates values will be computed during the cross-match process.
 
 .. rubric:: Footnotes
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,10 +11,14 @@ The current package requirements are:
 
 * ``numpy``
 * ``scipy``
+* ``astropy``
 
 and for running the test suite
 
-* ``tox``.
+* ``tox``
+* ``sphinx-fortran``
+* ``sphinx-astropy``
+* ``pytest-astropy``.
 
 Additionally, you will need the following to install ``macauff``:
 
@@ -28,7 +32,7 @@ As of now, the only way to install this package is by downloading it from the `G
 
 Once you have installed your choice of conda, then you can create an initial conda environment::
 
-	conda create -n your_environment_name python=3.7 numpy scipy
+	conda create -n your_environment_name python=3.7 numpy scipy astropy
 
 although you can drop the ``=3.7``, or chose another (later) Python version, if you desire to do so. Then activate this as our Python environment::
 
@@ -36,11 +40,12 @@ although you can drop the ``=3.7``, or chose another (later) Python version, if 
 
 If you require the additional test packages listed above, for running tests, you can install them separately with::
 
-	conda install -c conda-forge tox
+	conda install -c conda-forge tox sphinx-astropy pytest-astropy
+	conda install -c vacumm -c conda-forge sphinx-fortran
 
 You will also need to install ``gfortran`` in order to compile the fortran code in this package. Instructions for how to install this for Windows, MacOS, or Linux can be found `here <https://gcc.gnu.org/wiki/GFortranBinaries>`_. Finally, install ``git`` if you do not have it on your computer; `instructions <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ for installing it on your operating system are available.
 
-Once you have the required packages installed, you can clone the repository::
+Once you have the required packages installed -- whether in a new ``conda`` environment or otherwise -- you can clone the repository::
 
 	git clone git://github.com/onoddil/macauff.git
 

--- a/docs/macauff.rst
+++ b/docs/macauff.rst
@@ -15,18 +15,20 @@ Python
 Fortran
 =======
 
-Group Sources
-^^^^^^^^^^^^^
-.. f:automodule:: group_sources_fortran
+:doc:`Perturbation AUF<f90_docs/perturb_auf_docs>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Counterpart Pairing
-^^^^^^^^^^^^^^^^^^^
-.. f:automodule:: counterpart_pairing_fortran
+:doc:`Group Sources<f90_docs/group_sources_docs>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Miscellaneous Functions
-^^^^^^^^^^^^^^^^^^^^^^^
-.. f:automodule:: misc_functions_fortran
+:doc:`Photometric Likelihood<f90_docs/phot_like_docs>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Shared Library
-^^^^^^^^^^^^^^
-.. f:autosrcfile:: ../macauff/shared_library.f90
+:doc:`Counterpart Pairing<f90_docs/pairing_docs>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:doc:`Miscellaneous Functions<f90_docs/misc_func_docs>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:doc:`Shared Library<f90_docs/shared_library_docs>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -44,7 +44,8 @@ These files are the only inputs to `~macauff.CrossMatch`, the main class for per
 
 By default, the parameters in the files above are set up such that a cross-match will be performed in the equatorial coordinate frame region :math:`131 \leq \alpha \leq 138,\ -3 \leq \delta \leq 3`. Thus, depending on the coordinates you used when calling `~macauff.tests.generate_random_data`, you may wish to edit ``cross_match_extent`` and ``cf_region_points`` within ``crossmatch_params.txt``, to match your chosen sky coordinates.
 
-Discussion of the input parameters available in the catalogue-specific and joint match-specific input files is provided in more detail :doc:`here<inputs>`.
+.. note::
+	Discussion of the input parameters available in the catalogue-specific and joint match-specific input files is provided in more detail :doc:`here<inputs>`.
 
 Running the Matches
 ===================

--- a/macauff/__init__.py
+++ b/macauff/__init__.py
@@ -1,6 +1,7 @@
 from .matching import *
 from .perturbation_auf import *
 from .group_sources import *
+from .make_set_list import *
 from .misc_functions import *
 from .photometric_likelihood import *
 from .counterpart_pairing import *


### PR DESCRIPTION
Updates to the documentation to reflect the relaxation of the flags for photometric likelihood and perturbation AUF component inclusion. Mostly just adds the extra input parameters as descriptions, but also includes a few layout tweaks, and extra installation details.