### PR TITLE
Fix to tests in counterpart pairing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fix to issue with np.where test in ``test_counterpart_pairing`` causing incorrect
+  failure to match probabilities. [#36]
+
 - Fixes to various minor typos in variables in the cross-match workflow. [#32]
 
 - Allow for the non-existence of a TRILEGAL simulation in any folder, and download

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -290,7 +290,7 @@ class TestCounterpartPairing:
             self.Nfa*self.Nfa*self.Nfb
         _prob = self.Nc*self.G*self.Nfa
         norm_prob = _prob/_integral
-        q = np.where([a_matches == 0])[0][0]
+        q = np.where(a_matches == 0)[0][0]
         assert_allclose(prob_counterpart[q], norm_prob, rtol=1e-5)
         xicrpts = np.load('{}/pairing/xi.npy'.format(self.joint_folder_path))
         assert_allclose(xicrpts[q], np.array([np.log10(self.G / self.fa_priors[0, 0, 0])]),
@@ -359,7 +359,7 @@ class TestCounterpartPairing:
             self.Nfa*self.Nfa*self.Nfb
         _prob = self.Nc*self.G*self.Nfa
         norm_prob = _prob/_integral
-        q = np.where([a_matches == 0])[0][0]
+        q = np.where(a_matches == 0)[0][0]
         assert_allclose(prob_counterpart[q], norm_prob, rtol=1e-5)
         xicrpts = np.load('{}/pairing/xi.npy'.format(self.joint_folder_path))
         assert_allclose(xicrpts[q], np.array([np.log10(self.G / self.fa_priors[0, 0, 0])]),
@@ -552,7 +552,7 @@ class TestCounterpartPairing:
             self.Nfa*self.Nfa*self.Nfb
         _prob = self.Nc*self.G*self.Nfa
         norm_prob = _prob/_integral
-        q = np.where([a_matches == 0])[0][0]
+        q = np.where(a_matches == 0)[0][0]
         assert_allclose(prob_counterpart[q], norm_prob, rtol=1e-5)
         xicrpts = np.load('{}/pairing/xi.npy'.format(self.joint_folder_path))
         assert_allclose(xicrpts[q], np.array([np.log10(self.G / self.fa_priors[0, 0, 0])]),


### PR DESCRIPTION
PR to fix a syntax issue in ``test_counterpart_pairing``, where an ``np.where`` typo was causing a failure of an otherwise correct test depending on the order of the randomly arranged outputs from a multiprocess.