### PR TITLE
trilegal_download test fix

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,9 +1,8 @@
 name: Python package
 
 on:
-  push:
+  workflow_dispatch:
   pull_request:
-    types: [opened, reopened]
 
 jobs:
   build:
@@ -52,9 +51,6 @@ jobs:
         run: |
           pip install numpy
           pip install tox
-      - if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-        name: Run tests
-        run: tox -e ${{ matrix.toxenv }}
       - if: github.event_name == 'pull_request'
         name: Run tests with remote
         run: tox -e ${{ matrix.toxenv }} -- --remote-data

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,6 +1,9 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -52,7 +52,7 @@ jobs:
       - if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         name: Run tests
         run: tox -e ${{ matrix.toxenv }}
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request')
         name: Run tests with remote
         run: tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -52,7 +52,7 @@ jobs:
       - if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         name: Run tests
         run: tox -e ${{ matrix.toxenv }}
-      - if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request')
+      - if: github.event_name == 'pull_request'
         name: Run tests with remote
         run: tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,8 @@ General
 New Features
 ^^^^^^^^^^^^
 
-- Inclusion of galaxy count model, to be used in the generation of perturbation
-  AUF components. [#41]
+- Inclusion of galaxy count model, used in the generation of perturbation
+  AUF components. [#41, #44]
 
 - Creation of initial Galactic proper motion model, for inclusion within the
   cross-match framework in a future release. [#39]

--- a/macauff/galaxy_counts.py
+++ b/macauff/galaxy_counts.py
@@ -25,8 +25,8 @@ def create_galaxy_counts(cmau_array, mag_bins, z_array, wav, alpha0, alpha1, wei
     cmau_array : numpy.ndarray
         Array holding the c/m/a/u values that describe the parameterisation
         of the Schechter functions with wavelength, following Wilson (2022, RNAAS,
-        ...) [1]_. Shape should be `(5, 2, 4)`, with 5 parameters for both blue and red
-        galaxies.
+        6, 60) [1]_. Shape should be `(5, 2, 4)`, with 5 parameters for both
+        blue and red galaxies.
     mag_bins : numpy.ndarray
         The apparent magnitudes at which to evaluate the on-sky differential
         galaxy density.
@@ -67,7 +67,7 @@ def create_galaxy_counts(cmau_array, mag_bins, z_array, wav, alpha0, alpha1, wei
 
     References
     ----------
-    .. [1] Wilson T. J. (2022), RNAAS, ...
+    .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
     '''
@@ -207,7 +207,7 @@ def function_evaluation_lookup(cmau, ind1, ind2, x):
 
     References
     ----------
-    .. [1] Wilson T. J. (2022), RNAAS, ...
+    .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     '''
     c, m, a, u = cmau[ind1, ind2]
     if np.isnan(a) and np.isnan(u):

--- a/macauff/galaxy_counts.py
+++ b/macauff/galaxy_counts.py
@@ -14,7 +14,7 @@ __all__ = ['create_galaxy_counts', 'generate_speclite_filters']
 
 
 def create_galaxy_counts(cmau_array, mag_bins, z_array, wav, alpha0, alpha1, weight,
-                         ab_offset, filter_name):
+                         ab_offset, filter_name, al_inf):
     r'''
     Create a simulated distribution of galaxy magnitudes for a particular
     bandpass by consideration of double Schechter functions (for blue and
@@ -56,6 +56,8 @@ def create_galaxy_counts(cmau_array, mag_bins, z_array, wav, alpha0, alpha1, wei
         of the particular observations. If observations are in a filter system
         not provided by ``speclite``, response curve can be generated using
         ``generate_speclite_filters``.
+    al_inf : float
+        The reddening at infinity by which to extinct all galaxy magnitudes.
 
     Returns
     -------
@@ -122,7 +124,7 @@ def create_galaxy_counts(cmau_array, mag_bins, z_array, wav, alpha0, alpha1, wei
             kcorr[j] = -2.5 * np.log10(1/(1+_z) * shift_ab_maggy / non_shift_ab_maggy)
         # e.g. Loveday+2015 for absolute -> apparent magnitude conversion
         gal_dens += np.interp(mag_bins, abs_mag_bins + cosmology.distmod(z).value +
-                              np.percentile(kcorr, 50) - ab_offset, model_density)
+                              np.percentile(kcorr, 50) - ab_offset + al_inf, model_density)
 
     return gal_dens
 

--- a/macauff/galaxy_counts.py
+++ b/macauff/galaxy_counts.py
@@ -70,6 +70,7 @@ def create_galaxy_counts(cmau_array, mag_bins, z_array, wav, alpha0, alpha1, wei
     .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
+
     '''
     cosmology = default_cosmology.get()
     gal_dens = np.zeros_like(mag_bins)
@@ -162,6 +163,7 @@ def generate_phi(cmau_array, cmau_ind, log_wav, z, abs_mag_bins):
     References
     ----------
     .. [1] Schechter P. (1976), ApJ, 203, 297
+
     '''
     M_star0 = function_evaluation_lookup(cmau_array, 0, cmau_ind, log_wav)
     phi_star0 = function_evaluation_lookup(cmau_array, 1, cmau_ind, log_wav)
@@ -208,6 +210,7 @@ def function_evaluation_lookup(cmau, ind1, ind2, x):
     References
     ----------
     .. [1] Wilson T. J. (2022), RNAAS, 6, 60
+
     '''
     c, m, a, u = cmau[ind1, ind2]
     if np.isnan(a) and np.isnan(u):

--- a/macauff/get_trilegal_wrapper.py
+++ b/macauff/get_trilegal_wrapper.py
@@ -83,6 +83,8 @@ def get_trilegal(filename, ra, dec, folder='.', galactic=False,
     trilegal_webcall(trilegal_version, l, b, area, binaries, AV, sigma_AV, filterset, magnum,
                      maglim, outfile)
 
+    return AV
+
 
 def trilegal_webcall(trilegal_version, l, b, area, binaries, AV, sigma_AV, filterset, magnum,
                      maglim, outfile):

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -536,7 +536,7 @@ class CrossMatch():
 
         # TODO: allow as user input.
         self.gal_cmau_array = np.empty((5, 2, 4), float)
-        # See Wilson (2022, RNAAS, ...) for the meanings of the variables c, m,
+        # See Wilson (2022, RNAAS, 6, 60) for the meanings of the variables c, m,
         # a, and u. For each of M*/phi*/alpha/P/Q, for blue+red galaxies, 2-4
         # variables are derived as a function of wavelength, or Q(P).
         self.gal_cmau_array[0, :, :] = [[-24.286513, 1.141760, 2.655846, np.nan],

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -393,12 +393,12 @@ class CrossMatch():
                     [self.a_fit_gal_flag, self.b_fit_gal_flag], ['a_', 'b_']):
                 if fit_gal_flag:
                     for check_flag in ['gal_wavs', 'gal_zmax', 'gal_nzs',
-                                       'gal_aboffsets', 'gal_filternames']:
+                                       'gal_aboffsets', 'gal_filternames', 'gal_al_avs']:
                         if check_flag not in config:
                             raise ValueError("Missing key {} from catalogue {} metadata file."
                                              .format(check_flag, catname))
                     # Set all lists of floats
-                    for var in ['gal_wavs', 'gal_zmax', 'gal_aboffsets']:
+                    for var in ['gal_wavs', 'gal_zmax', 'gal_aboffsets', 'gal_al_avs']:
                         a = config[var].split(' ')
                         try:
                             b = np.array([float(f) for f in a])
@@ -587,7 +587,8 @@ class CrossMatch():
                                       'z_maxs': self.a_gal_zmax, 'nzs': self.a_gal_nzs,
                                       'ab_offsets': self.a_gal_aboffsets,
                                       'filter_names': self.a_gal_filternames,
-                                      'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
+                                      'al_avs': self.a_gal_al_avs, 'alpha0': self.gal_alpha0,
+                                      'alpha1': self.gal_alpha1,
                                       'alpha_weight': self.gal_alphaweight})
                 else:
                     _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})
@@ -651,7 +652,8 @@ class CrossMatch():
                                       'z_maxs': self.b_gal_zmax, 'nzs': self.b_gal_nzs,
                                       'ab_offsets': self.b_gal_aboffsets,
                                       'filter_names': self.b_gal_filternames,
-                                      'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
+                                      'al_avs': self.b_gal_al_avs, 'alpha0': self.gal_alpha0,
+                                      'alpha1': self.gal_alpha1,
                                       'alpha_weight': self.gal_alphaweight})
                 else:
                     _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -490,6 +490,26 @@ class CrossMatch():
         # TODO: allow as user input.
         self.delta_mag_cuts = np.array([2.5, 5])
 
+        # TODO: allow as user input.
+        self.gal_cmau_array = np.empty((5, 2, 4), float)
+        # See Wilson (2022, RNAAS, ...) for the meanings of the variables c, m,
+        # a, and u. For each of M*/phi*/alpha/P/Q, for blue+red galaxies, 2-4
+        # variables are derived as a function of wavelength, or Q(P).
+        self.gal_cmau_array[0, :, :] = [[-24.286513, 1.141760, 2.655846, np.nan],
+                                        [-23.192520, 1.778718, 1.668292, np.nan]]
+        self.gal_cmau_array[1, :, :] = [[0.001487, 2.918841, 0.000510, np.nan],
+                                        [0.000560, 7.691261, 0.003330, -0.065565]]
+        self.gal_cmau_array[2, :, :] = [[-1.257761, 0.021362, np.nan, np.nan],
+                                        [-0.309077, -0.067411, np.nan, np.nan]]
+        self.gal_cmau_array[3, :, :] = [[-0.302018, 0.034203, np.nan, np.nan],
+                                        [-0.713062, 0.233366, np.nan, np.nan]]
+        self.gal_cmau_array[4, :, :] = [[1.233627, -0.322347, np.nan, np.nan],
+                                        [1.068926, -0.385984, np.nan, np.nan]]
+        self.gal_alpha0 = [[2.079, 3.524, 1.917, 1.992, 2.536], [2.461, 2.358, 2.568, 2.268, 2.402]]
+        self.gal_alpha1 = [[2.265, 3.862, 1.921, 1.685, 2.480], [2.410, 2.340, 2.200, 2.540, 2.464]]
+        self.gal_alphaweight = [[3.47e+09, 3.31e+06, 2.13e+09, 1.64e+10, 1.01e+09],
+                                [3.84e+09, 1.57e+06, 3.91e+08, 4.66e+10, 3.03e+07]]
+
         if self.run_auf or not a_correct_file_number:
             if self.j0s is None:
                 self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
@@ -516,6 +536,17 @@ class CrossMatch():
                                    **{'tri_set_name': self.a_tri_set_name,
                                       'tri_filt_num': self.a_tri_filt_num,
                                       'auf_region_frame': self.a_auf_region_frame})
+                if self.a_fit_gal_flag:
+                    _kwargs = dict(_kwargs,
+                                   **{'fit_gal_flag': self.a_fit_gal_flag,
+                                      'cmau_array': self.gal_cmau_array, 'wavs': self.a_gal_wavs,
+                                      'z_maxs': self.a_gal_zmax, 'nzs': self.a_gal_nzs,
+                                      'ab_offsets': self.a_gal_aboffsets,
+                                      'filter_names': self.a_gal_filternames,
+                                      'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
+                                      'alpha_weight': self.gal_alphaweight})
+                else:
+                    _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})
                 if self.a_download_tri:
                     os.system("rm -rf {}/*".format(self.a_auf_folder_path))
                 else:
@@ -569,6 +600,17 @@ class CrossMatch():
                                    **{'tri_set_name': self.b_tri_set_name,
                                       'tri_filt_num': self.b_tri_filt_num,
                                       'auf_region_frame': self.b_auf_region_frame})
+                if self.b_fit_gal_flag:
+                    _kwargs = dict(_kwargs,
+                                   **{'fit_gal_flag': self.b_fit_gal_flag,
+                                      'cmau_array': self.gal_cmau_array, 'wavs': self.b_gal_wavs,
+                                      'z_maxs': self.b_gal_zmax, 'nzs': self.b_gal_nzs,
+                                      'ab_offsets': self.b_gal_aboffsets,
+                                      'filter_names': self.b_gal_filternames,
+                                      'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
+                                      'alpha_weight': self.gal_alphaweight})
+                else:
+                    _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})
                 if self.b_download_tri:
                     os.system("rm -rf {}/*".format(self.b_auf_folder_path))
                 else:

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -746,9 +746,9 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
     # TODO: add extinction reddening!
     if fit_gal_flag:
         z_array = np.linspace(0, z_max, nz)
-        gal_dens = create_galaxy_counts(cmau_array, model_mags, z_array, wav, alpha0, alpha1,
+        gal_dens = create_galaxy_counts(cmau_array, model_mag_mids, z_array, wav, alpha0, alpha1,
                                         alpha_weight, ab_offset, filter_name)
-        max_mag_bin = np.argwhere(model_mags[1:] > density_mag)[0][0]
+        max_mag_bin = np.argwhere(model_mags[1:] <= density_mag)[0][-1]
         gal_count = np.sum(gal_dens[:max_mag_bin]*model_mags_interval[:max_mag_bin])
         log10y_gal = -np.inf * np.ones_like(log10y_tri)
         log10y_gal[gal_dens > 0] = np.log10(gal_dens[gal_dens > 0])

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -168,11 +168,13 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     alpha_weight : list of numpy.ndarray or numpy.ndarray, optional
         Weights for use in calculating :math:`\alpha_i` from ``alpha0`` and
         ``alpha1``.
+
     References
     ----------
     .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
+
     """
     if include_perturb_auf and tri_download_flag and tri_set_name is None:
         raise ValueError("tri_set_name must be given if include_perturb_auf and tri_download_flag "
@@ -775,6 +777,7 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
     .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
+
     '''
     tri_name = 'trilegal_auf_simulation'
     f = open('{}/{}.dat'.format(tri_folder, tri_name), "r")

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -27,7 +27,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
                       fit_gal_flag=None, cmau_array=None, wavs=None, z_maxs=None, nzs=None,
                       ab_offsets=None, filter_names=None, al_avs=None, alpha0=None, alpha1=None,
                       alpha_weight=None):
-    """
+    r"""
     Function to perform the creation of the blended object perturbation component
     of the AUF.
 
@@ -122,6 +122,57 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         of internal catalogue sources, from which to calculate local density.
         Must be given if both ``include_perturb_auf`` and
         ``compute_local_density`` are both ``True``.
+    fit_gal_flag : boolean, optional
+        Flag indicating whether to include galaxy counts in derivations of
+        perturbation component of the AUF. Must be given if
+        ``include_perturb_auf`` is ``True``.
+    cmau_array : numpy.ndarray, optional
+        Array of shape ``(5, 2, 4)`` holding the Wilson (2022, RNAAS, ...) [1]_
+        c, m, a, and u values that describe the Schechter parameterisation with
+        wavelength.
+    wavs : list of floats or numpy.ndarray, optional
+        List of central wavelengths of each filter in ``filters``, used to
+        compute appropriate Schechter function parameters for fitting galaxy
+        counts. Must be given if ``include_perturb_auf`` and ``fit_gal_flag``
+        are ``True``.
+    z_maxs : list of floats or numpy.ndarray, optional
+        List of maximum redshifts to compute galaxy densities out to when
+        deriving Schechter functions. Must be given if ``include_perturb_auf``
+        and ``fit_gal_flag`` are ``True``.
+    nzs : list of integers or numpy.ndarray, optional
+        Resolution of redshift grid, in the sense of ``np.linspace(0, z_max, nz)``,
+        to evaluate Schechter functions on. Must be given if
+        ``include_perturb_auf`` and ``fit_gal_flag`` are ``True``.
+    ab_offsets : list of floats or numpy.ndarray, optional
+        For filters in a non-AB magnitude system, the given offset between
+        the chosen filter system and AB magnitudes, in the sense of m = m_AB -
+        ab_offset. Must be given if ``include_perturb_auf`` and ``fit_gal_flag``
+        are ``True``.
+    filter_names : list of string, optional
+        Names for each filter in ``filters`` in a ``speclite``-appropriate
+        naming scheme (``group_name``-``band_name``), for loading response
+        curves to calculate galaxy k-corrections. Must be given if
+        ``include_perturb_auf`` and ``fit_gal_flag`` are ``True``.
+    al_avs : list of numpy.ndarray or numpy.ndarray, optional
+        Relative extinction curve vectors for each filter in ``filters``,
+        :math:`\frac{A_\lambda}{A_V}`, to convert exinction in the V-band
+        to extinction in the relevant filter. Must be given if
+        ``include_perturb_auf`` and ``fit_gal_flag`` are ``True``.
+    alpha0 : list of numpy.ndarray or numpy.ndarray, optional
+        Indices used to calculate parameters :math:`\alpha_i`, used in deriving
+        Dirichlet-distributed SED coefficients. :math:`\alpha{i, 0}` are the
+        zero-redshift parameters; see [2]_ and [3]_ for more details.
+    alpha1 : list of numpy.ndarray or numpy.ndarray, optional
+        :math:`\alpha_{i, 1}`, indices at redshift z=1 used to derive
+        Dirichlet-distributed SED coefficient values :math:`\alpha_i`.
+    alpha_weight : list of numpy.ndarray or numpy.ndarray, optional
+        Weights for use in calculating :math:`\alpha_i` from ``alpha0`` and
+        ``alpha1``.
+    References
+    ----------
+    .. [1] Wilson T. J. (2022), RNAAS, ...
+    .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
+    .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
     """
     if include_perturb_auf and tri_download_flag and tri_set_name is None:
         raise ValueError("tri_set_name must be given if include_perturb_auf and tri_download_flag "

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -127,7 +127,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         perturbation component of the AUF. Must be given if
         ``include_perturb_auf`` is ``True``.
     cmau_array : numpy.ndarray, optional
-        Array of shape ``(5, 2, 4)`` holding the Wilson (2022, RNAAS, ...) [1]_
+        Array of shape ``(5, 2, 4)`` holding the Wilson (2022, RNAAS, 6, 60) [1]_
         c, m, a, and u values that describe the Schechter parameterisation with
         wavelength.
     wavs : list of floats or numpy.ndarray, optional
@@ -170,7 +170,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         ``alpha1``.
     References
     ----------
-    .. [1] Wilson T. J. (2022), RNAAS, ...
+    .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
     """
@@ -735,7 +735,7 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
     cmau_array : numpy.ndarray, optional
         Array holding the c/m/a/u values that describe the parameterisation
         of the Schechter functions with wavelength, following Wilson (2022, RNAAS,
-        ...) [1]_. Shape should be `(5, 2, 4)`, with 5 parameters for both blue
+        6, 60) [1]_. Shape should be `(5, 2, 4)`, with 5 parameters for both blue
         and red galaxies.
     wav : float, optional
         Wavelength, in microns, of the filter of the current observations.
@@ -772,7 +772,7 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
 
     References
     ----------
-    .. [1] Wilson T. J. (2022), RNAAS, ...
+    .. [1] Wilson T. J. (2022), RNAAS, 6, 60
     .. [2] Herbel J., Kacprzak T., Amara A., et al. (2017), JCAP, 8, 35
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
     '''

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -738,10 +738,12 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
     maxmag = d_mag * np.ceil(np.amax(tri_mags)/d_mag)
     hist, model_mags = np.histogram(tri_mags, bins=np.arange(minmag, maxmag+1e-10, d_mag))
     model_mags_interval = np.diff(model_mags)
+    model_mag_mids = model_mags[:-1]+model_mags_interval/2
 
     hist = hist / model_mags_interval / tri_area
     log10y_tri = np.log10(hist)
 
+    # TODO: add extinction reddening!
     if fit_gal_flag:
         z_array = np.linspace(0, z_max, nz)
         gal_dens = create_galaxy_counts(cmau_array, model_mags, z_array, wav, alpha0, alpha1,
@@ -781,7 +783,7 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
                                                         len(count_array)))
     Frac, Flux, fourieroffset, offset, cumulative = paf.perturb_aufs(
         count_array, mag_array, r[:-1]+dr/2, dr, r, j0s.T,
-        model_mags+model_mags_interval/2, model_mags_interval, log10y, model_count,
+        model_mag_mids, model_mags_interval, log10y, model_count,
         int(dm_max/d_mag) * np.ones_like(count_array), mag_cut, R, num_trials, seed)
     np.save('{}/{}/frac.npy'.format(tri_folder, filt), Frac)
     np.save('{}/{}/flux.npy'.format(tri_folder, filt), Flux)

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -25,7 +25,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
                       auf_region_frame=None, num_trials=None, j0s=None, density_mags=None,
                       dm_max=None, d_mag=None, compute_local_density=None, density_radius=None,
                       fit_gal_flag=None, cmau_array=None, wavs=None, z_maxs=None, nzs=None,
-                      ab_offsets=None, filter_names=None, alpha0=None, alpha1=None,
+                      ab_offsets=None, filter_names=None, al_avs=None, alpha0=None, alpha1=None,
                       alpha_weight=None):
     """
     Function to perform the creation of the blended object perturbation component
@@ -169,6 +169,8 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         raise ValueError("ab_offsets must be given if fit_gal_flag is True.")
     if include_perturb_auf and fit_gal_flag and filter_names is None:
         raise ValueError("filter_names must be given if fit_gal_flag is True.")
+    if include_perturb_auf and fit_gal_flag and al_avs is None:
+        raise ValueError("al_avs must be given if fit_gal_flag is True.")
     if include_perturb_auf and fit_gal_flag and alpha0 is None:
         raise ValueError("alpha0 must be given if fit_gal_flag is True.")
     if include_perturb_auf and fit_gal_flag and alpha1 is None:
@@ -304,7 +306,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
                         ax_folder, filters[j], r, dr, rho, drho, j0s, num_trials, psf_fwhms[j],
                         tri_filt_names[j], density_mags[j], a_photo, localN, dm_max, d_mag,
                         delta_mag_cuts, fit_gal_flag, cmau_array, wavs[j], z_maxs[j], nzs[j],
-                        alpha0, alpha1, alpha_weight, ab_offsets[j], filter_names[j])
+                        alpha0, alpha1, alpha_weight, ab_offsets[j], filter_names[j], al_avs[j])
                 else:
                     Narray = create_single_perturb_auf(
                         ax_folder, filters[j], r, dr, rho, drho, j0s, num_trials, psf_fwhms[j],

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -736,11 +736,11 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
 
     minmag = d_mag * np.floor(np.amin(tri_mags)/d_mag)
     maxmag = d_mag * np.ceil(np.amax(tri_mags)/d_mag)
-    hist, model_mags = np.histogram(tri_mags, bins=np.arange(minmag, maxmag+1e-10, d_mag))
+    h, model_mags = np.histogram(tri_mags, bins=np.arange(minmag, maxmag+1e-10, d_mag))
     model_mags_interval = np.diff(model_mags)
     model_mag_mids = model_mags[:-1]+model_mags_interval/2
 
-    hist = hist / model_mags_interval / tri_area
+    hist = h / model_mags_interval / tri_area
     log10y_tri = np.log10(hist)
 
     # TODO: add extinction reddening!
@@ -755,6 +755,12 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
     else:
         gal_count = 0
         log10y_gal = -np.inf * np.ones_like(log10y_tri)
+
+        # If we're not generating galaxy counts, we have to solely rely on
+        # TRILEGAL counting statistics, so we only want to keep populated bins.
+        hc = np.where(h > 3)[0]
+        model_mag_mids = model_mag_mids[hc]
+        model_mags_interval = model_mags_interval[hc]
 
     model_count = tri_count + gal_count
     log10y = np.log10(10**log10y_tri + 10**log10y_gal)

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -748,7 +748,7 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
         z_array = np.linspace(0, z_max, nz)
         gal_dens = create_galaxy_counts(cmau_array, model_mag_mids, z_array, wav, alpha0, alpha1,
                                         alpha_weight, ab_offset, filter_name)
-        max_mag_bin = np.argwhere(model_mags[1:] <= density_mag)[0][-1]
+        max_mag_bin = np.argwhere(model_mags[1:] <= density_mag)[0][-1] + 1
         gal_count = np.sum(gal_dens[:max_mag_bin]*model_mags_interval[:max_mag_bin])
         log10y_gal = -np.inf * np.ones_like(log10y_tri)
         log10y_gal[gal_dens > 0] = np.log10(gal_dens[gal_dens > 0])

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -746,7 +746,8 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
     model_mag_mids = model_mags[:-1]+model_mags_interval/2
 
     hist = h / model_mags_interval / tri_area
-    log10y_tri = np.log10(hist)
+    log10y_tri = -np.inf * np.ones_like(hist)
+    log10y_tri[hist > 0] = np.log10(hist[hist > 0])
 
     if fit_gal_flag:
         al_inf = al_av * av_inf
@@ -766,6 +767,7 @@ def create_single_perturb_auf(tri_folder, filt, r, dr, rho, drho, j0s, num_trial
         hc = np.where(h > 3)[0]
         model_mag_mids = model_mag_mids[hc]
         model_mags_interval = model_mags_interval[hc]
+        log10y_tri = log10y_tri[hc]
 
     model_count = tri_count + gal_count
     log10y = np.log10(10**log10y_tri + 10**log10y_gal)

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -19,6 +19,8 @@ tri_filt_names = G_BP G G_RP
 tri_filt_num = 1
 # Flag to determine whether to re-download TRILEGAL simulations if they exist - must be "yes"/"no", "true"/"false", "t"/"f", or "1"/"0"
 download_tri = no
+# Galaxy Perturbation AUF parameters
+fit_gal_flag = no
 
 # AUF region definition - either "rectangle" for NxM evenly spaced grid points, or "points" to define a list of two-point tuple coordinates, separated by a comma
 auf_region_type = rectangle

--- a/macauff/tests/data/cat_b_params.txt
+++ b/macauff/tests/data/cat_b_params.txt
@@ -19,6 +19,8 @@ tri_filt_names = W1 W2 W3 W4
 tri_filt_num = 11
 # Flag to determine whether to re-download TRILEGAL simulations if they exist - must be "yes"/"no", "true"/"false", "t"/"f", or "1"/"0"
 download_tri = no
+# Galaxy Perturbation AUF parameters
+fit_gal_flag = no
 
 # AUF region definition - either "rectangle" for NxM evenly spaced grid points, or "points" to define a list of two-point tuple coordinates, separated by a comma
 auf_region_type = rectangle

--- a/macauff/tests/test_galaxy_counts.py
+++ b/macauff/tests/test_galaxy_counts.py
@@ -62,7 +62,7 @@ class TestCreateGalaxyCounts():
         filter_name = 'wise2010-w1'
         gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
                                         gal_values.alpha0, gal_values.alpha1,
-                                        gal_values.alphaweight, self.ab_offset, filter_name)
+                                        gal_values.alphaweight, self.ab_offset, filter_name, 0)
         tot_fake_sch = np.zeros_like(gal_dens)
         for i in [0, 1]:
             fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
@@ -84,14 +84,14 @@ class TestCreateGalaxyCounts():
 
         gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
                                         gal_values.alpha0, gal_values.alpha1,
-                                        gal_values.alphaweight, self.ab_offset, filter_name)
+                                        gal_values.alphaweight, self.ab_offset, filter_name, 1.5)
         tot_fake_sch = np.zeros_like(gal_dens)
         for i in [0, 1]:
             fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
             fake_schechter = (0.4 * np.log(10) * fake_phi *
                               (10**(-0.4 * (self.fake_mags - fake_m)))**(fake_alpha+1) *
                               np.exp(-10**(-0.4 * (self.fake_mags - fake_m))))
-            tot_fake_sch += np.interp(self.mag_bins, self.fake_app_mags,
+            tot_fake_sch += np.interp(self.mag_bins, self.fake_app_mags + 1.5,
                                       fake_schechter) * self.dV_dOmega
 
         assert_allclose(tot_fake_sch, gal_dens, rtol=0.01, atol=1e-4)

--- a/macauff/tests/test_galaxy_counts.py
+++ b/macauff/tests/test_galaxy_counts.py
@@ -59,7 +59,7 @@ class TestCreateGalaxyCounts():
 
     def test_create_galaxy_counts(self):
         wav = 3.4  # microns
-        filter_name = 'wise2010-w1'
+        filter_name = 'wise2010-W1'
         gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
                                         gal_values.alpha0, gal_values.alpha1,
                                         gal_values.alphaweight, self.ab_offset, filter_name, 0)

--- a/macauff/tests/test_galaxy_counts.py
+++ b/macauff/tests/test_galaxy_counts.py
@@ -1,0 +1,97 @@
+# Licensed under a 3-clause BSD style license - see LICENSE
+'''
+Tests for the "galaxy_counts" module.
+'''
+
+import numpy as np
+from numpy.testing import assert_allclose
+import astropy.units as u
+from ..galaxy_counts import create_galaxy_counts, generate_speclite_filters
+from .test_perturbation_auf import GalCountValues
+
+gal_values = GalCountValues()
+
+
+class TestCreateGalaxyCounts():
+    def setup_class(self):
+        self.mag_bins = np.arange(10, 15, 0.1)
+        self.z_array = np.array([0, 0.01])
+
+        self.ab_offset = 0
+
+        # Avoid using astropy's functions to independently check working.
+        # For LambdaCDM, H0 = 67.7 km/s/Mpc, Ol = 0.69, Om = 0.31, Ok = 0:
+        # From e.g. https://ned.ipac.caltech.edu/level5/Hogg/Hogg_contents.html:
+        # dV = dh * (1+z)**2 * da**2 / E(z) dO dz
+        # da = dm / (1 + z); dm = dc for Omega_k = 0; dc = dh \int_0^z dz' / E(z')
+        # dV = dh**3 * (\int_0^z dz' / E(z'))**2 / E(z) dOdz
+        # E(z) = sqrt(Om (1+z)^3 + Ok (1 + z)^2 + Ol) = sqrt(Om (1+z)^3 + Ol)
+        Om, Ol = 0.31, 0.69
+        hubble_distance = 3000/0.677  # 3000/h Mpc
+        __z = np.linspace(self.z_array[0], self.z_array[1], 1001)
+        E__z = np.sqrt(Om * (1 + __z)**3 + Ol)
+        int_ez = np.sum(1/E__z) * (__z[1] - __z[0])
+        _dV_dOmega_dz_1 = 0  # at exactly z = 0 \int_0^z dz' / E(z') = 0
+        sterad_per_sq_deg = (np.pi/180)**2
+        _dV_dOmega_dz_2 = hubble_distance**3 * int_ez**2 / E__z[-1] * sterad_per_sq_deg
+        self.dV_dOmega = 0.5 * (_dV_dOmega_dz_1 + _dV_dOmega_dz_2) * np.diff(self.z_array)
+
+        self.fake_mags = np.linspace(-60, 50, 1101)
+        # m ~= M + 5 log10(dl(z)) + 25; dl = (1 + z) * dm = (1 + z) * dh \int_0^z dz' / E(z')
+        __z = np.linspace(self.z_array[0], 0.5 * np.sum(self.z_array), 1001)
+        E__z = np.sqrt(Om * (1 + __z)**3 + Ol)
+        int_ez = np.sum(1/E__z) * (__z[1] - __z[0])
+        dl = (1 + 0.5 * np.sum(self.z_array)) * hubble_distance * int_ez
+        self.fake_app_mags = self.fake_mags + 5 * np.log10(dl) + 25
+
+    def _calculate_params(self, lwav, i):
+        # Assume we're close enough to zero redshift to not need P and Q.
+        _cmau = gal_values.cmau[:, i, :]
+        fake_m = _cmau[0, 2] * np.exp(-lwav * _cmau[0, 1]) + _cmau[0, 0]
+        if i == 0:
+            fake_phi = _cmau[1, 2] * np.exp(-lwav * _cmau[1, 1]) + _cmau[1, 0]
+        else:
+            fake_phi = _cmau[1, 2] * np.exp(-0.5 * (lwav - _cmau[1, 3])**2 *
+                                            _cmau[1, 1]) + _cmau[1, 0]
+        fake_alpha = _cmau[2, 1] * lwav + _cmau[2, 0]
+
+        return fake_m, fake_phi, fake_alpha
+
+    def test_create_galaxy_counts(self):
+        wav = 3.4  # microns
+        filter_name = 'wise2010-w1'
+        gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
+                                        gal_values.alpha0, gal_values.alpha1,
+                                        gal_values.alphaweight, self.ab_offset, filter_name)
+        tot_fake_sch = np.zeros_like(gal_dens)
+        for i in [0, 1]:
+            fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
+            fake_schechter = (0.4 * np.log(10) * fake_phi *
+                              (10**(-0.4 * (self.fake_mags - fake_m)))**(fake_alpha+1) *
+                              np.exp(-10**(-0.4 * (self.fake_mags - fake_m))))
+            tot_fake_sch += np.interp(self.mag_bins, self.fake_app_mags,
+                                      fake_schechter) * self.dV_dOmega
+
+        assert_allclose(tot_fake_sch, gal_dens, rtol=0.01, atol=1e-4)
+
+    def test_create_filter_and_galaxy_counts(self):
+        wav = 0.16  # microns
+        f, n = 'filter', 'uuu'
+        filter_name = '{}-{}'.format(f, n)
+
+        generate_speclite_filters(f, [n], [np.array([0.159, 0.16, 0.161])], [np.array([0, 1, 0])],
+                                  u.micron)
+
+        gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
+                                        gal_values.alpha0, gal_values.alpha1,
+                                        gal_values.alphaweight, self.ab_offset, filter_name)
+        tot_fake_sch = np.zeros_like(gal_dens)
+        for i in [0, 1]:
+            fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
+            fake_schechter = (0.4 * np.log(10) * fake_phi *
+                              (10**(-0.4 * (self.fake_mags - fake_m)))**(fake_alpha+1) *
+                              np.exp(-10**(-0.4 * (self.fake_mags - fake_m))))
+            tot_fake_sch += np.interp(self.mag_bins, self.fake_app_mags,
+                                      fake_schechter) * self.dV_dOmega
+
+        assert_allclose(tot_fake_sch, gal_dens, rtol=0.01, atol=1e-4)

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -576,7 +576,7 @@ class TestInputs:
         new_line = ('fit_gal_flag = yes\ngal_wavs = 3.37 4.62 12.08 22.19\n'
                     'gal_zmax = 3.2 4.0 1 4\ngal_nzs = 33 41 11 41\n'
                     'gal_aboffsets = 0.5 0.5 0.5 0.5\n'
-                    'gal_filternames = wise2010-w1 wise2010-w2 wise2010-w3 wise2010-w4\n'
+                    'gal_filternames = wise2010-W1 wise2010-W2 wise2010-W3 wise2010-W4\n'
                     'gal_al_avs = 0.039 0.026 0.015 0.005\n')
         idx = np.where([old_line in line for line in f])[0][0]
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'), idx,
@@ -616,7 +616,7 @@ class TestInputs:
                  'gal_al_avs = 0.589 0.789 1.002', 'gal_al_avs = 0.589 0.789 1.002'],
                 ['gal_wavs = 0.513 0.641\n', 'gal_aboffsets = a 0.5 0.5 0.5\n',
                  'gal_nzs = 46 a 51\n', 'gal_nzs = 33.1 41 11 41\n', 'gal_nzs = 33 41 11\n',
-                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP wise2010-w1\n',
+                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP wise2010-W1\n',
                  'gal_al_avs = words\n', 'gal_al_avs = 0.789 1.002\n'],
                 ['a_gal_wavs and a_filt_names should contain the same number',
                  'gal_aboffsets should be a list of floats in catalogue "b"',

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -565,7 +565,8 @@ class TestInputs:
         new_line = ('fit_gal_flag = yes\ngal_wavs = 0.513 0.641 0.778\n'
                     'gal_zmax = 4.5 4.5 5\ngal_nzs = 46 46 51\n'
                     'gal_aboffsets = 0.5 0.5 0.5\n'
-                    'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP\n')
+                    'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP\n'
+                    'gal_al_avs = 0.589 0.789 1.002\n')
         idx = np.where([old_line in line for line in f])[0][0]
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'), idx,
                       new_line, out_file=os.path.join(os.path.dirname(__file__),
@@ -575,7 +576,8 @@ class TestInputs:
         new_line = ('fit_gal_flag = yes\ngal_wavs = 3.37 4.62 12.08 22.19\n'
                     'gal_zmax = 3.2 4.0 1 4\ngal_nzs = 33 41 11 41\n'
                     'gal_aboffsets = 0.5 0.5 0.5 0.5\n'
-                    'gal_filternames = wise2010-w1 wise2010-w2 wise2010-w3 wise2010-w4\n')
+                    'gal_filternames = wise2010-w1 wise2010-w2 wise2010-w3 wise2010-w4\n'
+                    'gal_al_avs = 0.039 0.026 0.015 0.005\n')
         idx = np.where([old_line in line for line in f])[0][0]
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'), idx,
                       new_line, out_file=os.path.join(os.path.dirname(__file__),
@@ -593,7 +595,7 @@ class TestInputs:
 
         f = open(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt')).readlines()
         for i, key in enumerate(['gal_wavs', 'gal_zmax', 'gal_nzs',
-                                 'gal_aboffsets', 'gal_filternames']):
+                                 'gal_aboffsets', 'gal_filternames', 'gal_al_avs']):
             idx = np.where([key in line for line in f])[0][0]
             _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'),
                           idx, '', out_file=os.path.join(os.path.dirname(__file__),
@@ -610,18 +612,22 @@ class TestInputs:
         for old_line, new_line, match_text, file in zip(
                 ['gal_wavs = 0.513 0.641 0.778', 'gal_aboffsets = 0.5 0.5 0.5 0.5',
                  'gal_nzs = 46 46 51', 'gal_nzs = 33 41 11 41', 'gal_nzs = 33 41 11 41',
-                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP'],
+                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP',
+                 'gal_al_avs = 0.589 0.789 1.002', 'gal_al_avs = 0.589 0.789 1.002'],
                 ['gal_wavs = 0.513 0.641\n', 'gal_aboffsets = a 0.5 0.5 0.5\n',
                  'gal_nzs = 46 a 51\n', 'gal_nzs = 33.1 41 11 41\n', 'gal_nzs = 33 41 11\n',
-                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP wise2010-w1'],
+                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP wise2010-w1\n',
+                 'gal_al_avs = words\n', 'gal_al_avs = 0.789 1.002\n'],
                 ['a_gal_wavs and a_filt_names should contain the same number',
                  'gal_aboffsets should be a list of floats in catalogue "b"',
                  'gal_nzs should be a list of integers in catalogue "a"',
                  'All elements of b_gal_nzs should be integers.',
                  'b_gal_nzs and b_filt_names should contain the same number of entries.',
-                 'a_gal_filternames and a_filt_names should contain the same number of entries.'],
+                 'a_gal_filternames and a_filt_names should contain the same number of entries.',
+                 'gal_al_avs should be a list of floats in catalogue "a"',
+                 'a_gal_al_avs and a_filt_names should contain the same number of entries.'],
                 ['cat_a_params', 'cat_b_params', 'cat_a_params', 'cat_b_params', 'cat_b_params',
-                 'cat_a_params']):
+                 'cat_a_params', 'cat_a_params', 'cat_a_params']):
             f = open(os.path.join(os.path.dirname(__file__),
                                   'data/{}_.txt'.format(file))).readlines()
             idx = np.where([old_line in line for line in f])[0][0]

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -542,6 +542,101 @@ class TestInputs:
                                 os.path.join(os.path.dirname(__file__),
                                 'data/cat_b_params.txt'))
 
+        for cat_reg, cat_name in zip(['"a"', '"b"'], ['cat_a_params', 'cat_b_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                     'data/{}.txt'.format(cat_name))).readlines()
+            old_line = 'fit_gal_flag = no'
+            new_line = ''
+            idx = np.where([old_line in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__),
+                          'data/{}.txt'.format(cat_name)), idx, new_line, out_file=os.path.join(
+                          os.path.dirname(__file__), 'data/{}_.txt'.format(cat_name)))
+            with pytest.raises(ValueError,
+                               match='Missing key fit_gal_flag from catalogue {}'.format(cat_reg)):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if 'a' in cat_reg else '')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if 'b' in cat_reg else '')))
+
+        f = open(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt')).readlines()
+        old_line = 'fit_gal_flag = no'
+        new_line = ('fit_gal_flag = yes\ngal_wavs = 0.513 0.641 0.778\n'
+                    'gal_zmax = 4.5 4.5 5\ngal_nzs = 46 46 51\n'
+                    'gal_aboffsets = 0.5 0.5 0.5\n'
+                    'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP\n')
+        idx = np.where([old_line in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'), idx,
+                      new_line, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/cat_a_params_.txt'))
+        f = open(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt')).readlines()
+        old_line = 'fit_gal_flag = no'
+        new_line = ('fit_gal_flag = yes\ngal_wavs = 3.37 4.62 12.08 22.19\n'
+                    'gal_zmax = 3.2 4.0 1 4\ngal_nzs = 33 41 11 41\n'
+                    'gal_aboffsets = 0.5 0.5 0.5 0.5\n'
+                    'gal_filternames = wise2010-w1 wise2010-w2 wise2010-w3 wise2010-w4\n')
+        idx = np.where([old_line in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'), idx,
+                      new_line, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/cat_b_params_.txt'))
+
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                        'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__),
+                        'data/cat_a_params_.txt'),
+                        os.path.join(os.path.dirname(__file__),
+                        'data/cat_b_params_.txt'))
+        assert_allclose(cm.a_gal_zmax, np.array([4.5, 4.5, 5.0]))
+        assert np.all(cm.b_gal_nzs == np.array([33, 41, 11, 41]))
+        assert np.all(cm.a_gal_filternames == ['gaiadr2-BP', 'gaiadr2-G', 'gaiadr2-RP'])
+
+        f = open(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt')).readlines()
+        for i, key in enumerate(['gal_wavs', 'gal_zmax', 'gal_nzs',
+                                 'gal_aboffsets', 'gal_filternames']):
+            idx = np.where([key in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'),
+                          idx, '', out_file=os.path.join(os.path.dirname(__file__),
+                          'data/cat_b_params__.txt'))
+            with pytest.raises(ValueError,
+                               match='Missing key {} from catalogue "b"'.format(key)):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params_.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params__.txt'))
+
+        for old_line, new_line, match_text, file in zip(
+                ['gal_wavs = 0.513 0.641 0.778', 'gal_aboffsets = 0.5 0.5 0.5 0.5',
+                 'gal_nzs = 46 46 51', 'gal_nzs = 33 41 11 41', 'gal_nzs = 33 41 11 41',
+                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP'],
+                ['gal_wavs = 0.513 0.641\n', 'gal_aboffsets = a 0.5 0.5 0.5\n',
+                 'gal_nzs = 46 a 51\n', 'gal_nzs = 33.1 41 11 41\n', 'gal_nzs = 33 41 11\n',
+                 'gal_filternames = gaiadr2-BP gaiadr2-G gaiadr2-RP wise2010-w1'],
+                ['a_gal_wavs and a_filt_names should contain the same number',
+                 'gal_aboffsets should be a list of floats in catalogue "b"',
+                 'gal_nzs should be a list of integers in catalogue "a"',
+                 'All elements of b_gal_nzs should be integers.',
+                 'b_gal_nzs and b_filt_names should contain the same number of entries.',
+                 'a_gal_filternames and a_filt_names should contain the same number of entries.'],
+                ['cat_a_params', 'cat_b_params', 'cat_a_params', 'cat_b_params', 'cat_b_params',
+                 'cat_a_params']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/{}_.txt'.format(file))).readlines()
+            idx = np.where([old_line in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__),
+                          'data/{}_.txt'.format(file)), idx, new_line, out_file=os.path.join(
+                          os.path.dirname(__file__), 'data/{}__.txt'.format(file)))
+
+            with pytest.raises(ValueError, match=match_text):
+                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                'data/crossmatch_params_.txt'),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_a_params{}.txt'.format('_' if '_b_' in file else '__')),
+                                os.path.join(os.path.dirname(__file__),
+                                'data/cat_b_params{}.txt'.format('_' if '_a_' in file else '__')))
+
     def test_crossmatch_fourier_inputs(self):
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -297,8 +297,8 @@ def test_circle_area():
         done += 1
 
 
-class TestCreateGalaxyCounts():
-    def setup_class(self):
+class GalCountValues():
+    def __init__(self):
         # Update these values if this is changed in CrossMatch
         self.cmau = np.empty((5, 2, 4), float)
         self.cmau[0, :, :] = [[-24.286513, 1.141760, 2.655846, np.nan],
@@ -316,6 +316,12 @@ class TestCreateGalaxyCounts():
         self.alphaweight = [[3.47e+09, 3.31e+06, 2.13e+09, 1.64e+10, 1.01e+09],
                             [3.84e+09, 1.57e+06, 3.91e+08, 4.66e+10, 3.03e+07]]
 
+
+gal_values = GalCountValues()
+
+
+class TestCreateGalaxyCounts():
+    def setup_class(self):
         self.mag_bins = np.arange(10, 15, 0.1)
         self.z_array = np.array([0, 0.01])
 
@@ -348,7 +354,7 @@ class TestCreateGalaxyCounts():
 
     def _calculate_params(self, lwav, i):
         # Assume we're close enough to zero redshift to not need P and Q.
-        _cmau = self.cmau[:, i, :]
+        _cmau = gal_values.cmau[:, i, :]
         fake_m = _cmau[0, 2] * np.exp(-lwav * _cmau[0, 1]) + _cmau[0, 0]
         if i == 0:
             fake_phi = _cmau[1, 2] * np.exp(-lwav * _cmau[1, 1]) + _cmau[1, 0]
@@ -362,8 +368,9 @@ class TestCreateGalaxyCounts():
     def test_create_galaxy_counts(self):
         wav = 3.4  # microns
         filter_name = 'wise2010-w1'
-        gal_dens = create_galaxy_counts(self.cmau, self.mag_bins, self.z_array, wav, self.alpha0,
-                                        self.alpha1, self.alphaweight, self.ab_offset, filter_name)
+        gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
+                                        gal_values.alpha0, gal_values.alpha1,
+                                        gal_values.alphaweight, self.ab_offset, filter_name)
         tot_fake_sch = np.zeros_like(gal_dens)
         for i in [0, 1]:
             fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
@@ -383,8 +390,9 @@ class TestCreateGalaxyCounts():
         generate_speclite_filters(f, [n], [np.array([0.159, 0.16, 0.161])], [np.array([0, 1, 0])],
                                   u.micron)
 
-        gal_dens = create_galaxy_counts(self.cmau, self.mag_bins, self.z_array, wav, self.alpha0,
-                                        self.alpha1, self.alphaweight, self.ab_offset, filter_name)
+        gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
+                                        gal_values.alpha0, gal_values.alpha1,
+                                        gal_values.alphaweight, self.ab_offset, filter_name)
         tot_fake_sch = np.zeros_like(gal_dens)
         for i in [0, 1]:
             fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
@@ -772,6 +780,161 @@ class TestMakePerturbAUFs():
         cm.num_trials = self.num_trials
         cm.a_fit_gal_flag = False
         cm.b_fit_gal_flag = False
+
+        cm.create_perturb_auf(self.files_per_auf_sim)
+
+        fracs = np.load('{}/{}/{}/{}/frac.npy'.format(
+            self.auf_folder, ax1, ax2, self.filters[0]))
+        fluxs = np.load('{}/{}/{}/{}/flux.npy'.format(
+            self.auf_folder, ax1, ax2, self.filters[0]))
+        fourier = np.load('{}/{}/{}/{}/fourier.npy'.format(
+            self.auf_folder, ax1, ax2, self.filters[0]))
+
+        assert_allclose(fracs[0, 0], 1-prob_0_draw, rtol=0.1)
+        assert_allclose(fluxs[0], (prob_0_draw*0 + prob_1_draw*rel_flux +
+                        prob_2_draw*2*rel_flux), rtol=0.1)
+
+        R = 1.185 * self.psf_fwhms[0]
+        small_R = R * rel_flux / (1 + rel_flux)
+
+        fake_fourier = (1-prob_0_draw) / (np.pi * small_R * (cm.rho[:-1]+cm.drho/2)) * j1(
+            2 * np.pi * small_R * (cm.rho[:-1]+cm.drho/2))
+        fake_fourier += prob_0_draw * j0(2 * np.pi * (cm.r[0]+cm.dr[0]/2) *
+                                         (cm.rho[:-1]+cm.drho/2))
+
+        assert_allclose(fake_fourier, fourier[:, 0], rtol=0.05)
+
+    def test_with_galaxy_counts(self):
+        # Number of sources per PSF circle, on average, solved backwards to ensure
+        # that local density ends up exactly in the middle of a count_array bin.
+        # This should be approximately 0.076 sources per PSF circle.
+        psf_mean = np.exp(8.7) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
+        # Local density is the controllable variable to ensure that we get
+        # the expected sources per PSF circle, with most variables cancelling
+        # mean divided by circle area sets the density needed.
+        local_dens = psf_mean / (np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2)
+        np.save('{}/local_N.npy'.format(self.auf_folder), np.array([[local_dens]]))
+
+        np.save('{}/con_cat_astro.npy'.format(self.cat_folder), np.array([[0.3, 0.3, 0.1]]))
+        np.save('{}/con_cat_photo.npy'.format(self.cat_folder), np.array([[14.99]]))
+        np.save('{}/magref.npy'.format(self.cat_folder), np.array([0]))
+
+        # Fake up a TRILEGAL simulation data file. Need to paste the same source
+        # four times to pass a check for more than three sources in a histogram.
+        text = ('#area = 4.0 sq deg\n#Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
+                'm2/m1 mbol   J      H      Ks     IRAC_3.6 IRAC_4.5 IRAC_5.8 IRAC_8.0 MIPS_24 ' +
+                'MIPS_70 MIPS_160 W1     W2     W3     W4       Mact\n 1   6.65 -0.39  0.02415 ' +
+                '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
+                '22.387 22.292 22.015 21.144 19.380 20.878 15.001 22.391 21.637 21.342  0.024\n ' +
+                '1   6.65 -0.39  0.02415 -2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 ' +
+                '24.409 23.524 22.583 22.387 22.292 22.015 21.144 19.380 20.878 15.002 22.391 ' +
+                '21.637 21.342  0.024\n 1   6.65 -0.39  0.02415 -2.701 3.397  4.057 14.00  ' +
+                '8.354 0.00 25.523 25.839 24.409 23.524 22.583 22.387 22.292 22.015 21.144 ' +
+                '19.380 20.878 15.003 22.391 21.637 21.342  0.024\n 1   6.65 -0.39  0.02415 ' +
+                '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
+                '22.387 22.292 22.015 21.144 19.380 20.878 15.004 22.391 21.637 21.342  0.024')
+        os.makedirs('{}/{}/{}'.format(
+            self.auf_folder, self.auf_points[0][0], self.auf_points[0][1]), exist_ok=True)
+        with open('{}/{}/{}/trilegal_auf_simulation.dat'.format(
+                  self.auf_folder, self.auf_points[0][0], self.auf_points[0][1]), "w") as f:
+            f.write(text)
+
+        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / np.math.factorial(0)
+        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / np.math.factorial(1)
+        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / np.math.factorial(2)
+
+        ax1, ax2 = self.auf_points[0]
+
+        # Catalogue bins for the source:
+        a_photo = np.load('{}/con_cat_photo.npy'.format(self.cat_folder))
+        dmag = 0.25
+        mag_min = dmag * np.floor(np.amin(a_photo)/dmag)
+        mag_max = dmag * np.ceil(np.amax(a_photo)/dmag)
+        mag_bins = np.arange(mag_min, mag_max+1e-10, dmag)
+        mag_bin = 0.5 * (mag_bins[1:]+mag_bins[:-1])
+        # Model magnitude bins:
+        d_mag = 0.1
+        tri_mags = np.array([15.001, 15.002, 15.003, 15.004])
+        minmag = d_mag * np.floor(np.amin(tri_mags)/d_mag)
+        maxmag = d_mag * np.ceil(np.amax(tri_mags)/d_mag)
+        mod_bins = np.arange(minmag, maxmag+1e-10, d_mag)
+        mod_bin = mod_bins[:-1] + np.diff(mod_bins)/2
+        mag_offset = mod_bin - mag_bin
+        rel_flux = 10**(-1/2.5 * mag_offset)
+
+        ol, nl = 'include_perturb_auf = no', 'include_perturb_auf = yes\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/crossmatch_params.txt')).readlines()
+        idx = np.where([ol in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                      idx, nl, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/crossmatch_params_.txt'))
+
+        ol, nl = 'filt_names = G_BP G G_RP', 'filt_names = G\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/cat_a_params.txt')).readlines()
+        idx = np.where([ol in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                      idx, nl, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/cat_a_params_.txt'))
+        for ol, nl in zip(['psf_fwhms = 0.12 0.12 0.12', 'cat_folder_path = gaia_folder',
+                           'auf_folder_path = gaia_auf_folder', 'tri_filt_names = G_BP G G_RP',
+                           'dens_mags = 20 20 20'],
+                          ['psf_fwhms = 0.12\n', 'cat_folder_path = cat_folder\n',
+                           'auf_folder_path = auf_folder\n', 'tri_filt_names = W1\n',
+                           'dens_mags = 20\n']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/cat_a_params.txt')).readlines()
+            idx = np.where([ol in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                          idx, nl)
+
+        ol, nl = 'filt_names = W1 W2 W3 W4', 'filt_names = W1\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/cat_b_params.txt')).readlines()
+        idx = np.where([ol in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'),
+                      idx, nl, out_file=os.path.join(os.path.dirname(__file__),
+                      'data/cat_b_params_.txt'))
+        for ol, nl in zip(['psf_fwhms = 6.08 6.84 7.36 11.99', 'cat_folder_path = wise_folder',
+                           'auf_folder_path = wise_auf_folder', 'tri_filt_names = W1 W2 W3 W4',
+                           'dens_mags = 20 20 20 20'],
+                          ['psf_fwhms = 6.08\n', 'cat_folder_path = cat_folder\n',
+                           'auf_folder_path = auf_folder\n', 'tri_filt_names = W1\n',
+                           'dens_mags = 20\n']):
+            f = open(os.path.join(os.path.dirname(__file__),
+                                  'data/cat_b_params.txt')).readlines()
+            idx = np.where([ol in line for line in f])[0][0]
+            _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'),
+                          idx, nl)
+
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+
+        cm.a_auf_region_points = self.auf_points
+        cm.b_auf_region_points = self.auf_points
+        cm.cross_match_extent = self.ax_lims
+        cm.run_auf = True
+        cm.run_group = True
+        cm.run_cf = True
+        cm.run_source = True
+        cm.num_trials = self.num_trials
+        cm.a_fit_gal_flag = True
+        cm.b_fit_gal_flag = True
+
+        cm.a_gal_wavs = np.array([0.641])
+        cm.a_gal_zmax = np.array([0.001])
+        cm.a_gal_nzs = np.array([2])
+        cm.a_gal_aboffsets = np.array([0.105])
+        cm.a_gal_filternames = np.array(['gaiadr2-G'])
+
+        cm.b_gal_wavs = np.array([3.4])
+        cm.b_gal_zmax = np.array([0.001])
+        cm.b_gal_nzs = np.array([2])
+        cm.b_gal_aboffsets = np.array([2.699])
+        cm.b_gal_filternames = ['wise2010-w1']
 
         cm.create_perturb_auf(self.files_per_auf_sim)
 

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -895,6 +895,6 @@ def test_trilegal_download():
     bits = line.split(' ')
     tri_area = float(bits[2])
     tri = np.genfromtxt('{}/{}.dat'.format(tri_folder, tri_name), delimiter=None,
-                        names=True, comments='#', skip_header=1)
+                        names=True, comments='#', skip_header=2)
     assert np.all(tri[:]['G'] <= 32)
     assert tri_area <= 10

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -931,8 +931,8 @@ class TestMakePerturbAUFs():
         cm.a_gal_filternames = np.array(['gaiadr2-G'])
 
         cm.b_gal_wavs = np.array([3.4])
-        cm.b_gal_zmax = np.array([0.001])
-        cm.b_gal_nzs = np.array([2])
+        cm.b_gal_zmax = np.array([1])
+        cm.b_gal_nzs = np.array([10])
         cm.b_gal_aboffsets = np.array([2.699])
         cm.b_gal_filternames = ['wise2010-w1']
 

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -449,7 +449,7 @@ class TestMakePerturbAUFs():
             make_perturb_aufs(*self.args, psf_fwhms=self.psf_fwhms, num_trials=num_trials, j0s=j0s,
                               density_mags=cutoff_mags, dm_max=dm_max, d_mag=d_mag,
                               delta_mag_cuts=self.delta_mag_cuts, compute_local_density=False,
-                              tri_filt_names=self.tri_filt_names)
+                              tri_filt_names=self.tri_filt_names, fit_gal_flag=False)
 
             if i == 0:
                 for name, size in zip(
@@ -619,6 +619,8 @@ class TestMakePerturbAUFs():
         cm.run_cf = True
         cm.run_source = True
         cm.num_trials = self.num_trials
+        cm.a_fit_gal_flag = False
+        cm.b_fit_gal_flag = False
 
         cm.create_perturb_auf(self.files_per_auf_sim)
 

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -472,7 +472,8 @@ class TestMakePerturbAUFs():
 
         # Fake up a TRILEGAL simulation data file. Need to paste the same source
         # four times to pass a check for more than three sources in a histogram.
-        text = ('#area = 4.0 sq deg\n#Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
+        text = ('#area = 4.0 sq deg\n#Av at infinity = 0\n' +
+                'Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
                 'm2/m1 mbol   J      H      Ks     IRAC_3.6 IRAC_4.5 IRAC_5.8 IRAC_8.0 MIPS_24 ' +
                 'MIPS_70 MIPS_160 W1     W2     W3     W4       Mact\n 1   6.65 -0.39  0.02415 ' +
                 '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
@@ -583,7 +584,8 @@ class TestMakePerturbAUFs():
 
         # Fake up a TRILEGAL simulation data file. Need to paste the same source
         # four times to pass a check for more than three sources in a histogram.
-        text = ('#area = 4.0 sq deg\n#Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
+        text = ('#area = 4.0 sq deg\n#Av at infinity = 0\n' +
+                'Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
                 'm2/m1 mbol   J      H      Ks     IRAC_3.6 IRAC_4.5 IRAC_5.8 IRAC_8.0 MIPS_24 ' +
                 'MIPS_70 MIPS_160 W1     W2     W3     W4       Mact\n 1   6.65 -0.39  0.02415 ' +
                 '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +
@@ -734,7 +736,8 @@ class TestMakePerturbAUFs():
 
         # Fake up a TRILEGAL simulation data file. Need to paste the same source
         # four times to pass a check for more than three sources in a histogram.
-        text = ('#area = 4.0 sq deg\n#Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
+        text = ('#area = 4.0 sq deg\n#Av at infinity = 10\n' +
+                'Gc logAge [M/H] m_ini   logL   logTe logg  m-M0   Av    ' +
                 'm2/m1 mbol   J      H      Ks     IRAC_3.6 IRAC_4.5 IRAC_5.8 IRAC_8.0 MIPS_24 ' +
                 'MIPS_70 MIPS_160 W1     W2     W3     W4       Mact\n 1   6.65 -0.39  0.02415 ' +
                 '-2.701 3.397  4.057 14.00  8.354 0.00 25.523 25.839 24.409 23.524 22.583 ' +

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -479,6 +479,55 @@ class TestMakePerturbAUFs():
                               compute_local_density=True, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, dm_max=1, d_mag=1)
 
+        with pytest.raises(ValueError, match='fit_gal_flag must not be None if include_'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1)
+        with pytest.raises(ValueError, match='cmau_array must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True)
+        with pytest.raises(ValueError, match='wavs must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1)
+        with pytest.raises(ValueError, match='z_maxs must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1)
+        with pytest.raises(ValueError, match='nzs must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1)
+        with pytest.raises(ValueError, match='ab_offsets must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1, nzs=1)
+        with pytest.raises(ValueError, match='filter_names must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1)
+        with pytest.raises(ValueError, match='alpha0 must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1)
+        with pytest.raises(ValueError, match='alpha1 must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, alpha0=1)
+        with pytest.raises(ValueError, match='alpha_weight must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, alpha0=1,
+                              alpha1=1)
+
     def test_without_compute_local_density(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -432,22 +432,28 @@ class TestMakePerturbAUFs():
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
                               wavs=1, z_maxs=1, nzs=1, ab_offsets=1)
-        with pytest.raises(ValueError, match='alpha0 must be given if fit_gal_flag is True.'):
+        with pytest.raises(ValueError, match='al_avs must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
                               wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1)
+        with pytest.raises(ValueError, match='alpha0 must be given if fit_gal_flag is True.'):
+            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+                              compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
+                              density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1)
         with pytest.raises(ValueError, match='alpha1 must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
-                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, alpha0=1)
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1,
+                              alpha0=1)
         with pytest.raises(ValueError, match='alpha_weight must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, dm_max=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
-                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, alpha0=1,
-                              alpha1=1)
+                              wavs=1, z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1,
+                              alpha0=1, alpha1=1)
 
     def test_without_compute_local_density(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
@@ -845,12 +851,14 @@ class TestMakePerturbAUFs():
         cm.a_gal_nzs = np.array([2])
         cm.a_gal_aboffsets = np.array([0.105])
         cm.a_gal_filternames = np.array(['gaiadr2-G'])
+        cm.a_gal_al_avs = np.array([0.789])
 
         cm.b_gal_wavs = np.array([3.4])
         cm.b_gal_zmax = np.array([1])
         cm.b_gal_nzs = np.array([10])
         cm.b_gal_aboffsets = np.array([2.699])
         cm.b_gal_filternames = ['wise2010-w1']
+        cm.b_gal_al_avs = np.array([0.030])
 
         cm.create_perturb_auf(self.files_per_auf_sim)
 

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -857,7 +857,7 @@ class TestMakePerturbAUFs():
         cm.b_gal_zmax = np.array([1])
         cm.b_gal_nzs = np.array([10])
         cm.b_gal_aboffsets = np.array([2.699])
-        cm.b_gal_filternames = ['wise2010-w1']
+        cm.b_gal_filternames = ['wise2010-W1']
         cm.b_gal_al_avs = np.array([0.030])
 
         cm.create_perturb_auf(self.files_per_auf_sim)

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -8,13 +8,11 @@ import os
 import numpy as np
 from numpy.testing import assert_allclose
 from scipy.special import j0, j1
-import astropy.units as u
 
 from ..matching import CrossMatch
 from ..misc_functions_fortran import misc_functions_fortran as mff
 from ..perturbation_auf import (make_perturb_aufs, download_trilegal_simulation)
 from ..perturbation_auf_fortran import perturbation_auf_fortran as paf
-from ..galaxy_counts import create_galaxy_counts, generate_speclite_filters
 
 from .test_matching import _replace_line
 
@@ -318,91 +316,6 @@ class GalCountValues():
 
 
 gal_values = GalCountValues()
-
-
-class TestCreateGalaxyCounts():
-    def setup_class(self):
-        self.mag_bins = np.arange(10, 15, 0.1)
-        self.z_array = np.array([0, 0.01])
-
-        self.ab_offset = 0
-
-        # Avoid using astropy's functions to independently check working.
-        # For LambdaCDM, H0 = 67.7 km/s/Mpc, Ol = 0.69, Om = 0.31, Ok = 0:
-        # From e.g. https://ned.ipac.caltech.edu/level5/Hogg/Hogg_contents.html:
-        # dV = dh * (1+z)**2 * da**2 / E(z) dO dz
-        # da = dm / (1 + z); dm = dc for Omega_k = 0; dc = dh \int_0^z dz' / E(z')
-        # dV = dh**3 * (\int_0^z dz' / E(z'))**2 / E(z) dOdz
-        # E(z) = sqrt(Om (1+z)^3 + Ok (1 + z)^2 + Ol) = sqrt(Om (1+z)^3 + Ol)
-        Om, Ol = 0.31, 0.69
-        hubble_distance = 3000/0.677  # 3000/h Mpc
-        __z = np.linspace(self.z_array[0], self.z_array[1], 1001)
-        E__z = np.sqrt(Om * (1 + __z)**3 + Ol)
-        int_ez = np.sum(1/E__z) * (__z[1] - __z[0])
-        _dV_dOmega_dz_1 = 0  # at exactly z = 0 \int_0^z dz' / E(z') = 0
-        sterad_per_sq_deg = (np.pi/180)**2
-        _dV_dOmega_dz_2 = hubble_distance**3 * int_ez**2 / E__z[-1] * sterad_per_sq_deg
-        self.dV_dOmega = 0.5 * (_dV_dOmega_dz_1 + _dV_dOmega_dz_2) * np.diff(self.z_array)
-
-        self.fake_mags = np.linspace(-60, 50, 1101)
-        # m ~= M + 5 log10(dl(z)) + 25; dl = (1 + z) * dm = (1 + z) * dh \int_0^z dz' / E(z')
-        __z = np.linspace(self.z_array[0], 0.5 * np.sum(self.z_array), 1001)
-        E__z = np.sqrt(Om * (1 + __z)**3 + Ol)
-        int_ez = np.sum(1/E__z) * (__z[1] - __z[0])
-        dl = (1 + 0.5 * np.sum(self.z_array)) * hubble_distance * int_ez
-        self.fake_app_mags = self.fake_mags + 5 * np.log10(dl) + 25
-
-    def _calculate_params(self, lwav, i):
-        # Assume we're close enough to zero redshift to not need P and Q.
-        _cmau = gal_values.cmau[:, i, :]
-        fake_m = _cmau[0, 2] * np.exp(-lwav * _cmau[0, 1]) + _cmau[0, 0]
-        if i == 0:
-            fake_phi = _cmau[1, 2] * np.exp(-lwav * _cmau[1, 1]) + _cmau[1, 0]
-        else:
-            fake_phi = _cmau[1, 2] * np.exp(-0.5 * (lwav - _cmau[1, 3])**2 *
-                                            _cmau[1, 1]) + _cmau[1, 0]
-        fake_alpha = _cmau[2, 1] * lwav + _cmau[2, 0]
-
-        return fake_m, fake_phi, fake_alpha
-
-    def test_create_galaxy_counts(self):
-        wav = 3.4  # microns
-        filter_name = 'wise2010-w1'
-        gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
-                                        gal_values.alpha0, gal_values.alpha1,
-                                        gal_values.alphaweight, self.ab_offset, filter_name)
-        tot_fake_sch = np.zeros_like(gal_dens)
-        for i in [0, 1]:
-            fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
-            fake_schechter = (0.4 * np.log(10) * fake_phi *
-                              (10**(-0.4 * (self.fake_mags - fake_m)))**(fake_alpha+1) *
-                              np.exp(-10**(-0.4 * (self.fake_mags - fake_m))))
-            tot_fake_sch += np.interp(self.mag_bins, self.fake_app_mags,
-                                      fake_schechter) * self.dV_dOmega
-
-        assert_allclose(tot_fake_sch, gal_dens, rtol=0.01, atol=1e-4)
-
-    def test_create_filter_and_galaxy_counts(self):
-        wav = 0.16  # microns
-        f, n = 'filter', 'uuu'
-        filter_name = '{}-{}'.format(f, n)
-
-        generate_speclite_filters(f, [n], [np.array([0.159, 0.16, 0.161])], [np.array([0, 1, 0])],
-                                  u.micron)
-
-        gal_dens = create_galaxy_counts(gal_values.cmau, self.mag_bins, self.z_array, wav,
-                                        gal_values.alpha0, gal_values.alpha1,
-                                        gal_values.alphaweight, self.ab_offset, filter_name)
-        tot_fake_sch = np.zeros_like(gal_dens)
-        for i in [0, 1]:
-            fake_m, fake_phi, fake_alpha = self._calculate_params(np.log10(wav), i)
-            fake_schechter = (0.4 * np.log(10) * fake_phi *
-                              (10**(-0.4 * (self.fake_mags - fake_m)))**(fake_alpha+1) *
-                              np.exp(-10**(-0.4 * (self.fake_mags - fake_m))))
-            tot_fake_sch += np.interp(self.mag_bins, self.fake_app_mags,
-                                      fake_schechter) * self.dV_dOmega
-
-        assert_allclose(tot_fake_sch, gal_dens, rtol=0.01, atol=1e-4)
 
 
 class TestMakePerturbAUFs():


### PR DESCRIPTION
Missed a change of number of lines in the header of downloaded TRILEGAL simulations in #44.

Additionally, edited actions workflow such that ``--remote-data`` is run on a PR instead of a merge, to avoid missing any changes that affect. Trust that `trilegal_download` test passes on a merge if it passed the PR.