### PR TITLE
Improve runtime of matching process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed inefficiencies in both group sources and perturbation AUF creation runtime,
+  significantly improving the speed of those parts of a cross-match. [#31]
+
 - Corrected an error in ``tests.generate_random_data``, where only one catalogue
   had its source uncertainties simulated. [#23]
 

--- a/macauff/counterpart_pairing_fortran.f90
+++ b/macauff/counterpart_pairing_fortran.f90
@@ -39,7 +39,7 @@ subroutine contam_match_prob(Fcc, Fcn, Fnc, Fnn, rho, drho, sep, Gcc, Gcn, Gnc, 
 
     do j = 1, size(rho)
         z = rho(j)*sep*2.0_dp*pi
-        call jy01a(z, j0)
+        call jy01a_j0(z, j0)
         Gcc = Gcc + rho(j) * Fcc(j) * j0 * drho(j)
         Gcn = Gcn + rho(j) * Fcn(j) * j0 * drho(j)
         Gnc = Gnc + rho(j) * Fnc(j) * j0 * drho(j)

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from .misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
                              hav_dist_constant_lat, map_large_index_to_small_index,
-                             _load_rectangular_slice)
+                             _load_rectangular_slice, _create_rectangular_slice_arrays)
 from .group_sources_fortran import group_sources_fortran as gsf
 from .make_set_list import set_list
 
@@ -125,6 +125,20 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     a_full = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path), mmap_mode='r')
     b_full = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path), mmap_mode='r')
 
+    # Generate the necessary memmap sky slice arrays now.
+    _create_rectangular_slice_arrays(joint_folder_path, 'a', len(a_full))
+    memmap_slice_arrays_a = []
+    for n in ['1', '2', '3', '4', 'combined']:
+        memmap_slice_arrays_a.append(np.lib.format.open_memmap(
+            '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a', n), mode='r+',
+            dtype=bool, shape=(len(a_full),)))
+    _create_rectangular_slice_arrays(joint_folder_path, 'b', len(b_full))
+    memmap_slice_arrays_b = []
+    for n in ['1', '2', '3', '4', 'combined']:
+        memmap_slice_arrays_b.append(np.lib.format.open_memmap(
+            '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b', n), mode='r+',
+            dtype=bool, shape=(len(b_full),)))
+
     asize = np.lib.format.open_memmap('{}/group/asize.npy'.format(joint_folder_path), mode='w+',
                                       dtype=int, shape=(len(a_full),))
     asize[:] = 0
@@ -136,15 +150,16 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         for ax2_start, ax2_end in zip(ax2_loops[:-1], ax2_loops[1:]):
             ax_cutout = [ax1_start, ax1_end, ax2_start, ax2_end]
             a, afouriergrid, amodrefindsmall, a_cut = _load_fourier_grid_cutouts(
-                a_full, ax_cutout, joint_folder_path, a_cat_folder_path, a_auf_folder_path, 0, 'a')
+                a_full, ax_cutout, joint_folder_path, a_cat_folder_path, a_auf_folder_path, 0, 'a',
+                memmap_slice_arrays_a)
             b, bfouriergrid, bmodrefindsmall, b_cut = _load_fourier_grid_cutouts(
                 b_full, ax_cutout, joint_folder_path, b_cat_folder_path, b_auf_folder_path,
-                max_sep, 'b')
+                max_sep, 'b', memmap_slice_arrays_b)
 
             if len(a) > 0 and len(b) > 0:
                 overlapa, overlapb = gsf.get_max_overlap(
                     a[:, 0], a[:, 1], b[:, 0], b[:, 1], max_sep, a[:, 2], b[:, 2],
-                    rho[:-1], drho, afouriergrid, bfouriergrid, amodrefindsmall,
+                    r[:-1]+dr/2, rho[:-1], drho, j1s, afouriergrid, bfouriergrid, amodrefindsmall,
                     bmodrefindsmall, int_fracs[2])
                 asize[a_cut] = asize[a_cut] + overlapa
                 bsize[b_cut] = bsize[b_cut] + overlapb
@@ -170,15 +185,16 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         for ax2_start, ax2_end in zip(ax2_loops[:-1], ax2_loops[1:]):
             ax_cutout = [ax1_start, ax1_end, ax2_start, ax2_end]
             a, afouriergrid, amodrefindsmall, a_cut = _load_fourier_grid_cutouts(
-                a_full, ax_cutout, joint_folder_path, a_cat_folder_path, a_auf_folder_path, 0, 'a')
+                a_full, ax_cutout, joint_folder_path, a_cat_folder_path, a_auf_folder_path, 0, 'a',
+                memmap_slice_arrays_a)
             b, bfouriergrid, bmodrefindsmall, b_cut = _load_fourier_grid_cutouts(
                 b_full, ax_cutout, joint_folder_path, b_cat_folder_path, b_auf_folder_path,
-                max_sep, 'b')
+                max_sep, 'b', memmap_slice_arrays_b)
 
             if len(a) > 0 and len(b) > 0:
                 indicesa, indicesb, overlapa, overlapb = gsf.get_overlap_indices(
                     a[:, 0], a[:, 1], b[:, 0], b[:, 1], max_sep, amaxsize, bmaxsize, a[:, 2],
-                    b[:, 2], rho[:-1], drho, afouriergrid, bfouriergrid,
+                    b[:, 2], r[:-1]+dr/2, rho[:-1], drho, j1s, afouriergrid, bfouriergrid,
                     amodrefindsmall, bmodrefindsmall, int_fracs[2])
 
                 a_cut2 = np.arange(0, len(a_full))[a_cut]
@@ -465,7 +481,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
 
 
 def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder_path,
-                               auf_folder_path, padding, cat_name):
+                               auf_folder_path, padding, cat_name, memmap_slice_arrays):
     '''
     Function to load a sub-set of a given catalogue's astrometry, slicing it
     in a given sky coordinate rectangle, and load the appropriate sub-array
@@ -495,12 +511,15 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     cat_name : string
         String indicating whether we are loading cutouts from catalogue "a" or
         "b".
+    memmap_slice_arrays : list of numpy.ndarray
+        List of the memmap sky slice arrays, to be used in the loading of the
+        rectangular sky patch.
     '''
 
     lon1, lon2, lat1, lat2 = sky_rect_coords
 
     sky_cut = _load_rectangular_slice(joint_folder_path, cat_name, a, lon1, lon2,
-                                      lat1, lat2, padding)
+                                      lat1, lat2, padding, memmap_slice_arrays)
 
     a_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path), mmap_mode='r')[sky_cut]
 

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -20,7 +20,7 @@ __all__ = ['make_island_groupings']
 
 def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_path,
                           a_auf_folder_path, b_auf_folder_path, a_auf_pointings, b_auf_pointings,
-                          a_filt_names, b_filt_names, a_title, b_title, r, dr, rho, drho, j0s,
+                          a_filt_names, b_filt_names, a_title, b_title, r, dr, rho, drho, j1s,
                           max_sep, ax_lims, int_fracs, mem_chunk_num, include_phot_like,
                           use_phot_priors):
     '''
@@ -69,9 +69,9 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     drho : numpy.ndarray
         Array representing the bin widths of ``rho``. As with ``dr``, is one
         shorter than ``rho`` due to its additional bin edge.
-    j0s : 2-D numpy.ndarray
+    j1s : 2-D numpy.ndarray
         Array holding the evaluations of the Bessel Function of First kind of
-        Zeroth Order, evaluated at all ``r`` and ``rho`` bin-middle combination.
+        First Order, evaluated at all ``r`` and ``rho`` bin-middle combination.
     max_sep : float
         The maximum allowed sky separation between two sources in opposing
         catalogues for consideration as potential counterparts.
@@ -143,8 +143,8 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
 
             if len(a) > 0 and len(b) > 0:
                 overlapa, overlapb = gsf.get_max_overlap(
-                    a[:, 0], a[:, 1], b[:, 0], b[:, 1], max_sep, a[:, 2], b[:, 2], r[:-1], dr,
-                    rho[:-1], drho, j0s, afouriergrid, bfouriergrid, amodrefindsmall,
+                    a[:, 0], a[:, 1], b[:, 0], b[:, 1], max_sep, a[:, 2], b[:, 2],
+                    rho[:-1], drho, afouriergrid, bfouriergrid, amodrefindsmall,
                     bmodrefindsmall, int_fracs[2])
                 asize[a_cut] = asize[a_cut] + overlapa
                 bsize[b_cut] = bsize[b_cut] + overlapb
@@ -178,7 +178,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             if len(a) > 0 and len(b) > 0:
                 indicesa, indicesb, overlapa, overlapb = gsf.get_overlap_indices(
                     a[:, 0], a[:, 1], b[:, 0], b[:, 1], max_sep, amaxsize, bmaxsize, a[:, 2],
-                    b[:, 2], r[:-1], dr, rho[:-1], drho, j0s, afouriergrid, bfouriergrid,
+                    b[:, 2], rho[:-1], drho, afouriergrid, bfouriergrid,
                     amodrefindsmall, bmodrefindsmall, int_fracs[2])
 
                 a_cut2 = np.arange(0, len(a_full))[a_cut]
@@ -240,7 +240,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             del modrefind
 
             a_int_lens = gsf.get_integral_length(
-                a, b, r[:-1], dr, rho[:-1], drho, j0s, a_fouriergrid, b_fouriergrid,
+                a, b, r[:-1], dr, rho[:-1], drho, j1s, a_fouriergrid, b_fouriergrid,
                 a_modrefindsmall, b_modrefindsmall, a_inds_map, a_size_small, int_fracs[0:2])
             ablen[lowind:highind] = a_int_lens[:, 0]
             aflen[lowind:highind] = a_int_lens[:, 1]
@@ -270,7 +270,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             del modrefind
 
             b_int_lens = gsf.get_integral_length(
-                b, a, r[:-1], dr, rho[:-1], drho, j0s, b_fouriergrid, a_fouriergrid,
+                b, a, r[:-1], dr, rho[:-1], drho, j1s, b_fouriergrid, a_fouriergrid,
                 b_modrefindsmall, a_modrefindsmall, b_inds_map, b_size_small, int_fracs[0:2])
             bblen[lowind:highind] = b_int_lens[:, 0]
             bflen[lowind:highind] = b_int_lens[:, 1]

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -240,7 +240,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             del modrefind
 
             a_int_lens = gsf.get_integral_length(
-                a, b, r[:-1], dr, rho[:-1], drho, j1s, a_fouriergrid, b_fouriergrid,
+                a, b, r[:-1]+dr/2, rho[:-1], drho, j1s, a_fouriergrid, b_fouriergrid,
                 a_modrefindsmall, b_modrefindsmall, a_inds_map, a_size_small, int_fracs[0:2])
             ablen[lowind:highind] = a_int_lens[:, 0]
             aflen[lowind:highind] = a_int_lens[:, 1]
@@ -270,7 +270,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             del modrefind
 
             b_int_lens = gsf.get_integral_length(
-                b, a, r[:-1], dr, rho[:-1], drho, j1s, b_fouriergrid, a_fouriergrid,
+                b, a, r[:-1]+dr/2, rho[:-1], drho, j1s, b_fouriergrid, a_fouriergrid,
                 b_modrefindsmall, a_modrefindsmall, b_inds_map, b_size_small, int_fracs[0:2])
             bblen[lowind:highind] = b_int_lens[:, 0]
             bflen[lowind:highind] = b_int_lens[:, 1]

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from .perturbation_auf import make_perturb_aufs
 from .group_sources import make_island_groupings
+from .group_sources_fortran import group_sources_fortran as gsf
 from .misc_functions_fortran import misc_functions_fortran as mff
 from .photometric_likelihood import compute_photometric_likelihoods
 from .counterpart_pairing import source_pairing
@@ -452,8 +453,9 @@ class CrossMatch():
         self.dr = np.diff(self.r)
         self.rho = np.linspace(0, self.four_max_rho, self.four_hankel_points)
         self.drho = np.diff(self.rho)
-        # Only need to calculate this the first time we need it, so buffer for now.
+        # Only need to calculate these the first time we need them, so buffer for now.
         self.j0s = None
+        self.j1s = None
 
     def create_perturb_auf(self, files_per_auf_sim, perturb_auf_func=make_perturb_aufs):
         '''
@@ -615,8 +617,11 @@ class CrossMatch():
         # First check whether we actually need to dip into the group sources
         # routine or not.
         if self.run_group or not correct_file_number:
-            if self.j0s is None:
-                self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
+            if self.j1s is None:
+                self.j1s = np.empty((len(self.drho), len(self.dr)), float)
+                for i in range(len(self.dr)):
+                    self.j1s[:, i] = gsf.calc_j1s(self.rho[:-1], self.drho,
+                                                  self.r[i]+self.dr[i]/2)
             # Only worry about the warning if we didn't choose to run the grouping
             # but hit incorrect file numbers.
             if not correct_file_number and not self.run_group:
@@ -629,7 +634,7 @@ class CrossMatch():
                        self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_region_points,
                        self.b_auf_region_points, self.a_filt_names, self.b_filt_names,
                        self.a_cat_name, self.b_cat_name, self.r, self.dr, self.rho, self.drho,
-                       self.j0s, self.pos_corr_dist, self.cross_match_extent, self.int_fracs,
+                       self.j1s, self.pos_corr_dist, self.cross_match_extent, self.int_fracs,
                        self.mem_chunk_num, self.include_phot_like, self.use_phot_priors)
         else:
             print('Loading catalogue islands and overlaps...')

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -618,10 +618,7 @@ class CrossMatch():
         # routine or not.
         if self.run_group or not correct_file_number:
             if self.j1s is None:
-                self.j1s = np.empty((len(self.drho), len(self.dr)), float)
-                for i in range(len(self.dr)):
-                    self.j1s[:, i] = gsf.calc_j1s(self.rho[:-1], self.drho,
-                                                  self.r[i]+self.dr[i]/2)
+                self.j1s = gsf.calc_j1s(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
             # Only worry about the warning if we didn't choose to run the grouping
             # but hit incorrect file numbers.
             if not correct_file_number and not self.run_group:

--- a/macauff/misc_functions_fortran.f90
+++ b/macauff/misc_functions_fortran.f90
@@ -53,7 +53,7 @@ subroutine find_nearest_point(source_lon, source_lat, point_lon, point_lat, poin
 end subroutine find_nearest_point
 
 subroutine calc_j0(r, r0, j0s)
-    ! Wrapper for jy01a, to calculate the Bessel Function of First Kind of
+    ! Wrapper for jy01a_j0, to calculate the Bessel Function of First Kind of
     ! Zeroth Order for arrays of rs and rhos.
     integer, parameter :: dp = kind(0.0d0)  ! double precision
     ! Input r/rho arrays.
@@ -69,7 +69,7 @@ subroutine calc_j0(r, r0, j0s)
     do i = 1, size(r0)
         do j = 1, size(r)
             z = r(j)*r0(i)*2.0_dp*pi
-            call jy01a(z, j0s(j, i))
+            call jy01a_j0(z, j0s(j, i))
         end do
     end do
 !$OMP END PARALLEL DO

--- a/macauff/shared_library.f90
+++ b/macauff/shared_library.f90
@@ -29,8 +29,8 @@ subroutine haversine(lon1, lon2, lat1, lat2, hav_dist)
 
 end subroutine haversine
 
-subroutine jy01a (x, bj0)
-    ! JY01A computes Bessel functions J0(x).
+subroutine jy01a_j0 (x, bj0)
+    ! JY01A_J0 computes Bessel function J0(x).
     !
     !
     !
@@ -135,6 +135,119 @@ subroutine jy01a (x, bj0)
       end do
       cu = sqrt ( rp2 / x )
       bj0 = cu * ( p0 * cos ( t1 ) - q0 * sin ( t1 ) )
+
+    end if
+    return
+end
+
+subroutine jy01a_j1 (x, bj1)
+    ! JY01A_J1 computes Bessel function J1(x).
+    !
+    !
+    !
+    !  Licensing:
+    !
+    !    This routine is copyrighted by Shanjie Zhang and Jianming Jin. However,
+    !    they give permission to incorporate this routine into a user program 
+    !    provided that the copyright is acknowledged.
+    !
+    !  Modified:
+    !
+    !    01 August 2012
+    !
+    !  Author:
+    !
+    !    Shanjie Zhang, Jianming Jin
+    !
+    !  Reference:
+    !
+    !    Shanjie Zhang, Jianming Jin,
+    !    Computation of Special Functions,
+    !    Wiley, 1996,
+    !    ISBN: 0-471-11963-6,
+    !    LC: QA351.C45.
+    !
+    !  Parameters:
+    !
+    !    Input, real ( kind = 8 ) X, the argument.
+    !
+    !    Output, real ( kind = 8 ) BJ1,
+    !    the value of J1(x).
+    !
+    !  Modified slightly by TJW, 2021.
+    !
+    implicit none
+
+    real ( kind = 8 ), save, dimension(12) :: a1 = (/ &
+      0.1171875000000000D+00, -0.1441955566406250D+00, &
+      0.6765925884246826D+00, -0.6883914268109947D+01, &
+      0.1215978918765359D+03, -0.3302272294480852D+04, &
+      0.1276412726461746D+06, -0.6656367718817688D+07, &
+      0.4502786003050393D+09, -0.3833857520742790D+11, &
+      0.4011838599133198D+13, -0.5060568503314727D+15 /)
+    real ( kind = 8 ), save, dimension(12) :: b1 = (/ &
+      -0.1025390625000000D+00, 0.2775764465332031D+00, &
+      -0.1993531733751297D+01, 0.2724882731126854D+02, &
+      -0.6038440767050702D+03, 0.1971837591223663D+05, &
+      -0.8902978767070678D+06, 0.5310411010968522D+08, &
+      -0.4043620325107754D+10, 0.3827011346598605D+12, &
+      -0.4406481417852278D+14, 0.6065091351222699D+16 /)
+    real ( kind = 8 ) bj1
+    real ( kind = 8 ) cu
+
+    integer ( kind = 4 ) k
+    integer ( kind = 4 ) k0
+    real ( kind = 8 ) p1
+    real ( kind = 8 ) pi
+    real ( kind = 8 ) q1
+    real ( kind = 8 ) r
+    real ( kind = 8 ) rp2
+    real ( kind = 8 ) t2
+    real ( kind = 8 ) x
+    real ( kind = 8 ) x2
+
+    pi = 3.141592653589793D+00
+    rp2 = 0.63661977236758D+00
+    x2 = x * x
+
+    if ( abs( x ) <= 1.0D-05 ) then
+      bj1 = 0.0D+00
+      return
+    end if
+
+    if ( x <= 12.0D+00 ) then
+
+      bj1 = 1.0D+00
+      r = 1.0D+00
+      do k = 1, 30
+        r = -0.25D+00 * r * x2 / ( k * ( k + 1.0D+00 ) )
+        bj1 = bj1 + r
+        if ( abs ( r ) < abs ( bj1 ) * 1.0D-15 ) then
+          exit
+        end if
+      end do
+
+      bj1 = 0.5D+00 * x * bj1
+
+    else
+
+      if ( x < 35.0D+00 ) then
+        k0 = 12
+      else if ( x < 50.0D+00 ) then
+        k0 = 10
+      else
+        k0 = 8
+      end if
+
+      t2 = x - 0.75D+00 * pi
+      p1 = 1.0D+00
+      q1 = 0.375D+00 / x
+      do k = 1, k0
+        p1 = p1 + a1(k) * x ** ( - 2 * k )
+        q1 = q1 + b1(k) * x ** ( - 2 * k - 1 )
+      end do
+      cu = sqrt ( rp2 / x )
+      bj1 = cu * ( p1 * cos ( t2 ) - q1 * sin ( t2 ) )
 
     end if
     return

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -10,7 +10,8 @@ import scipy.special
 
 from ..misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
                               hav_dist_constant_lat, map_large_index_to_small_index,
-                              _load_rectangular_slice, _load_single_sky_slice)
+                              _load_rectangular_slice, _load_single_sky_slice,
+                              _create_rectangular_slice_arrays)
 from ..misc_functions_fortran import misc_functions_fortran as mff
 
 
@@ -108,7 +109,12 @@ def test_load_rectangular_slice():
     a = rng.uniform(2, 3, size=(5000, 2))
     lon1, lon2, lat1, lat2 = 2.2, 2.4, 2.1, 2.3
     padding = 0.05
-    sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2, padding)
+    _create_rectangular_slice_arrays('.', '', len(a))
+    memmap_arrays = []
+    for n in ['1', '2', '3', '4', 'combined']:
+        memmap_arrays.append(np.lib.format.open_memmap('{}/{}_temporary_sky_slice_{}.npy'.format(
+                             '.', '', n), mode='r+', dtype=bool, shape=(len(a),)))
+    sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2, padding, memmap_arrays)
     for i in range(len(a)):
         within_range = np.empty(4, bool)
         within_range[0] = ((hav_dist_constant_lat(a[i, 0], a[i, 1], lon1) <= padding) |


### PR DESCRIPTION
This PR fixes an outstanding issue with the runtime of running cross-matches. Initially this was an improvement to the fairly naive method of calculating generic convolved AUF radial integrals, using a more smart algorithm involving the rearranging of the fourier- and real-space coordinates in the double integral. However, after this failed to solve all of the speed up issues it revealed a bottleneck in the loading of memmap arrays in an inner loop, which was also fixed.