### PR TITLE
Extend output file creation process with additional columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- Added additional data outputs to ``counterpart_pairing``: match separations, as
+  well as the nearest neighbour non-match for each source within a given island,
+  and its eta/xi and average contamination derived values. [#37]
+
 - Added functionality to convert .csv files to internal files used in the
   matching process, and create output .csv files from the resulting merged
   datasets created as a result of the matching. [#34]
@@ -51,6 +55,13 @@ Bug Fixes
 
 API Changes
 ^^^^^^^^^^^
+
+- Added extra columns derived in ``counterpart_pairing`` to output datafiles in
+  ``npy_to_csv``. [#37]
+
+- ``npy_to_csv`` now has ``extra_col_name_lists``, allowing for the inclusion of
+  extra columns from the original catalogue .csv file to be passed through to the
+  output merged datafiles. [#37]
 
 - Moved several functions (``_load_single_sky_slice``, ``_load_rectangular_slice``,
   ``_lon_cut``, ``_lat_cut``) out of individual Python scripts into

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -369,6 +369,7 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
     del acountinds, bcountinds, acontamprob, bcontamprob, acontamflux, bcontamflux, afieldinds
     del bfieldinds, probcarray, etaarray, xiarray, probfaarray, probfbarray
     del afieldflux, bfieldflux
+    del crptseps, afieldseps, afieldeta, afieldxi, bfieldseps, bfieldeta, bfieldxi
     tot = countsum + afieldsum + lenrejecta
     if tot < len_a:
         warnings.warn("{} catalogue a source{} not in either counterpart, field, or rejected "

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -91,6 +91,8 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
                                          mode='w+', dtype=float, shape=(small_len,))
     xiarray = np.lib.format.open_memmap('{}/pairing/xi.npy'.format(joint_folder_path),
                                         mode='w+', dtype=float, shape=(small_len,))
+    crptseps = np.lib.format.open_memmap('{}/pairing/crptseps.npy'.format(joint_folder_path),
+                                         mode='w+', dtype=float, shape=(small_len,))
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(small_len*cnum/mem_chunk_num).astype(int)
         highind = np.floor(small_len*(cnum+1)/mem_chunk_num).astype(int)
@@ -103,17 +105,27 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         probcarray[lowind:highind] = -100
         etaarray[lowind:highind] = -100
         xiarray[lowind:highind] = -100
+        crptseps[lowind:highind] = -100
     afieldinds = np.lib.format.open_memmap('{}/pairing/af.npy'.format(joint_folder_path),
                                            mode='w+', dtype=int, shape=(len_a,))
     probfaarray = np.lib.format.open_memmap('{}/pairing/pfa.npy'.format(joint_folder_path),
                                             mode='w+', dtype=float, shape=(len_a,))
     afieldflux = np.lib.format.open_memmap('{}/pairing/afieldflux.npy'.format(joint_folder_path),
                                            mode='w+', dtype=float, shape=(len_a,))
+    afieldseps = np.lib.format.open_memmap('{}/pairing/afieldseps.npy'.format(joint_folder_path),
+                                           mode='w+', dtype=float, shape=(len_a,))
+    afieldeta = np.lib.format.open_memmap('{}/pairing/afieldeta.npy'.format(joint_folder_path),
+                                          mode='w+', dtype=float, shape=(len_a,))
+    afieldxi = np.lib.format.open_memmap('{}/pairing/afieldxi.npy'.format(joint_folder_path),
+                                         mode='w+', dtype=float, shape=(len_a,))
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(len_a*cnum/mem_chunk_num).astype(int)
         highind = np.floor(len_a*(cnum+1)/mem_chunk_num).astype(int)
         afieldinds[lowind:highind] = large_len+1
         afieldflux[lowind:highind] = -100
+        afieldseps[lowind:highind] = -100
+        afieldeta[lowind:highind] = -100
+        afieldxi[lowind:highind] = -100
         probfaarray[lowind:highind] = -100
     bfieldinds = np.lib.format.open_memmap('{}/pairing/bf.npy'.format(joint_folder_path),
                                            mode='w+', dtype=int, shape=(len_b,))
@@ -121,11 +133,20 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
                                             mode='w+', dtype=float, shape=(len_b,))
     bfieldflux = np.lib.format.open_memmap('{}/pairing/bfieldflux.npy'.format(joint_folder_path),
                                            mode='w+', dtype=float, shape=(len_b,))
+    bfieldseps = np.lib.format.open_memmap('{}/pairing/bfieldseps.npy'.format(joint_folder_path),
+                                           mode='w+', dtype=float, shape=(len_b,))
+    bfieldeta = np.lib.format.open_memmap('{}/pairing/bfieldeta.npy'.format(joint_folder_path),
+                                          mode='w+', dtype=float, shape=(len_b,))
+    bfieldxi = np.lib.format.open_memmap('{}/pairing/bfieldxi.npy'.format(joint_folder_path),
+                                         mode='w+', dtype=float, shape=(len_b,))
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(len_b*cnum/mem_chunk_num).astype(int)
         highind = np.floor(len_b*(cnum+1)/mem_chunk_num).astype(int)
         bfieldinds[lowind:highind] = large_len+1
         bfieldflux[lowind:highind] = -100
+        bfieldseps[lowind:highind] = -100
+        bfieldeta[lowind:highind] = -100
+        bfieldxi[lowind:highind] = -100
         probfbarray[lowind:highind] = -100
 
     counterpartticker = 0
@@ -220,20 +241,27 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
                 # objects), and update afield; otherwise 'b' indicates an empty
                 # "a" island, and lonely "b" sources.
                 if np.any([isinstance(q, str) and q == 'a' for q in return_items]):
-                    _, _, aperm, aperm_, aff = return_items
+                    _, _, aperm, aperm_, aff, afsep, afeta, afxi = return_items
                     afieldinds[afieldticker:afieldticker+len(aperm)] = aperm_
                     probfaarray[afieldticker:afieldticker+len(aperm)] = 1
                     afieldflux[afieldticker:afieldticker+len(aperm)] = aff
+                    afieldseps[afieldticker:afieldticker+len(aperm)] = afsep
+                    afieldeta[afieldticker:afieldticker+len(aperm)] = afeta
+                    afieldxi[afieldticker:afieldticker+len(aperm)] = afxi
                     afieldticker += len(aperm)
                 else:
-                    _, _, bperm, bperm_, bff = return_items
+                    _, _, bperm, bperm_, bff, bfsep, bfeta, bfxi = return_items
                     bfieldinds[bfieldticker:bfieldticker+len(bperm)] = bperm_
                     probfbarray[bfieldticker:bfieldticker+len(bperm)] = 1
                     bfieldflux[bfieldticker:bfieldticker+len(bperm)] = bff
+                    bfieldseps[bfieldticker:bfieldticker+len(bperm)] = bfsep
+                    bfieldeta[bfieldticker:bfieldticker+len(bperm)] = bfeta
+                    bfieldxi[bfieldticker:bfieldticker+len(bperm)] = bfxi
                     bfieldticker += len(bperm)
             else:
                 [acrpts, bcrpts, acrptscontp, bcrptscontp, etacrpts, xicrpts, acrptflux, bcrptflux,
-                 afield, bfield, aff, bff, prob, integral] = return_items
+                 cseps, afield, bfield, aff, bff, afseps, afeta, afxi, bfseps, bfeta, bfxi, prob,
+                 integral] = return_items
                 if len(acrpts) > 0:
                     acountinds[counterpartticker:counterpartticker+len(acrpts)] = acrpts
                     bcountinds[counterpartticker:counterpartticker+len(bcrpts)] = bcrpts
@@ -244,18 +272,25 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
                     acontamflux[counterpartticker:counterpartticker+len(acrptflux)] = acrptflux
                     bcontamflux[counterpartticker:counterpartticker+len(bcrptflux)] = bcrptflux
                     probcarray[counterpartticker:counterpartticker+len(acrpts)] = prob/integral
+                    crptseps[counterpartticker:counterpartticker+len(cseps)] = cseps
                     counterpartticker += len(acrpts)
 
                 if len(afield) > 0:
                     afieldinds[afieldticker:afieldticker+len(afield)] = afield
                     probfaarray[afieldticker:afieldticker+len(afield)] = prob/integral
                     afieldflux[afieldticker:afieldticker+len(afield)] = aff
+                    afieldseps[afieldticker:afieldticker+len(afield)] = afseps
+                    afieldeta[afieldticker:afieldticker+len(afield)] = afeta
+                    afieldxi[afieldticker:afieldticker+len(afield)] = afxi
                     afieldticker += len(afield)
 
                 if len(bfield) > 0:
                     bfieldinds[bfieldticker:bfieldticker+len(bfield)] = bfield
                     probfbarray[bfieldticker:bfieldticker+len(bfield)] = prob/integral
                     bfieldflux[bfieldticker:bfieldticker+len(bfield)] = bff
+                    bfieldseps[bfieldticker:bfieldticker+len(bfield)] = bfseps
+                    bfieldeta[bfieldticker:bfieldticker+len(bfield)] = bfeta
+                    bfieldxi[bfieldticker:bfieldticker+len(bfield)] = bfxi
                     bfieldticker += len(bfield)
         pool.close()
 
@@ -306,18 +341,21 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
     # criteria above from all saved numpy arrays.
     for file_name, variable, shape, typing, filter_variable in zip(
         ['ac', 'bc', 'pacontam', 'pbcontam', 'acontamflux', 'bcontamflux', 'af', 'bf', 'pc', 'eta',
-         'xi', 'pfa', 'pfb', 'afieldflux', 'bfieldflux'],
+         'xi', 'pfa', 'pfb', 'afieldflux', 'bfieldflux', 'crptseps', 'afieldseps', 'afieldeta',
+         'afieldxi', 'bfieldseps', 'bfieldeta', 'bfieldxi'],
         [acountinds, bcountinds, acontamprob, bcontamprob, acontamflux, bcontamflux, afieldinds,
          bfieldinds, probcarray, etaarray, xiarray, probfaarray, probfbarray, afieldflux,
-         bfieldflux],
+         bfieldflux, crptseps, afieldseps, afieldeta, afieldxi, bfieldseps, bfieldeta, bfieldxi],
         [(countsum,), (countsum,), (countsum, n_fracs), (countsum, n_fracs), (countsum,),
          (countsum,), (afieldsum,), (bfieldsum,), (countsum,), (countsum,), (countsum,),
-         (afieldsum,), (bfieldsum,), (afieldsum,), (bfieldsum,)],
+         (afieldsum,), (bfieldsum,), (afieldsum,), (bfieldsum,), (countsum,), (afieldsum,),
+         (afieldsum,), (afieldsum,), (bfieldsum,), (bfieldsum,), (bfieldsum,)],
         [int, int, float, float, float, float, int, int, float, float, float, float, float,
-         float, float],
+         float, float, float, float, float, float, float, float, float],
         [countfilter, countfilter, countfilter, countfilter, countfilter, countfilter,
          afieldfilter, bfieldfilter, countfilter, countfilter, countfilter, afieldfilter,
-         bfieldfilter, afieldfilter, bfieldfilter]):
+         bfieldfilter, afieldfilter, bfieldfilter, countfilter, afieldfilter, afieldfilter,
+         afieldfilter, bfieldfilter, bfieldfilter, bfieldfilter]):
         temp_variable = np.lib.format.open_memmap('{}/pairing/{}2.npy'.format(
             joint_folder_path, file_name), mode='w+', dtype=typing, shape=shape)
         di = max(1, shape[0] // 20)
@@ -378,14 +416,18 @@ def _individual_island_probability(iterable_wrapper):
         acontamfluxgrid = np.empty(len(aperm), float)
         for j in range(0, len(aperm)):
             acontamfluxgrid[j] = aflux_grids[arefinds[0, j], arefinds[1, j], arefinds[2, j]]
-        return ['a', None, alist[:agrplen[i], i], alist_[:agrplen[i], i], acontamfluxgrid]
+        return ['a', None, alist[:agrplen[i], i], alist_[:agrplen[i], i], acontamfluxgrid,
+                np.nan * np.empty(len(aperm), float), np.nan * np.empty(len(aperm), float),
+                np.nan * np.empty(len(aperm), float)]
     elif agrplen[i] == 0:
         bperm = blist[:bgrplen[i], i]
         brefinds = bmodelrefinds[:, bperm]
         bcontamfluxgrid = np.empty(len(bperm), float)
         for j in range(0, len(bperm)):
             bcontamfluxgrid[j] = bflux_grids[brefinds[0, j], brefinds[1, j], brefinds[2, j]]
-        return ['b', None, blist[:bgrplen[i], i], blist_[:bgrplen[i], i], bcontamfluxgrid]
+        return ['b', None, blist[:bgrplen[i], i], blist_[:bgrplen[i], i], bcontamfluxgrid,
+                np.nan * np.empty(len(bperm), float), np.nan * np.empty(len(bperm), float),
+                np.nan * np.empty(len(bperm), float)]
     else:
         aperm = alist[:agrplen[i], i]
         bperm = blist[:bgrplen[i], i]
@@ -416,6 +458,7 @@ def _individual_island_probability(iterable_wrapper):
         Nfb = np.zeros(len(bperm), float)
         fa = np.empty((len(aperm)), float)
         fb = np.empty((len(bperm)), float)
+        seps = np.empty((len(aperm), len(bperm)), float)
 
         for j in range(0, len(aperm)):
             bina[j] = np.where(a_photo[aperm[j], amagref[aperm[j]]] - abinsarray[
@@ -492,6 +535,7 @@ def _individual_island_probability(iterable_wrapper):
                     xigrid[j, k] = -10
                 else:
                     xigrid[j, k] = np.log10(Nc*G/(Nfa[j]*Nfb[k]))
+                seps[j, k] = sep
 
         prob = 0
         integral = 1e-10
@@ -514,6 +558,30 @@ def _individual_island_probability(iterable_wrapper):
         bfield = bperm_
         afieldflux = acontamfluxgrid
         bfieldflux = bcontamfluxgrid
+        crptseps = np.array([])
+        afieldseps = np.empty(len(aperm), float) * np.nan
+        afieldeta = np.empty(len(aperm), float) * np.nan
+        afieldxi = np.empty(len(aperm), float) * np.nan
+        for j in range(len(aperm)):
+            tempsep = 1e10
+            for k in range(len(bperm)):
+                if seps[j, k] < tempsep:
+                    afieldseps[j] = seps[j, k]
+                    afieldeta[j] = etagrid[j, k]
+                    afieldxi[j] = xigrid[j, k]
+                    tempsep = seps[j, k]
+
+        bfieldseps = np.empty(len(bperm), float) * np.nan
+        bfieldeta = np.empty(len(bperm), float) * np.nan
+        bfieldxi = np.empty(len(bperm), float) * np.nan
+        for k in range(len(bperm)):
+            tempsep = 1e10
+            for j in range(len(aperm)):
+                if seps[j, k] < tempsep:
+                    bfieldseps[k] = seps[j, k]
+                    bfieldeta[k] = etagrid[j, k]
+                    bfieldxi[k] = xigrid[j, k]
+                    tempsep = seps[j, k]
         for N in range(1, min(len(aperm), len(bperm))+1):
             aiter = np.array(list(itertools.combinations(aperm, r=N)))
             biter = np.array(list(itertools.permutations(bperm, r=N)))
@@ -543,6 +611,33 @@ def _individual_island_probability(iterable_wrapper):
                         bfield = np.array(bperm_[tb])
                         afieldflux = np.array(acontamfluxgrid[ta])
                         bfieldflux = np.array(bcontamfluxgrid[tb])
+                        crptseps = np.array(seps[ya, yb])
 
+                        # TODO: do we want these to be nearest of all sources,
+                        # or nearest non-paired object?
+                        afieldseps = np.empty(len(ta), float) * np.nan
+                        afieldeta = np.empty(len(ta), float) * np.nan
+                        afieldxi = np.empty(len(ta), float) * np.nan
+                        for ta_counter, j in enumerate(ta):
+                            tempsep = 1e10
+                            for k in tb:
+                                if seps[j, k] < tempsep:
+                                    afieldseps[ta_counter] = seps[j, k]
+                                    afieldeta[ta_counter] = etagrid[j, k]
+                                    afieldxi[ta_counter] = xigrid[j, k]
+                                    tempsep = seps[j, k]
+
+                        bfieldseps = np.empty(len(tb), float) * np.nan
+                        bfieldeta = np.empty(len(tb), float) * np.nan
+                        bfieldxi = np.empty(len(tb), float) * np.nan
+                        for tb_counter, k in enumerate(tb):
+                            tempsep = 1e10
+                            for j in ta:
+                                if seps[j, k] < tempsep:
+                                    bfieldseps[tb_counter] = seps[j, k]
+                                    bfieldeta[tb_counter] = etagrid[j, k]
+                                    bfieldxi[tb_counter] = xigrid[j, k]
+                                    tempsep = seps[j, k]
         return [acrpts, bcrpts, acrptscontp, bcrptscontp, etacrpts, xicrpts, acrptflux, bcrptflux,
-                afield, bfield, afieldflux, bfieldflux, prob, integral]
+                crptseps, afield, bfield, afieldflux, bfieldflux, afieldseps, afieldeta,
+                afieldxi, bfieldseps, bfieldeta, bfieldxi, prob, integral]

--- a/macauff/parse_catalogue.py
+++ b/macauff/parse_catalogue.py
@@ -171,11 +171,13 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     match_df.to_csv('{}/{}.csv'.format(output_folder, output_filenames[0]), encoding='utf-8',
                     index=False, header=False)
 
-    # For non-match, ID/coordinates/mags, then island probability.
-    # TODO: add average contaminant flux recording to non-match outputs.
+    # For non-match, ID/coordinates/mags, then island probability + average
+    # contamination.
     af = np.load('{}/pairing/af.npy'.format(input_match_folder), mmap_mode='r')
+    a_avg_cont = np.load('{}/pairing/afieldflux.npy'.format(input_match_folder), mmap_mode='r')
     p = np.load('{}/pairing/pfa.npy'.format(input_match_folder), mmap_mode='r')
-    cols = np.append(column_name_lists[0], ['MATCH_P'])
+    cols = np.append(column_name_lists[0],
+                     ['MATCH_P', '{}_AVG_CONT'.format(extra_col_cat_names[0])])
     n_anonmatches = len(af)
     a_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_anonmatches))
     for cnum in range(0, mem_chunk_num):
@@ -184,13 +186,16 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         for i in column_name_lists[0]:
             a_nonmatch_df[i].iloc[lowind:highind] = cat_a[i].iloc[af[lowind:highind]].values
         a_nonmatch_df.iloc[lowind:highind, 3+n_amags] = p[lowind:highind]
+        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+1] = a_avg_cont[lowind:highind]
 
     a_nonmatch_df.to_csv('{}/{}.csv'.format(output_folder, output_filenames[1]), encoding='utf-8',
                          index=False, header=False)
 
     bf = np.load('{}/pairing/bf.npy'.format(input_match_folder), mmap_mode='r')
+    b_avg_cont = np.load('{}/pairing/bfieldflux.npy'.format(input_match_folder), mmap_mode='r')
     p = np.load('{}/pairing/pfb.npy'.format(input_match_folder), mmap_mode='r')
-    cols = np.append(column_name_lists[1], ['MATCH_P'])
+    cols = np.append(column_name_lists[1],
+                     ['MATCH_P', '{}_AVG_CONT'.format(extra_col_cat_names[1])])
     n_bnonmatches = len(bf)
     b_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_bnonmatches))
     for cnum in range(0, mem_chunk_num):
@@ -199,6 +204,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         for i in column_name_lists[1]:
             b_nonmatch_df[i].iloc[lowind:highind] = cat_b[i].iloc[bf[lowind:highind]].values
         b_nonmatch_df.iloc[lowind:highind, 3+n_bmags] = p[lowind:highind]
+        b_nonmatch_df.iloc[lowind:highind, 3+1+n_bmags] = b_avg_cont[lowind:highind]
 
     b_nonmatch_df.to_csv('{}/{}.csv'.format(output_folder, output_filenames[2]), encoding='utf-8',
                          index=False, header=False)

--- a/macauff/parse_catalogue.py
+++ b/macauff/parse_catalogue.py
@@ -74,7 +74,7 @@ def csv_to_npy(input_folder, input_filename, output_folder, astro_cols, photo_co
 
 
 def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenames,
-               output_filenames, column_name_lists, csv_col_name_or_num_lists,
+               output_filenames, column_name_lists, column_num_lists,
                extra_col_cat_names, mem_chunk_num, headers=[False, False]):
     '''
     Function to convert output .npy files, as created during the cross-match
@@ -101,7 +101,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         be included in the merged dataset -- its ID or designation, two
         orthogonal sky positions, and N magnitudes, as were originally used
         in the matching process, and likely used in ``csv_to_npy``.
-    csv_col_name_or_num_lists : list of list or array of integers
+    column_num_lists : list of list or array of integers
         List containing two lists or arrays of integers, one per catalogue,
         with the zero-index column integers corresponding to those columns listed
         in ``column_name_lists``.
@@ -145,10 +145,10 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     n_amags, n_bmags = len(column_name_lists[0]) - 3, len(column_name_lists[1]) - 3
     cat_a = pd.read_csv('{}/{}.csv'.format(input_csv_folders[0], csv_filenames[0]),
                         memory_map=True, header=None if not headers[0] else 0,
-                        usecols=csv_col_name_or_num_lists[0], names=column_name_lists[0])
+                        usecols=column_num_lists[0], names=column_name_lists[0])
     cat_b = pd.read_csv('{}/{}.csv'.format(input_csv_folders[1], csv_filenames[1]),
                         memory_map=True, header=None if not headers[1] else 0,
-                        usecols=csv_col_name_or_num_lists[1], names=column_name_lists[1])
+                        usecols=column_num_lists[1], names=column_name_lists[1])
     n_matches = len(ac)
     match_df = pd.DataFrame(columns=cols, index=np.arange(0, n_matches))
 

--- a/macauff/parse_catalogue.py
+++ b/macauff/parse_catalogue.py
@@ -123,7 +123,8 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     # TODO: un-hardcode number of relative contaminant fractions
     # TODO: remove photometric likelihood when not used.
     cols = np.append(np.append(column_name_lists[0], column_name_lists[1]),
-                     ['MATCH_P', 'ETA', 'XI', '{}_AVG_CONT'.format(extra_col_cat_names[0]),
+                     ['MATCH_P', 'SEPARATION', 'ETA', 'XI',
+                      '{}_AVG_CONT'.format(extra_col_cat_names[0]),
                       '{}_AVG_CONT'.format(extra_col_cat_names[1]),
                       '{}_CONT_F1'.format(extra_col_cat_names[0]),
                       '{}_CONT_F10'.format(extra_col_cat_names[0]),
@@ -138,6 +139,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     b_avg_cont = np.load('{}/pairing/bcontamflux.npy'.format(input_match_folder), mmap_mode='r')
     acontprob = np.load('{}/pairing/pacontam.npy'.format(input_match_folder), mmap_mode='r')
     bcontprob = np.load('{}/pairing/pbcontam.npy'.format(input_match_folder), mmap_mode='r')
+    seps = np.load('{}/pairing/crptseps.npy'.format(input_match_folder), mmap_mode='r')
     # TODO: generalise so that other columns than designation+position+magnitudes
     # can be kept.
     n_amags, n_bmags = len(column_name_lists[0]) - 3, len(column_name_lists[1]) - 3
@@ -158,14 +160,15 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         for i in column_name_lists[1]:
             match_df[i].iloc[lowind:highind] = cat_b[i].iloc[bc[lowind:highind]].values
         match_df.iloc[lowind:highind, 6+n_amags+n_bmags] = p[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+1] = eta[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+2] = xi[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+3] = a_avg_cont[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+4] = b_avg_cont[lowind:highind]
+        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+1] = seps[lowind:highind]
+        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+2] = eta[lowind:highind]
+        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+3] = xi[lowind:highind]
+        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+4] = a_avg_cont[lowind:highind]
+        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+5] = b_avg_cont[lowind:highind]
         for i in range(acontprob.shape[1]):
-            match_df.iloc[lowind:highind, 6+n_amags+n_bmags+5+i] = acontprob[lowind:highind, i]
+            match_df.iloc[lowind:highind, 6+n_amags+n_bmags+6+i] = acontprob[lowind:highind, i]
         for i in range(bcontprob.shape[1]):
-            match_df.iloc[lowind:highind, 6+n_amags+n_bmags+5+acontprob.shape[1]+i] = bcontprob[
+            match_df.iloc[lowind:highind, 6+n_amags+n_bmags+6+acontprob.shape[1]+i] = bcontprob[
                 lowind:highind, i]
 
     match_df.to_csv('{}/{}.csv'.format(output_folder, output_filenames[0]), encoding='utf-8',
@@ -176,8 +179,12 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     af = np.load('{}/pairing/af.npy'.format(input_match_folder), mmap_mode='r')
     a_avg_cont = np.load('{}/pairing/afieldflux.npy'.format(input_match_folder), mmap_mode='r')
     p = np.load('{}/pairing/pfa.npy'.format(input_match_folder), mmap_mode='r')
+    seps = np.load('{}/pairing/afieldseps.npy'.format(input_match_folder), mmap_mode='r')
+    afeta = np.load('{}/pairing/afieldeta.npy'.format(input_match_folder), mmap_mode='r')
+    afxi = np.load('{}/pairing/afieldxi.npy'.format(input_match_folder), mmap_mode='r')
     cols = np.append(column_name_lists[0],
-                     ['MATCH_P', '{}_AVG_CONT'.format(extra_col_cat_names[0])])
+                     ['MATCH_P', 'NNM_SEPARATION', 'NNM_ETA', 'NNM_XI',
+                      '{}_AVG_CONT'.format(extra_col_cat_names[0])])
     n_anonmatches = len(af)
     a_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_anonmatches))
     for cnum in range(0, mem_chunk_num):
@@ -186,7 +193,10 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         for i in column_name_lists[0]:
             a_nonmatch_df[i].iloc[lowind:highind] = cat_a[i].iloc[af[lowind:highind]].values
         a_nonmatch_df.iloc[lowind:highind, 3+n_amags] = p[lowind:highind]
-        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+1] = a_avg_cont[lowind:highind]
+        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+1] = seps[lowind:highind]
+        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+2] = afeta[lowind:highind]
+        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+3] = afxi[lowind:highind]
+        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+4] = a_avg_cont[lowind:highind]
 
     a_nonmatch_df.to_csv('{}/{}.csv'.format(output_folder, output_filenames[1]), encoding='utf-8',
                          index=False, header=False)
@@ -194,8 +204,12 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     bf = np.load('{}/pairing/bf.npy'.format(input_match_folder), mmap_mode='r')
     b_avg_cont = np.load('{}/pairing/bfieldflux.npy'.format(input_match_folder), mmap_mode='r')
     p = np.load('{}/pairing/pfb.npy'.format(input_match_folder), mmap_mode='r')
+    seps = np.load('{}/pairing/bfieldseps.npy'.format(input_match_folder), mmap_mode='r')
+    bfeta = np.load('{}/pairing/bfieldeta.npy'.format(input_match_folder), mmap_mode='r')
+    bfxi = np.load('{}/pairing/bfieldxi.npy'.format(input_match_folder), mmap_mode='r')
     cols = np.append(column_name_lists[1],
-                     ['MATCH_P', '{}_AVG_CONT'.format(extra_col_cat_names[1])])
+                     ['MATCH_P', 'NNM_SEPARATION', 'NNM_ETA', 'NNM_XI',
+                      '{}_AVG_CONT'.format(extra_col_cat_names[1])])
     n_bnonmatches = len(bf)
     b_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_bnonmatches))
     for cnum in range(0, mem_chunk_num):
@@ -204,7 +218,10 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         for i in column_name_lists[1]:
             b_nonmatch_df[i].iloc[lowind:highind] = cat_b[i].iloc[bf[lowind:highind]].values
         b_nonmatch_df.iloc[lowind:highind, 3+n_bmags] = p[lowind:highind]
-        b_nonmatch_df.iloc[lowind:highind, 3+1+n_bmags] = b_avg_cont[lowind:highind]
+        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+1] = seps[lowind:highind]
+        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+2] = bfeta[lowind:highind]
+        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+3] = bfxi[lowind:highind]
+        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+4] = b_avg_cont[lowind:highind]
 
     b_nonmatch_df.to_csv('{}/{}.csv'.format(output_folder, output_filenames[2]), encoding='utf-8',
                          index=False, header=False)

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -268,6 +268,11 @@ class TestCounterpartPairing:
         bflux = np.load('{}/pairing/bcontamflux.npy'.format(self.joint_folder_path))
         assert np.all(bflux == np.zeros((3), float))
 
+        aflux = np.load('{}/pairing/afieldflux.npy'.format(self.joint_folder_path))
+        assert np.all(aflux == np.zeros((4), float))
+        bflux = np.load('{}/pairing/bfieldflux.npy'.format(self.joint_folder_path))
+        assert np.all(bflux == np.zeros((1), float))
+
         a_matches = np.load('{}/pairing/ac.npy'.format(self.joint_folder_path))
         assert np.all([q in a_matches for q in [0, 1, 2]])
         assert np.all([q not in a_matches for q in [3, 4, 5, 6]])

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -36,8 +36,9 @@ class TestCounterpartPairing:
     def setup_class(self):
         seed = 8888
         rng = np.random.default_rng(seed)
-        # Test will have three overlap islands: 2 a sources and 1 b source, and
-        # a single lonely a source. Also two islands each with one "field" object.
+        # Test will have three overlap islands: two with 2 a sources and 1 b
+        # source, with 1 unmatched a source, and one with 2 a + 1 b all unmatched
+        # sources. Also two islands each with just one "field" object.
         self.a_astro = np.empty((7, 3), float)
         self.b_astro = np.empty((4, 3), float)
         self.a_sig, self.b_sig = 0.1, 0.08
@@ -57,6 +58,9 @@ class TestCounterpartPairing:
         # Swap the last two indexes as well
         self.b_astro[-2:, 0] = self.b_astro[[-1, -2], 0]
         self.b_astro[-2:, 1] = self.b_astro[[-1, -2], 1]
+        # Force no match between the third island by adding distance between
+        # a[2] and b[3]. Unphysical but effective.
+        self.b_astro[3, 1] += 7*self.b_sig/3600
 
         self.a_astro[:, 2] = self.a_sig
         self.b_astro[:, 2] = self.b_sig
@@ -84,9 +88,10 @@ class TestCounterpartPairing:
         self.c_array = np.ones((1, 1, 4, 3, 1), float, order='F')
         self.fa_array = np.ones((1, 4, 3, 1), float, order='F')
         self.fb_array = np.ones((1, 4, 3, 1), float, order='F')
-        self.c_priors = np.asfortranarray((3/0.1**2 * 0.5) * np.ones((4, 3, 1), float))
-        self.fa_priors = np.asfortranarray((7/0.1**2 - 3/0.1**2 * 0.5) * np.ones((4, 3, 1), float))
-        self.fb_priors = np.asfortranarray((3/0.1**2 * 0.5) * np.ones((4, 3, 1), float))
+        self.c_priors = np.asfortranarray((3/0.001**2 * 0.5) * np.ones((4, 3, 1), float))
+        self.fa_priors = np.asfortranarray((7/0.001**2 - 3/0.001**2 * 0.5) *
+                                           np.ones((4, 3, 1), float))
+        self.fb_priors = np.asfortranarray((3/0.001**2 * 0.5) * np.ones((4, 3, 1), float))
 
         self.amagref = np.zeros((self.a_astro.shape[0]), int)
         self.bmagref = np.zeros((self.b_astro.shape[0]), int)
@@ -191,7 +196,8 @@ class TestCounterpartPairing:
             self.n_fracs]
         results = _individual_island_probability(wrapper)
         (acrpts, bcrpts, acrptscontp, bcrptscontp, etacrpts, xicrpts, acrptflux, bcrptflux,
-         afield, bfield, prob, integral) = results
+         crptseps, afield, bfield, afieldflux, bfieldflux, afieldseps, afieldeta,
+         afieldxi, bfieldseps, bfieldeta, bfieldxi, prob, integral) = results
 
         assert np.all(acrpts == np.array([0]))
         assert np.all(bcrpts == np.array([1]))
@@ -231,7 +237,8 @@ class TestCounterpartPairing:
             self.n_fracs]
         results = _individual_island_probability(wrapper)
         (acrpts, bcrpts, acrptscontp, bcrptscontp, etacrpts, xicrpts, acrptflux, bcrptflux,
-         afield, bfield, prob, integral) = results
+         crptseps, afield, bfield, afieldflux, bfieldflux, afieldseps, afieldeta,
+         afieldxi, bfieldseps, bfieldeta, bfieldxi, prob, integral) = results
 
         assert np.all(acrpts == np.array([0]))
         assert np.all(bcrpts == np.array([1]))
@@ -249,7 +256,8 @@ class TestCounterpartPairing:
             self.n_fracs]
         results = _individual_island_probability(wrapper)
         (acrpts, bcrpts, acrptscontp, bcrptscontp, etacrpts, xicrpts, acrptflux, bcrptflux,
-         afield, bfield, prob, integral) = results
+         crptseps, afield, bfield, afieldflux, bfieldflux, afieldseps, afieldeta,
+         afieldxi, bfieldseps, bfieldeta, bfieldxi, prob, integral) = results
 
         assert len(acrpts) == 0
         assert len(bcrpts) == 0
@@ -266,28 +274,28 @@ class TestCounterpartPairing:
             mem_chunk_num, n_pool)
 
         bflux = np.load('{}/pairing/bcontamflux.npy'.format(self.joint_folder_path))
-        assert np.all(bflux == np.zeros((3), float))
+        assert np.all(bflux == np.zeros((2), float))
 
         aflux = np.load('{}/pairing/afieldflux.npy'.format(self.joint_folder_path))
-        assert np.all(aflux == np.zeros((4), float))
+        assert np.all(aflux == np.zeros((5), float))
         bflux = np.load('{}/pairing/bfieldflux.npy'.format(self.joint_folder_path))
-        assert np.all(bflux == np.zeros((1), float))
+        assert np.all(bflux == np.zeros((2), float))
 
         a_matches = np.load('{}/pairing/ac.npy'.format(self.joint_folder_path))
-        assert np.all([q in a_matches for q in [0, 1, 2]])
-        assert np.all([q not in a_matches for q in [3, 4, 5, 6]])
+        assert np.all([q in a_matches for q in [0, 1]])
+        assert np.all([q not in a_matches for q in [2, 3, 4, 5, 6]])
 
         a_field = np.load('{}/pairing/af.npy'.format(self.joint_folder_path))
-        assert np.all([q in a_field for q in [3, 4, 5, 6]])
-        assert np.all([q not in a_field for q in [0, 1, 2]])
+        assert np.all([q in a_field for q in [2, 3, 4, 5, 6]])
+        assert np.all([q not in a_field for q in [0, 1]])
 
         b_matches = np.load('{}/pairing/bc.npy'.format(self.joint_folder_path))
-        assert np.all([q in b_matches for q in [0, 1, 3]])
-        assert np.all([q not in b_matches for q in [2]])
+        assert np.all([q in b_matches for q in [0, 1]])
+        assert np.all([q not in b_matches for q in [2, 3]])
 
         b_field = np.load('{}/pairing/bf.npy'.format(self.joint_folder_path))
-        assert np.all([q in b_field for q in [2]])
-        assert np.all([q not in b_field for q in [0, 1, 3]])
+        assert np.all([q in b_field for q in [2, 3]])
+        assert np.all([q not in b_field for q in [0, 1]])
 
         prob_counterpart = np.load('{}/pairing/pc.npy'.format(self.joint_folder_path))
         self._calculate_prob_integral()
@@ -300,6 +308,9 @@ class TestCounterpartPairing:
         xicrpts = np.load('{}/pairing/xi.npy'.format(self.joint_folder_path))
         assert_allclose(xicrpts[q], np.array([np.log10(self.G / self.fa_priors[0, 0, 0])]),
                         rtol=1e-6)
+        csep = np.load('{}/pairing/crptseps.npy'.format(self.joint_folder_path))
+        assert_allclose(csep[q], self.sep * 3600, rtol=1e-6)
+        assert len(csep) == len(a_matches)
 
         prob_a_field = np.load('{}/pairing/pfa.npy'.format(self.joint_folder_path))
         a_field = np.load('{}/pairing/af.npy'.format(self.joint_folder_path))
@@ -310,6 +321,22 @@ class TestCounterpartPairing:
         b_field = np.load('{}/pairing/bf.npy'.format(self.joint_folder_path))
         q = np.where(b_field == 2)[0][0]
         assert prob_b_field[q] == 1
+
+        afs = np.load('{}/pairing/afieldseps.npy'.format(self.joint_folder_path))
+        afeta = np.load('{}/pairing/afieldeta.npy'.format(self.joint_folder_path))
+        afxi = np.load('{}/pairing/afieldxi.npy'.format(self.joint_folder_path))
+        q = np.where(a_field == 2)[0][0]
+        fake_field_sep = np.sqrt(((self.a_astro[2, 0] -
+                                   self.b_astro[3, 0])*np.cos(np.radians(self.b_astro[3, 1])))**2 +
+                                 (self.a_astro[2, 1] - self.b_astro[3, 1])**2)
+        assert_allclose(afs[q], fake_field_sep * 3600, rtol=1e-6)
+
+        fake_field_G = 1/(2 * np.pi * self.o**2) * np.exp(-0.5 * fake_field_sep**2 / self.o**2)
+        # c_priors and fb_priors are the same, so they cancel in the division.
+        # Being in log space we can be relatively forgiving in our assertion limits.
+        assert_allclose(afxi[q], np.log10(fake_field_G / self.Nfa), rtol=0.01, atol=0.01)
+        # Ignoring photometry here, so this should be equal probability.
+        assert_allclose(afeta[q], np.log10(1.0))
 
     def test_including_b_reject(self):
         os.system('rm -r {}/pairing'.format(self.joint_folder_path))
@@ -533,23 +560,23 @@ class TestCounterpartPairing:
         self.cm.pair_sources(self.files_per_pairing)
 
         bflux = np.load('{}/pairing/bcontamflux.npy'.format(self.joint_folder_path))
-        assert np.all(bflux == np.zeros((3), float))
+        assert np.all(bflux == np.zeros((2), float))
 
         a_matches = np.load('{}/pairing/ac.npy'.format(self.joint_folder_path))
-        assert np.all([q in a_matches for q in [0, 1, 2]])
-        assert np.all([q not in a_matches for q in [3, 4, 5, 6]])
+        assert np.all([q in a_matches for q in [0, 1]])
+        assert np.all([q not in a_matches for q in [2, 3, 4, 5, 6]])
 
         a_field = np.load('{}/pairing/af.npy'.format(self.joint_folder_path))
-        assert np.all([q in a_field for q in [3, 4, 5, 6]])
-        assert np.all([q not in a_field for q in [0, 1, 2]])
+        assert np.all([q in a_field for q in [2, 3, 4, 5, 6]])
+        assert np.all([q not in a_field for q in [0, 1]])
 
         b_matches = np.load('{}/pairing/bc.npy'.format(self.joint_folder_path))
-        assert np.all([q in b_matches for q in [0, 1, 3]])
-        assert np.all([q not in b_matches for q in [2]])
+        assert np.all([q in b_matches for q in [0, 1]])
+        assert np.all([q not in b_matches for q in [2, 3]])
 
         b_field = np.load('{}/pairing/bf.npy'.format(self.joint_folder_path))
-        assert np.all([q in b_field for q in [2]])
-        assert np.all([q not in b_field for q in [0, 1, 3]])
+        assert np.all([q in b_field for q in [2, 3]])
+        assert np.all([q not in b_field for q in [0, 1]])
 
         prob_counterpart = np.load('{}/pairing/pc.npy'.format(self.joint_folder_path))
         self._calculate_prob_integral()
@@ -572,6 +599,22 @@ class TestCounterpartPairing:
         b_field = np.load('{}/pairing/bf.npy'.format(self.joint_folder_path))
         q = np.where(b_field == 2)[0][0]
         assert prob_b_field[q] == 1
+
+        afs = np.load('{}/pairing/afieldseps.npy'.format(self.joint_folder_path))
+        afeta = np.load('{}/pairing/afieldeta.npy'.format(self.joint_folder_path))
+        afxi = np.load('{}/pairing/afieldxi.npy'.format(self.joint_folder_path))
+        q = np.where(a_field == 2)[0][0]
+        fake_field_sep = np.sqrt(((self.a_astro[2, 0] -
+                                   self.b_astro[3, 0])*np.cos(np.radians(self.b_astro[3, 1])))**2 +
+                                 (self.a_astro[2, 1] - self.b_astro[3, 1])**2)
+        assert_allclose(afs[q], fake_field_sep * 3600, rtol=1e-6)
+
+        fake_field_G = 1/(2 * np.pi * self.o**2) * np.exp(-0.5 * fake_field_sep**2 / self.o**2)
+        # c_priors and fb_priors are the same, so they cancel in the division.
+        # Being in log space we can be relatively forgiving in our assertion limits.
+        assert_allclose(afxi[q], np.log10(fake_field_G / self.Nfa), rtol=0.01, atol=0.01)
+        # Ignoring photometry here, so this should be equal probability.
+        assert_allclose(afeta[q], np.log10(1.0))
 
     def test_pair_sources_incorrect_warning(self):
         os.system('rm -r {}/pairing'.format(self.joint_folder_path))

--- a/macauff/tests/test_parse_catalogue.py
+++ b/macauff/tests/test_parse_catalogue.py
@@ -109,10 +109,27 @@ class TestParseCatalogue:
         bff = rng.uniform(0, 3, size=len(bf))
         np.save('test_folder/pairing/bfieldflux.npy', bff)
 
+        csep = rng.uniform(0, 0.5, size=N_match)
+        np.save('test_folder/pairing/crptseps.npy', csep)
+
+        afs = rng.uniform(0, 0.5, size=len(af))
+        np.save('test_folder/pairing/afieldseps.npy', afs)
+        afeta = rng.uniform(-3, 0, size=len(af))
+        np.save('test_folder/pairing/afieldeta.npy', afeta)
+        afxi = rng.uniform(-3, 0, size=len(af))
+        np.save('test_folder/pairing/afieldxi.npy', afxi)
+
+        bfs = rng.uniform(0, 0.5, size=len(bf))
+        np.save('test_folder/pairing/bfieldseps.npy', bfs)
+        bfeta = rng.uniform(0, 0.5, size=len(bf))
+        np.save('test_folder/pairing/bfieldeta.npy', bfeta)
+        bfxi = rng.uniform(0, 0.5, size=len(bf))
+        np.save('test_folder/pairing/bfieldxi.npy', bfxi)
+
         a_cols = ['A_Designation', 'A_RA', 'A_Dec', 'G', 'G_RP']
         b_cols = ['B_Designation', 'B_RA', 'B_Dec', 'W1', 'W2', 'W3']
-        extra_cols = ['MATCH_P', 'ETA', 'XI', 'A_AVG_CONT', 'B_AVG_CONT', 'A_CONT_F1',
-                      'A_CONT_F10', 'B_CONT_F1', 'B_CONT_F10']
+        extra_cols = ['MATCH_P', 'SEPARATION', 'ETA', 'XI', 'A_AVG_CONT', 'B_AVG_CONT',
+                      'A_CONT_F1', 'A_CONT_F10', 'B_CONT_F1', 'B_CONT_F10']
 
         npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data', 'test_b_data'],
                    ['match_csv', 'a_nonmatch_csv', 'b_nonmatch_csv'], [a_cols, b_cols],
@@ -134,24 +151,30 @@ class TestParseCatalogue:
             assert_allclose(df[col], data[bc, i])
         assert np.all([df[b_cols[0]].iloc[i] == data2[bc[i], 0] for i in range(len(bc))])
 
-        for f, col in zip([pc, eta, xi, acf, bcf, pac[:, 0], pac[:, 1], pbc[:, 0], pbc[:, 1]],
-                          extra_cols):
+        for f, col in zip([pc, csep, eta, xi, acf, bcf, pac[:, 0], pac[:, 1], pbc[:, 0],
+                           pbc[:, 1]], extra_cols):
             assert_allclose(df[col], f)
 
-        names = np.append(a_cols, ['MATCH_P', 'A_AVG_CONT'])
+        names = np.append(a_cols, ['MATCH_P', 'NNM_SEPARATION', 'NNM_ETA', 'NNM_XI', 'A_AVG_CONT'])
         df = pd.read_csv('a_nonmatch_csv.csv', header=None, names=names)
         for i, col in zip([1, 2, 4, 5], a_cols[1:]):
             assert_allclose(df[col], self.data[af, i])
         assert np.all([df[a_cols[0]].iloc[i] == data1[af[i], 0] for i in range(len(af))])
         assert_allclose(df['MATCH_P'], pfa)
         assert_allclose(df['A_AVG_CONT'], aff)
-        names = np.append(b_cols, ['MATCH_P', 'B_AVG_CONT'])
+        assert_allclose(df['NNM_SEPARATION'], afs)
+        assert_allclose(df['NNM_ETA'], afeta)
+        assert_allclose(df['NNM_XI'], afxi)
+        names = np.append(b_cols, ['MATCH_P', 'NNM_SEPARATION', 'NNM_ETA', 'NNM_XI', 'B_AVG_CONT'])
         df = pd.read_csv('b_nonmatch_csv.csv', header=None, names=names)
         for i, col in zip([1, 2, 4, 5, 6], b_cols[1:]):
             assert_allclose(df[col], data[bf, i])
         assert np.all([df[b_cols[0]].iloc[i] == data2[bf[i], 0] for i in range(len(bf))])
         assert_allclose(df['MATCH_P'], pfb)
         assert_allclose(df['B_AVG_CONT'], bff)
+        assert_allclose(df['NNM_SEPARATION'], bfs)
+        assert_allclose(df['NNM_ETA'], bfeta)
+        assert_allclose(df['NNM_XI'], bfxi)
 
     def test_rect_slice_npy(self):
         np.save('con_cat_astro.npy', self.data[:, [1, 2, 3]])

--- a/macauff/tests/test_parse_catalogue.py
+++ b/macauff/tests/test_parse_catalogue.py
@@ -104,6 +104,11 @@ class TestParseCatalogue:
         bcf = rng.uniform(0, 3, size=N_match)
         np.save('test_folder/pairing/bcontamflux.npy', bcf)
 
+        aff = rng.uniform(0, 0.2, size=len(af))
+        np.save('test_folder/pairing/afieldflux.npy', aff)
+        bff = rng.uniform(0, 3, size=len(bf))
+        np.save('test_folder/pairing/bfieldflux.npy', bff)
+
         a_cols = ['A_Designation', 'A_RA', 'A_Dec', 'G', 'G_RP']
         b_cols = ['B_Designation', 'B_RA', 'B_Dec', 'W1', 'W2', 'W3']
         extra_cols = ['MATCH_P', 'ETA', 'XI', 'A_AVG_CONT', 'B_AVG_CONT', 'A_CONT_F1',
@@ -133,18 +138,20 @@ class TestParseCatalogue:
                           extra_cols):
             assert_allclose(df[col], f)
 
-        names = np.append(a_cols, ['MATCH_P'])
+        names = np.append(a_cols, ['MATCH_P', 'A_AVG_CONT'])
         df = pd.read_csv('a_nonmatch_csv.csv', header=None, names=names)
         for i, col in zip([1, 2, 4, 5], a_cols[1:]):
             assert_allclose(df[col], self.data[af, i])
         assert np.all([df[a_cols[0]].iloc[i] == data1[af[i], 0] for i in range(len(af))])
         assert_allclose(df['MATCH_P'], pfa)
-        names = np.append(b_cols, ['MATCH_P'])
+        assert_allclose(df['A_AVG_CONT'], aff)
+        names = np.append(b_cols, ['MATCH_P', 'B_AVG_CONT'])
         df = pd.read_csv('b_nonmatch_csv.csv', header=None, names=names)
         for i, col in zip([1, 2, 4, 5, 6], b_cols[1:]):
             assert_allclose(df[col], data[bf, i])
         assert np.all([df[b_cols[0]].iloc[i] == data2[bf[i], 0] for i in range(len(bf))])
         assert_allclose(df['MATCH_P'], pfb)
+        assert_allclose(df['B_AVG_CONT'], bff)
 
     def test_rect_slice_npy(self):
         np.save('con_cat_astro.npy', self.data[:, [1, 2, 3]])


### PR DESCRIPTION
This PR extends ``npy_to_csv`` in its creation of the three output datafiles: match and x2 non-match catalogue files.

First, we keep a record of the separation between matches.

Second, the non-match datafiles are extended with their average contamination from simulated perturbation AUFs, and then -- if they have any partner non-matches within the opposing catalogue in their "island" -- record separation, eta, and xi of the closest other opposing-catalogue non-match, for investigative purposes.

Finally, the ``npy_to_csv`` API is extended to allow the passing of additional columns -- other than a name, two position, and N magnitude columns -- from the original catalogues into the merged datasets, if this is of use to the user.