### PR TITLE
Improvements to pytest timings

### DIFF
--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -308,13 +308,13 @@ class TestMakeIslandGroupings():
 
         self.j1s = gsf.calc_j1s(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
 
-        self.a_auf_pointings = np.array([[10, -20], [12, -22], [15, -25]])
-        self.b_auf_pointings = np.array([[11, -21], [14, -22], [14, -24]])
+        self.a_auf_pointings = np.array([[10, -26], [11, -25], [12, -24]])
+        self.b_auf_pointings = np.array([[10.1, -25.9], [11.3, -25.1], [11.9, -24]])
 
         self.N_a, self.N_b = 30, 45
         self.N_com = 25
 
-        self.ax_lims = np.array([8, 16, -26, -19])
+        self.ax_lims = np.array([10, 12, -26, -24])
 
         # Fake fourier grid, in this case under the assumption that there
         # is no extra AUF component:
@@ -518,10 +518,13 @@ class TestMakeIslandGroupings():
         os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         N_a, N_b, N_c = self.N_a, self.N_b, self.N_com
-        ax_lims = np.array([0, 360, -90, -19])
+        ax_lims = np.array([0, 360, -90, -88])
         # Check if axlims are changed to include wrap-around 0/360, or +-90 latitude,
         # then we don't reject any sources.
         a_coords, b_coords = np.copy(self.a_coords), np.copy(self.b_coords)
+        # Set up -26 to -24, and we now want them -90 to -88:
+        a_coords[:, 1] -= 64
+        b_coords[:, 1] -= 64
         a_c_diff = a_coords[3:6, 0] - (ax_lims[0] + self.max_sep/3600 - 1/3600)
         a_coords[3:6, 0] = ax_lims[0] + self.max_sep/3600 - 1/3600
         b_coords[3:6, 0] -= a_c_diff

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -335,11 +335,12 @@ class TestMakePerturbAUFs():
         self.psf_fwhms = np.array([6.1])
         self.r = np.linspace(0, 1.185 * self.psf_fwhms[0], 2500)
         self.dr = np.diff(self.r)
-        self.rho = np.linspace(0, 100, 10000)
+        self.rho = np.linspace(0, 100, 5000)
         self.drho = np.diff(self.rho)
         self.which_cat = 'b'
         self.include_perturb_auf = True
-        self.num_trials = 100000
+        self.num_trials = 50000
+        self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
 
         self.mem_chunk_num = 1
         self.delta_mag_cuts = np.array([2.5, 5])
@@ -470,8 +471,6 @@ class TestMakePerturbAUFs():
         np.save('{}/con_cat_photo.npy'.format(self.cat_folder), np.array([[14.99]]))
         np.save('{}/magref.npy'.format(self.cat_folder), np.array([0]))
 
-        num_trials = 100000
-        j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
         cutoff_mags = np.array([20])
         dm_max = np.array([10])
         d_mag = 0.1
@@ -523,10 +522,10 @@ class TestMakePerturbAUFs():
         mag_offset = mod_bin - mag_bin
         rel_flux = 10**(-1/2.5 * mag_offset)
 
-        N = 25
+        N = 15
         for i in range(N):
-            make_perturb_aufs(*self.args, psf_fwhms=self.psf_fwhms, num_trials=num_trials, j0s=j0s,
-                              density_mags=cutoff_mags, dm_max=dm_max, d_mag=d_mag,
+            make_perturb_aufs(*self.args, psf_fwhms=self.psf_fwhms, num_trials=self.num_trials,
+                              j0s=self.j0s, density_mags=cutoff_mags, dm_max=dm_max, d_mag=d_mag,
                               delta_mag_cuts=self.delta_mag_cuts, compute_local_density=False,
                               tri_filt_names=self.tri_filt_names, fit_gal_flag=False)
 
@@ -694,6 +693,11 @@ class TestMakePerturbAUFs():
         cm.a_dens_dist = density_radius
         cm.b_dens_dist = density_radius
         cm.compute_local_density = True
+        cm.r = self.r
+        cm.dr = self.dr
+        cm.rho = self.rho
+        cm.drho = self.drho
+        cm.j0s = self.j0s
         cm.run_auf = True
         cm.run_group = True
         cm.run_cf = True
@@ -837,6 +841,11 @@ class TestMakePerturbAUFs():
 
         cm.a_auf_region_points = self.auf_points
         cm.b_auf_region_points = self.auf_points
+        cm.r = self.r
+        cm.dr = self.dr
+        cm.rho = self.rho
+        cm.drho = self.drho
+        cm.j0s = self.j0s
         cm.cross_match_extent = self.ax_lims
         cm.run_auf = True
         cm.run_group = True

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -168,7 +168,7 @@ def test_perturb_aufs():
 
     # Limit the size of each simulation, but run many to aggregate
     # better counting statistics.
-    num = 100
+    num = 50
     for _ in range(num):
         seed = rng.choice(1000000, size=(seed_size, 1))
         offsets, fracs, fluxs = paf.scatter_perturbers(np.array([mean]), m, R, 5, mag_cut,
@@ -196,7 +196,7 @@ def test_perturb_aufs():
 
     # Here we assume that the direct and wrapper calls had the same seed for
     # each call, and identical results, and hence should basically agree perfectly.
-    assert_allclose(track_pa_hist, track_sp_hist, atol=1e-6)
+    assert_allclose(track_pa_hist, track_sp_hist, atol=2e-6)
 
     offsets_fake = np.zeros_like(r[:-1])
     offsets_fake[0] += prob_0_draw / (np.pi * (r[1]**2 - r[0]**2))

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -896,7 +896,7 @@ class TestMakePerturbAUFs():
 @pytest.mark.remote_data
 def test_trilegal_download():
     tri_folder = '.'
-    download_trilegal_simulation(tri_folder, 'gaiaDR2', 180, 20, 1, 'galactic', total_objs=10000)
+    download_trilegal_simulation(tri_folder, 'gaiaDR2', 15, 6, 1, 'galactic', total_objs=10000)
     tri_name = 'trilegal_auf_simulation'
     f = open('{}/{}.dat'.format(tri_folder, tri_name), "r")
     line = f.readline()


### PR DESCRIPTION
Edited a few tests to speed up the amount of time taken to run `pytest`.

Primarily avoiding unnecessary calls to functions and decreasing numerical resolution.