### PR TITLE
Fix GitHub Testing

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [workflow_dispatch, pull_request]
 
 jobs:
   build:
@@ -49,11 +49,7 @@ jobs:
         run: |
           pip install numpy
           pip install tox
-      - if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-        name: Run tests
-        run: tox -e ${{ matrix.toxenv }}
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        name: Run tests with remote
+      - name: Run tests with remote
         run: tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation
         run: tox -e build_docs

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -54,11 +54,7 @@ jobs:
         run: |
           pip install numpy
           pip install tox
-      - if: github.event_name == 'push'
-        name: Run tests
-        run: tox -e ${{ matrix.toxenv }}
-      - if: github.event_name != 'push'
-        name: Run tests with remote
+      - name: Run tests with remote
         run: tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation
         run: tox -e build_docs

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,6 +1,11 @@
 name: Python package
 
-on: [workflow_dispatch, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -49,7 +54,11 @@ jobs:
         run: |
           pip install numpy
           pip install tox
-      - name: Run tests with remote
+      - if: github.event_name == 'push'
+        name: Run tests
+        run: tox -e ${{ matrix.toxenv }}
+      - if: github.event_name != 'push'
+        name: Run tests with remote
         run: tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation
         run: tox -e build_docs

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -895,6 +895,6 @@ def test_trilegal_download():
     bits = line.split(' ')
     tri_area = float(bits[2])
     tri = np.genfromtxt('{}/{}.dat'.format(tri_folder, tri_name), delimiter=None,
-                        names=True, comments='#', skip_header=1)
+                        names=True, comments='#', skip_header=2)
     assert np.all(tri[:]['G'] <= 32)
     assert tri_area <= 10


### PR DESCRIPTION
1. PR fixes a minor typo missed in #44 where ``trilegal_download`` did not have its ``header`` value changed.
2. Changed github actions workflow to avoid this mistake happening again. Always run full, ``--remote-data`` ``tox`` tests, unless merging a PR into ``main`` (which is a push).
3. Additionally, avoid duplicating push vs pull_request CI, and just only run automatic tests within a PR. Added ``workflow_dispatch`` to allow for manual testing on a per-run basis.