### PR TITLE
Added codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.15%


### PR DESCRIPTION
PR adds `codecov.yml`, to serve two purposes:
1. turn off github comments for coverage reports
2. allow a 0.15% drop in coverage to still pass CI.