### PR TITLE
MPI Parallelisation and Option to Disable Use of Memory-Mapped Files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,7 +93,7 @@ API Changes
 - Removed ``joint_file_path``, ``cat_a_file_path`` and ``cat_b_file_path``
   from ``CrossMatch`` constructor and added ``chunks_folder_path``,
   ``use_memmap_files``, ``resume_file_path``, ``walltime``, ``end_within``,
-  and ``polling_rate. [#49]
+  and ``polling_rate``. [#49]
 
 - Added ``use_memmap_files`` as input parameter to relevant functions. [#49]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ General
 New Features
 ^^^^^^^^^^^^
 
+- Added MPI parallelisation and checkpointing. [#49]
+
+- Added option to disable use of memory-mapped files for internal arrays.
+  Reduces I/O operations at the cost of increased memory consuption. [#49]
+
 - Inclusion of galaxy count model, used in the generation of perturbation
   AUF components. [#41, #44]
 
@@ -85,6 +90,15 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Removed ``joint_file_path``, ``cat_a_file_path`` and ``cat_b_file_path``
+  from ``CrossMatch`` constructor and added ``chunks_folder_path``,
+  ``use_memmap_files``, ``resume_file_path``, ``walltime``, ``end_within``,
+  and ``polling_rate. [#49]
+
+- Added ``use_memmap_files`` as input parameter to relevant functions. [#49]
+
+- Added ``StageData`` class to ``misc_functions``. [#49]
+
 - Added ``npool`` as input parameter to ``make_island_groupings``. [#38]
 
 - Removed ``npool`` as input parameter to ``source_pairing``. [#38]
@@ -111,6 +125,8 @@ API Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+
+- Added ``mpi4py`` as a dependency [#49]
 
 - Added ``skypy`` and ``speclite`` as dependencies. [#41]
 

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -373,16 +373,21 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         highind = np.floor(len_b*(cnum+1)/mem_chunk_num).astype(int)
         bfieldfilter[lowind:highind] = ((bfieldinds[lowind:highind] < large_len+1) &
                                         (probfbarray[lowind:highind] >= 0))
-    if os.path.isfile('{}/reject/reject_a.npy'.format(joint_folder_path)):
-        lenrejecta = len(np.load('{}/reject/reject_a.npy'.format(joint_folder_path),
-                                 mmap_mode='r'))
+
+    if use_memmap_files:
+        if os.path.isfile('{}/reject/reject_a.npy'.format(joint_folder_path)):
+            lenrejecta = len(np.load('{}/reject/reject_a.npy'.format(joint_folder_path),
+                                    mmap_mode='r'))
+        else:
+            lenrejecta = 0
+        if os.path.isfile('{}/reject/reject_b.npy'.format(joint_folder_path)):
+            lenrejectb = len(np.load('{}/reject/reject_b.npy'.format(joint_folder_path),
+                                    mmap_mode='r'))
+        else:
+            lenrejectb = 0
     else:
-        lenrejecta = 0
-    if os.path.isfile('{}/reject/reject_b.npy'.format(joint_folder_path)):
-        lenrejectb = len(np.load('{}/reject/reject_b.npy'.format(joint_folder_path),
-                                 mmap_mode='r'))
-    else:
-        lenrejectb = 0
+        lenrejecta = group_sources_data.lenrejecta
+        lenrejectb = group_sources_data.lenrejectb
 
     countsum = int(np.sum(countfilter))
     afieldsum = int(np.sum(afieldfilter))

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -260,7 +260,7 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
             bgrplen = np.load('{}/group/bgrplen.npy'.format(joint_folder_path),
                             mmap_mode='r')[lowind:highind]
         else:
-            a_sky_inds = phot_like_data.a_sky_inds
+            a_sky_inds = phot_like_data.a_sky_inds[alistunique_flat]
 
             blist_ = group_sources_data.blist[:, lowind:highind]
             bgrplen = group_sources_data.bgrplen[lowind:highind]
@@ -286,9 +286,9 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
             bmodrefind = np.load('{}/modelrefinds.npy'.format(b_auf_folder_path),
                                 mmap_mode='r')[:, blistunique_flat]
         else:
-            b_sky_inds = phot_like_data.b_sky_inds
-            amodrefind = a_modelrefinds
-            bmodrefind = b_modelrefinds
+            b_sky_inds = phot_like_data.b_sky_inds[blistunique_flat]
+            amodrefind = a_modelrefinds[:, alistunique_flat]
+            bmodrefind = b_modelrefinds[:, blistunique_flat]
 
         [afourier_grids, afrac_grids, aflux_grids], amodrefind = load_small_ref_auf_grid(
             amodrefind, a_auf_folder_path, ['fourier', 'frac', 'flux'])

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -624,10 +624,15 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     # Only return reject counts if they were created
     if num_a_failed_checks + a_first_rejected_len > 0:
         lenrejecta = len(reject_a)
+        # Save rejects output files. Not needed explicitly if using memmapped files
+        if not use_memmap_files:
+            np.save('{}/reject/reject_a.npy'.format(joint_folder_path), reject_a)
     else:
         lenrejecta = 0
     if num_b_failed_checks + b_first_rejected_len > 0:
         lenrejectb = len(reject_b)
+        if not use_memmap_files:
+            np.save('{}/reject/reject_b.npy'.format(joint_folder_path), reject_b)
     else:
         lenrejectb = 0
 

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -327,7 +327,8 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
          amodrefindsmall, bmodrefindsmall, afouriergrid, bfouriergrid)
 
     # Delete sky slices used to make fourier cutouts.
-    os.system('rm {}/*temporary_sky_slice*.npy'.format(joint_folder_path))
+    if use_memmap_files:
+        os.system('rm {}/*temporary_sky_slice*.npy'.format(joint_folder_path))
 
     print("Cleaning overlaps...")
     sys.stdout.flush()
@@ -609,16 +610,34 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         os.remove('{}/group/failed_check.npy'.format(joint_folder_path))
 
         # Ensure unused arrays are garbage collected if memory mapped files enabled
+        # Without this, references would persist in StageData object
+        ablen = bblen = None
+        ainds = binds = None
+        asize = bsize = None
         aflen = bflen = None
         new_alist = new_blist = new_agrplen = new_bgrplen = None
 
     # Only return aflen and bflen if they were created
     if not (include_phot_like or use_phot_priors):
+        ablen = bblen = None
         aflen = bflen = None
+    # Only return reject counts if they were created
+    if num_a_failed_checks + a_first_rejected_len > 0:
+        lenrejecta = len(reject_a)
+    else:
+        lenrejecta = 0
+    if num_b_failed_checks + b_first_rejected_len > 0:
+        lenrejectb = len(reject_b)
+    else:
+        lenrejectb = 0
 
-    group_sources_data = StageData(aflen=aflen, bflen=bflen,
+    group_sources_data = StageData(ablen=ablen, bblen=bblen,
+                                   ainds=ainds, binds=binds,
+                                   asize=asize, bsize=bsize,
+                                   aflen=aflen, bflen=bflen,
                                    alist=new_alist, blist=new_blist,
-                                   agrplen=new_agrplen, bgrplen=new_bgrplen)
+                                   agrplen=new_agrplen, bgrplen=new_bgrplen,
+                                   lenrejecta=lenrejecta, lenrejectb=lenrejectb)
     return group_sources_data
 
 

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -701,7 +701,7 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
         modrefind = np.load('{}/modelrefinds.npy'.format(auf_folder_path),
                             mmap_mode='r')[:, large_sky_slice][:, sky_cut]
     else:
-        modrefind = modelrefinds
+        modrefind = modelrefinds[:, large_sky_slice][:, sky_cut]
 
     [fouriergrid], modrefindsmall = load_small_ref_auf_grid(modrefind, auf_folder_path,
                                                             ['fourier'])

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from .misc_functions import (load_small_ref_auf_grid, hav_dist_constant_lat,
                              map_large_index_to_small_index, _load_rectangular_slice,
-                             _create_rectangular_slice_arrays)
+                             _create_rectangular_slice_arrays, StageData)
 from .group_sources_fortran import group_sources_fortran as gsf
 from .make_set_list import set_list
 
@@ -22,9 +22,9 @@ __all__ = ['make_island_groupings']
 
 def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_path,
                           a_auf_folder_path, b_auf_folder_path, a_auf_pointings, b_auf_pointings,
-                          a_filt_names, b_filt_names, a_title, b_title, r, dr, rho, drho, j1s,
-                          max_sep, ax_lims, int_fracs, mem_chunk_num, include_phot_like,
-                          use_phot_priors, n_pool):
+                          a_filt_names, b_filt_names, a_title, b_title, a_modelrefinds, b_modelrefinds,
+                          r, dr, rho, drho, j1s, max_sep, ax_lims, int_fracs, mem_chunk_num,
+                          include_phot_like, use_phot_priors, n_pool, use_memmap_files):
     '''
     Function to handle the creation of "islands" of astrometrically coeval
     sources, and identify which overlap to some probability based on their
@@ -59,6 +59,14 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         Name used to describe catalogue "a" in the cross-match.
     b_title : string
         Catalogue "b" description, for identifying its given folder.
+    a_modelrefinds : numpy.ndarray
+        Catalogue "a" modelrefinds array output from ``create_perturb_auf``. Used
+        only when use_memmap_files is False.
+        TODO Improve description
+    b_modelrefinds : numpy.ndarray
+        Catalogue "b" modelrefinds array output from ``create_perturb_auf``. Used
+        only when use_memmap_files is False.
+        TODO Improve description
     r : numpy.ndarray
         Array of real-space distances, in arcseconds, used in the evaluation of
         convolved AUF integrals; represent bin edges.
@@ -95,6 +103,10 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         calculate photometric-information dependent priors for cross-matching.
     n_pool : integer
         Number of multiprocessing pools to use when parallelising.
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
     '''
 
     # Convert from arcseconds to degrees internally.
@@ -134,25 +146,33 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     b_full = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path), mmap_mode='r')
 
     # Generate the necessary memmap sky slice arrays now.
-    _create_rectangular_slice_arrays(joint_folder_path, 'a', len(a_full))
     memmap_slice_arrays_a = []
-    for n in ['1', '2', '3', '4', 'combined']:
-        memmap_slice_arrays_a.append(np.lib.format.open_memmap(
-            '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a', n), mode='r+',
-            dtype=bool, shape=(len(a_full),)))
-    _create_rectangular_slice_arrays(joint_folder_path, 'b', len(b_full))
     memmap_slice_arrays_b = []
-    for n in ['1', '2', '3', '4', 'combined']:
-        memmap_slice_arrays_b.append(np.lib.format.open_memmap(
-            '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b', n), mode='r+',
-            dtype=bool, shape=(len(b_full),)))
+    if use_memmap_files:
+        _create_rectangular_slice_arrays(joint_folder_path, 'a', len(a_full))
+        for n in ['1', '2', '3', '4', 'combined']:
+            memmap_slice_arrays_a.append(np.lib.format.open_memmap(
+                '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a', n), mode='r+',
+                dtype=bool, shape=(len(a_full),)))
 
-    asize = np.lib.format.open_memmap('{}/group/asize.npy'.format(joint_folder_path), mode='w+',
+        _create_rectangular_slice_arrays(joint_folder_path, 'b', len(b_full))
+        for n in ['1', '2', '3', '4', 'combined']:
+            memmap_slice_arrays_b.append(np.lib.format.open_memmap(
+                '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b', n), mode='r+',
+                dtype=bool, shape=(len(b_full),)))
+
+        asize = np.lib.format.open_memmap('{}/group/asize.npy'.format(joint_folder_path), mode='w+',
                                       dtype=int, shape=(len(a_full),))
-    asize[:] = 0
-    bsize = np.lib.format.open_memmap('{}/group/bsize.npy'.format(joint_folder_path), mode='w+',
-                                      dtype=int, shape=(len(b_full),))
-    bsize[:] = 0
+        asize[:] = 0
+        bsize = np.lib.format.open_memmap('{}/group/bsize.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(len(b_full),))
+        bsize[:] = 0
+    else:
+        for _ in range(5):
+            memmap_slice_arrays_a.append(np.zeros(dtype=bool, shape=(len(a_full),)))
+            memmap_slice_arrays_b.append(np.zeros(dtype=bool, shape=(len(b_full),)))
+        asize = np.zeros(dtype=int, shape=(len(a_full),))
+        bsize = np.zeros(dtype=int, shape=(len(b_full),))
 
     for i, (ax1_sparse_start, ax1_sparse_end) in enumerate(zip(ax1_sparse_loops[:-1],
                                                                ax1_sparse_loops[1:])):
@@ -166,18 +186,24 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                 ax2_sparse_end, max_sep, memmap_slice_arrays_b)
             a_cutout = a_full[a_big_sky_cut]
             b_cutout = b_full[b_big_sky_cut]
-            _create_rectangular_slice_arrays(joint_folder_path, 'a_cutout', len(a_cutout))
+
             small_memmap_slice_arrays_a = []
-            for n in ['1', '2', '3', '4', 'combined']:
-                small_memmap_slice_arrays_a.append(np.lib.format.open_memmap(
-                    '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a_cutout', n),
-                    mode='r+', dtype=bool, shape=(len(a_cutout),)))
-            _create_rectangular_slice_arrays(joint_folder_path, 'b_cutout', len(b_cutout))
             small_memmap_slice_arrays_b = []
-            for n in ['1', '2', '3', '4', 'combined']:
-                small_memmap_slice_arrays_b.append(np.lib.format.open_memmap(
-                    '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b_cutout', n),
-                    mode='r+', dtype=bool, shape=(len(b_cutout),)))
+            if use_memmap_files:
+                _create_rectangular_slice_arrays(joint_folder_path, 'a_cutout', len(a_cutout))
+                for n in ['1', '2', '3', '4', 'combined']:
+                    small_memmap_slice_arrays_a.append(np.lib.format.open_memmap(
+                        '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a_cutout', n),
+                        mode='r+', dtype=bool, shape=(len(a_cutout),)))
+                _create_rectangular_slice_arrays(joint_folder_path, 'b_cutout', len(b_cutout))
+                for n in ['1', '2', '3', '4', 'combined']:
+                    small_memmap_slice_arrays_b.append(np.lib.format.open_memmap(
+                        '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b_cutout', n),
+                        mode='r+', dtype=bool, shape=(len(b_cutout),)))
+            else:
+                for _ in range(5):
+                    small_memmap_slice_arrays_a.append(np.zeros(dtype=bool, shape=(len(a_cutout),)))
+                    small_memmap_slice_arrays_b.append(np.zeros(dtype=bool, shape=(len(b_cutout),)))
 
             # TODO: avoid np.arange by first iterating an np.sum(big_sky_cut)
             # and pre-generating a memmapped sub-array, and looping over
@@ -191,11 +217,12 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                     ax_cutout = [ax1_start, ax1_end, ax2_start, ax2_end]
                     a, afouriergrid, amodrefindsmall, a_cut = _load_fourier_grid_cutouts(
                         a_cutout, ax_cutout, joint_folder_path, a_cat_folder_path,
-                        a_auf_folder_path, 0, 'a', small_memmap_slice_arrays_a, a_big_sky_cut)
+                        a_auf_folder_path, 0, 'a', small_memmap_slice_arrays_a, a_big_sky_cut,
+                        a_modelrefinds, use_memmap_files)
                     b, bfouriergrid, bmodrefindsmall, b_cut = _load_fourier_grid_cutouts(
                         b_cutout, ax_cutout, joint_folder_path, b_cat_folder_path,
                         b_auf_folder_path, max_sep, 'b', small_memmap_slice_arrays_b,
-                        b_big_sky_cut)
+                        b_big_sky_cut, b_modelrefinds, use_memmap_files)
 
                     if len(a) > 0 and len(b) > 0:
                         overlapa, overlapb = gsf.get_max_overlap(
@@ -216,10 +243,15 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     print("Truncating star overlaps by AUF integral...")
     sys.stdout.flush()
 
-    ainds = np.lib.format.open_memmap('{}/group/ainds.npy'.format(joint_folder_path), mode='w+',
-                                      dtype=int, shape=(amaxsize, len(a_full)), fortran_order=True)
-    binds = np.lib.format.open_memmap('{}/group/binds.npy'.format(joint_folder_path), mode='w+',
-                                      dtype=int, shape=(bmaxsize, len(b_full)), fortran_order=True)
+    if use_memmap_files:
+        ainds = np.lib.format.open_memmap('{}/group/ainds.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(amaxsize, len(a_full)), fortran_order=True)
+        binds = np.lib.format.open_memmap('{}/group/binds.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(bmaxsize, len(b_full)), fortran_order=True)
+    else:
+        ainds = np.zeros(dtype=int, shape=(amaxsize, len(a_full)), order='F')
+        binds = np.zeros(dtype=int, shape=(bmaxsize, len(b_full)), order='F')
+
     ainds[:, :] = -1
     binds[:, :] = -1
     asize[:] = 0
@@ -237,18 +269,24 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                 ax2_sparse_end, max_sep, memmap_slice_arrays_b)
             a_cutout = a_full[a_big_sky_cut]
             b_cutout = b_full[b_big_sky_cut]
-            _create_rectangular_slice_arrays(joint_folder_path, 'a_cutout', len(a_cutout))
+
             small_memmap_slice_arrays_a = []
-            for n in ['1', '2', '3', '4', 'combined']:
-                small_memmap_slice_arrays_a.append(np.lib.format.open_memmap(
-                    '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a_cutout', n),
-                    mode='r+', dtype=bool, shape=(len(a_cutout),)))
-            _create_rectangular_slice_arrays(joint_folder_path, 'b_cutout', len(b_cutout))
             small_memmap_slice_arrays_b = []
-            for n in ['1', '2', '3', '4', 'combined']:
-                small_memmap_slice_arrays_b.append(np.lib.format.open_memmap(
-                    '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b_cutout', n),
-                    mode='r+', dtype=bool, shape=(len(b_cutout),)))
+            if use_memmap_files:
+                _create_rectangular_slice_arrays(joint_folder_path, 'a_cutout', len(a_cutout))
+                for n in ['1', '2', '3', '4', 'combined']:
+                    small_memmap_slice_arrays_a.append(np.lib.format.open_memmap(
+                        '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'a_cutout', n),
+                        mode='r+', dtype=bool, shape=(len(a_cutout),)))
+                _create_rectangular_slice_arrays(joint_folder_path, 'b_cutout', len(b_cutout))
+                for n in ['1', '2', '3', '4', 'combined']:
+                    small_memmap_slice_arrays_b.append(np.lib.format.open_memmap(
+                        '{}/{}_temporary_sky_slice_{}.npy'.format(joint_folder_path, 'b_cutout', n),
+                        mode='r+', dtype=bool, shape=(len(b_cutout),)))
+            else:
+                for _ in range(5):
+                    small_memmap_slice_arrays_a.append(np.zeros(dtype=bool, shape=(len(a_cutout),)))
+                    small_memmap_slice_arrays_b.append(np.zeros(dtype=bool, shape=(len(b_cutout),)))
 
             a_sky_inds = np.arange(0, len(a_full))[a_big_sky_cut]
             b_sky_inds = np.arange(0, len(b_full))[b_big_sky_cut]
@@ -259,11 +297,12 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                     ax_cutout = [ax1_start, ax1_end, ax2_start, ax2_end]
                     a, afouriergrid, amodrefindsmall, a_cut = _load_fourier_grid_cutouts(
                         a_cutout, ax_cutout, joint_folder_path, a_cat_folder_path,
-                        a_auf_folder_path, 0, 'a', small_memmap_slice_arrays_a, a_big_sky_cut)
+                        a_auf_folder_path, 0, 'a', small_memmap_slice_arrays_a, a_big_sky_cut,
+                        a_modelrefinds, use_memmap_files)
                     b, bfouriergrid, bmodrefindsmall, b_cut = _load_fourier_grid_cutouts(
                         b_cutout, ax_cutout, joint_folder_path, b_cat_folder_path,
                         b_auf_folder_path, max_sep, 'b', small_memmap_slice_arrays_b,
-                        b_big_sky_cut)
+                        b_big_sky_cut, b_modelrefinds, use_memmap_files)
 
                     if len(a) > 0 and len(b) > 0:
                         indicesa, indicesb, overlapa, overlapb = gsf.get_overlap_indices(
@@ -293,21 +332,27 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     print("Cleaning overlaps...")
     sys.stdout.flush()
 
-    ainds, asize = _clean_overlaps(ainds, asize, joint_folder_path, 'ainds', n_pool)
-    binds, bsize = _clean_overlaps(binds, bsize, joint_folder_path, 'binds', n_pool)
+    ainds, asize = _clean_overlaps(ainds, asize, joint_folder_path, 'ainds', n_pool, use_memmap_files)
+    binds, bsize = _clean_overlaps(binds, bsize, joint_folder_path, 'binds', n_pool, use_memmap_files)
 
     print("Calculating integral lengths...")
     sys.stdout.flush()
 
     if include_phot_like or use_phot_priors:
-        ablen = np.lib.format.open_memmap('{}/group/ablen.npy'.format(joint_folder_path),
-                                          mode='w+', dtype=float, shape=(len(a_full),))
-        aflen = np.lib.format.open_memmap('{}/group/aflen.npy'.format(joint_folder_path),
-                                          mode='w+', dtype=float, shape=(len(a_full),))
-        bblen = np.lib.format.open_memmap('{}/group/bblen.npy'.format(joint_folder_path),
-                                          mode='w+', dtype=float, shape=(len(b_full),))
-        bflen = np.lib.format.open_memmap('{}/group/bflen.npy'.format(joint_folder_path),
-                                          mode='w+', dtype=float, shape=(len(b_full),))
+        if use_memmap_files:
+            ablen = np.lib.format.open_memmap('{}/group/ablen.npy'.format(joint_folder_path),
+                                            mode='w+', dtype=float, shape=(len(a_full),))
+            aflen = np.lib.format.open_memmap('{}/group/aflen.npy'.format(joint_folder_path),
+                                            mode='w+', dtype=float, shape=(len(a_full),))
+            bblen = np.lib.format.open_memmap('{}/group/bblen.npy'.format(joint_folder_path),
+                                            mode='w+', dtype=float, shape=(len(b_full),))
+            bflen = np.lib.format.open_memmap('{}/group/bflen.npy'.format(joint_folder_path),
+                                            mode='w+', dtype=float, shape=(len(b_full),))
+        else:
+            ablen = np.zeros(dtype=float, shape=(len(a_full),))
+            aflen = np.zeros(dtype=float, shape=(len(a_full),))
+            bblen = np.zeros(dtype=float, shape=(len(b_full),))
+            bflen = np.zeros(dtype=float, shape=(len(b_full),))
 
         for cnum in range(0, mem_chunk_num):
             lowind = np.floor(len(a_full)*cnum/mem_chunk_num).astype(int)
@@ -319,19 +364,28 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             a_inds_small = np.asfortranarray(a_inds_small[:np.amax(a_size_small), :])
 
             a_inds_map, a_inds_unique = map_large_index_to_small_index(
-                a_inds_small, len(b_full), '{}/group'.format(joint_folder_path))
+                a_inds_small, len(b_full), '{}/group'.format(joint_folder_path), use_memmap_files)
 
             b = b_full[a_inds_unique, 2]
 
-            modrefind = np.load('{}/modelrefinds.npy'.format(a_auf_folder_path),
-                                mmap_mode='r')[:, lowind:highind]
+            if use_memmap_files:
+                modrefind = np.load('{}/modelrefinds.npy'.format(a_auf_folder_path),
+                                    mmap_mode='r')[:, lowind:highind]
+            else:
+                modrefind = a_modelrefinds[:, lowind:highind]
             [a_fouriergrid], a_modrefindsmall = load_small_ref_auf_grid(
                 modrefind, a_auf_folder_path, ['fourier'])
-            modrefind = np.load('{}/modelrefinds.npy'.format(b_auf_folder_path),
-                                mmap_mode='r')[:, a_inds_unique]
+
+            if use_memmap_files:
+                modrefind = np.load('{}/modelrefinds.npy'.format(b_auf_folder_path),
+                                    mmap_mode='r')[:, a_inds_unique]
+            else:
+                modrefind = b_modelrefinds[:, a_inds_unique]
             [b_fouriergrid], b_modrefindsmall = load_small_ref_auf_grid(
                 modrefind, b_auf_folder_path, ['fourier'])
-            del modrefind
+
+            if use_memmap_files:
+                del modrefind
 
             a_int_lens = gsf.get_integral_length(
                 a, b, r[:-1]+dr/2, rho[:-1], drho, j1s, a_fouriergrid, b_fouriergrid,
@@ -349,19 +403,28 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             b_inds_small = np.asfortranarray(b_inds_small[:np.amax(b_size_small), :])
 
             b_inds_map, b_inds_unique = map_large_index_to_small_index(
-                b_inds_small, len(a_full), '{}/group'.format(joint_folder_path))
+                b_inds_small, len(a_full), '{}/group'.format(joint_folder_path), use_memmap_files)
 
             a = a_full[b_inds_unique, 2]
 
-            modrefind = np.load('{}/modelrefinds.npy'.format(b_auf_folder_path),
-                                mmap_mode='r')[:, lowind:highind]
+            if use_memmap_files:
+                modrefind = np.load('{}/modelrefinds.npy'.format(b_auf_folder_path),
+                                    mmap_mode='r')[:, lowind:highind]
+            else:
+                modrefind = b_modelrefinds[:, lowind:highind]
             [b_fouriergrid], b_modrefindsmall = load_small_ref_auf_grid(
                 modrefind, b_auf_folder_path, ['fourier'])
-            modrefind = np.load('{}/modelrefinds.npy'.format(a_auf_folder_path),
-                                mmap_mode='r')[:, b_inds_unique]
+
+            if use_memmap_files:
+                modrefind = np.load('{}/modelrefinds.npy'.format(a_auf_folder_path),
+                                    mmap_mode='r')[:, b_inds_unique]
+            else:
+                modrefind = a_modelrefinds[:, b_inds_unique]
             [a_fouriergrid], a_modrefindsmall = load_small_ref_auf_grid(
                 modrefind, a_auf_folder_path, ['fourier'])
-            del modrefind
+
+            if use_memmap_files:
+                del modrefind
 
             b_int_lens = gsf.get_integral_length(
                 b, a, r[:-1]+dr/2, rho[:-1], drho, j1s, b_fouriergrid, a_fouriergrid,
@@ -376,19 +439,24 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     sys.stdout.flush()
 
     alist, blist, agrplen, bgrplen = set_list(ainds, binds, asize, bsize, joint_folder_path,
-                                              n_pool)
+                                              n_pool, use_memmap_files)
 
     # The final act of creating island groups is to clear out any sources too
     # close to the edge of the catalogue -- defined by its rectangular extend.
     # TODO: add flag for allowing the keeping of potentially incomplete islands
     # in the main catalogue; here we default to, and only allow, their removal.
 
-    passed_check = np.lib.format.open_memmap('{}/group/passed_check.npy'.format(joint_folder_path),
-                                             mode='w+', dtype=bool, shape=(alist.shape[1],))
-    passed_check[:] = 0
-    failed_check = np.lib.format.open_memmap('{}/group/failed_check.npy'.format(joint_folder_path),
-                                             mode='w+', dtype=bool, shape=(alist.shape[1],))
-    failed_check[:] = 1
+    if use_memmap_files:
+        passed_check = np.lib.format.open_memmap('{}/group/passed_check.npy'.format(joint_folder_path),
+                                                mode='w+', dtype=bool, shape=(alist.shape[1],))
+        passed_check[:] = 0
+        failed_check = np.lib.format.open_memmap('{}/group/failed_check.npy'.format(joint_folder_path),
+                                                mode='w+', dtype=bool, shape=(alist.shape[1],))
+        failed_check[:] = 1
+    else:
+        passed_check = np.zeros(dtype=bool, shape=(alist.shape[1],))
+        failed_check = np.ones(dtype=bool, shape=(alist.shape[1],))
+
     islelen = alist.shape[1]
     num_good_checks = 0
     num_a_failed_checks = 0
@@ -451,9 +519,12 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     else:
         a_first_rejected_len = 0
     if num_a_failed_checks + a_first_rejected_len > 0:
-        reject_a = np.lib.format.open_memmap(
-            '{}/reject/reject_a.npy'.format(joint_folder_path), mode='w+', dtype=int,
-            shape=(num_a_failed_checks+a_first_rejected_len,))
+        if use_memmap_files:
+            reject_a = np.lib.format.open_memmap(
+                '{}/reject/reject_a.npy'.format(joint_folder_path), mode='w+', dtype=int,
+                shape=(num_a_failed_checks+a_first_rejected_len,))
+        else:
+            reject_a = np.zeros(dtype=int, shape=(num_a_failed_checks+a_first_rejected_len,))
     if os.path.isfile('{}/reject/areject.npy'.format(joint_folder_path)):
         reject_a[num_a_failed_checks:] = np.load('{}/reject/areject.npy'.format(joint_folder_path),
                                                  mmap_mode='r')
@@ -464,9 +535,12 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     else:
         b_first_rejected_len = 0
     if num_b_failed_checks + b_first_rejected_len > 0:
-        reject_b = np.lib.format.open_memmap(
-            '{}/reject/reject_b.npy'.format(joint_folder_path), mode='w+', dtype=int,
-            shape=(num_b_failed_checks+b_first_rejected_len,))
+        if use_memmap_files:
+            reject_b = np.lib.format.open_memmap(
+                '{}/reject/reject_b.npy'.format(joint_folder_path), mode='w+', dtype=int,
+                shape=(num_b_failed_checks+b_first_rejected_len,))
+        else:
+            reject_b = np.zeros(dtype=int, shape=(num_b_failed_checks+b_first_rejected_len,))
     if os.path.isfile('{}/reject/breject.npy'.format(joint_folder_path)):
         reject_b[num_b_failed_checks:] = np.load('{}/reject/breject.npy'.format(joint_folder_path),
                                                  mmap_mode='r')
@@ -478,16 +552,23 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             amaxlen = max(amaxlen, int(np.amax(agrplen[i:i+di][passed_check[i:i+di]])))
             bmaxlen = max(bmaxlen, int(np.amax(bgrplen[i:i+di][passed_check[i:i+di]])))
 
-    new_alist = np.lib.format.open_memmap(
-        '{}/group/alist2.npy'.format(joint_folder_path), mode='w+', dtype=int,
-        shape=(amaxlen, num_good_checks), fortran_order=True)
-    new_blist = np.lib.format.open_memmap(
-        '{}/group/blist2.npy'.format(joint_folder_path), mode='w+', dtype=int,
-        shape=(bmaxlen, num_good_checks), fortran_order=True)
-    new_agrplen = np.lib.format.open_memmap('{}/group/agrplen2.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=int, shape=(num_good_checks,))
-    new_bgrplen = np.lib.format.open_memmap('{}/group/bgrplen2.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=int, shape=(num_good_checks,))
+    if use_memmap_files:
+        new_alist = np.lib.format.open_memmap(
+            '{}/group/alist2.npy'.format(joint_folder_path), mode='w+', dtype=int,
+            shape=(amaxlen, num_good_checks), fortran_order=True)
+        new_blist = np.lib.format.open_memmap(
+            '{}/group/blist2.npy'.format(joint_folder_path), mode='w+', dtype=int,
+            shape=(bmaxlen, num_good_checks), fortran_order=True)
+        new_agrplen = np.lib.format.open_memmap('{}/group/agrplen2.npy'.format(joint_folder_path),
+                                                mode='w+', dtype=int, shape=(num_good_checks,))
+        new_bgrplen = np.lib.format.open_memmap('{}/group/bgrplen2.npy'.format(joint_folder_path),
+                                                mode='w+', dtype=int, shape=(num_good_checks,))
+    else:
+        new_alist = np.zeros(dtype=int, shape=(amaxlen, num_good_checks), order='F')
+        new_blist = np.zeros(dtype=int, shape=(bmaxlen, num_good_checks), order='F')
+        new_agrplen = np.zeros(dtype=int, shape=(num_good_checks,))
+        new_bgrplen = np.zeros(dtype=int, shape=(num_good_checks,))
+
     a_fail_count, b_fail_count, pass_count = 0, 0, 0
     di = max(1, alist.shape[1] // 20)
     for i in range(0, alist.shape[1], di):
@@ -517,21 +598,33 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         new_bgrplen[pass_count:pass_count+n_extra] = bgrplen[i:i+di][passed_check[i:i+di]]
         pass_count += n_extra
 
-    for cat_kind in ['a', 'b']:
-        os.system('mv {}/group/{}list2.npy {}/group/{}list.npy'.format(
-            joint_folder_path, cat_kind, joint_folder_path, cat_kind))
-        os.system('mv {}/group/{}grplen2.npy {}/group/{}grplen.npy'.format(
-            joint_folder_path, cat_kind, joint_folder_path, cat_kind))
+    if use_memmap_files:
+        for cat_kind in ['a', 'b']:
+            os.system('mv {}/group/{}list2.npy {}/group/{}list.npy'.format(
+                joint_folder_path, cat_kind, joint_folder_path, cat_kind))
+            os.system('mv {}/group/{}grplen2.npy {}/group/{}grplen.npy'.format(
+                joint_folder_path, cat_kind, joint_folder_path, cat_kind))
 
-    os.remove('{}/group/passed_check.npy'.format(joint_folder_path))
-    os.remove('{}/group/failed_check.npy'.format(joint_folder_path))
+        os.remove('{}/group/passed_check.npy'.format(joint_folder_path))
+        os.remove('{}/group/failed_check.npy'.format(joint_folder_path))
 
-    return
+        # Ensure unused arrays are garbage collected if memory mapped files enabled
+        aflen = bflen = None
+        new_alist = new_blist = new_agrplen = new_bgrplen = None
+
+    # Only return aflen and bflen if they were created
+    if not (include_phot_like or use_phot_priors):
+        aflen = bflen = None
+
+    group_sources_data = StageData(aflen=aflen, bflen=bflen,
+                                   alist=new_alist, blist=new_blist,
+                                   agrplen=new_agrplen, bgrplen=new_bgrplen)
+    return group_sources_data
 
 
 def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder_path,
                                auf_folder_path, padding, cat_name, memmap_slice_arrays,
-                               large_sky_slice):
+                               large_sky_slice, modelrefinds, use_memmap_files):
     '''
     Function to load a sub-set of a given catalogue's astrometry, slicing it
     in a given sky coordinate rectangle, and load the appropriate sub-array
@@ -567,6 +660,14 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     large_sky_slice : boolean
         Slice array containing the ``True`` and ``False`` elements of which
         elements of the full catalogue, in ``con_cat_astro.npy``, are in ``a``.
+    modelrefinds : numpy.ndarray
+        The modelrefinds array output from ``create_perturb_auf``. Used only when
+        use_memmap_files is False.
+        TODO Improve description
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
     '''
 
     lon1, lon2, lat1, lat2 = sky_rect_coords
@@ -577,8 +678,11 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     a_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path),
                        mmap_mode='r')[large_sky_slice][sky_cut]
 
-    modrefind = np.load('{}/modelrefinds.npy'.format(auf_folder_path),
-                        mmap_mode='r')[:, large_sky_slice][:, sky_cut]
+    if use_memmap_files:
+        modrefind = np.load('{}/modelrefinds.npy'.format(auf_folder_path),
+                            mmap_mode='r')[:, large_sky_slice][:, sky_cut]
+    else:
+        modrefind = modelrefinds
 
     [fouriergrid], modrefindsmall = load_small_ref_auf_grid(modrefind, auf_folder_path,
                                                             ['fourier'])
@@ -586,7 +690,7 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     return a_cutout, fouriergrid, modrefindsmall, sky_cut
 
 
-def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool):
+def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool, use_memmap_files):
     '''
     Convenience function to parse either catalogue's indices array for
     duplicate references to the opposing array on a per-source basis,
@@ -607,6 +711,10 @@ def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool):
         The name of the ``inds`` array saved to disk.
     n_pool : integer
         Number of multiprocessing threads to use.
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
 
     Returns
     -------
@@ -636,16 +744,23 @@ def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool):
 
     # We ideally want to basically do np.asfortranarray(inds[:maxsize, :]), but
     # this would involve a copy instead of a read so we have to loop.
-    inds2 = np.lib.format.open_memmap('{}/group/{}2.npy'.format(joint_folder_path, filename),
-                                      mode='w+', dtype=int, shape=(maxsize, len(size)),
-                                      fortran_order=True)
+    if use_memmap_files:
+        inds2 = np.lib.format.open_memmap('{}/group/{}2.npy'.format(joint_folder_path, filename),
+                                        mode='w+', dtype=int, shape=(maxsize, len(size)),
+                                        fortran_order=True)
+    else:
+        inds2 = np.zeros(dtype=int, shape=(maxsize, len(size)), order='F')
+
     di = max(1, len(size) // 20)
     for i in range(0, len(size), di):
         inds2[:, i:i+di] = inds[:maxsize, i:i+di]
 
-    os.system('mv {}/group/{}2.npy {}/group/{}.npy'.format(joint_folder_path, filename,
-                                                           joint_folder_path, filename))
-    inds = np.load('{}/group/{}.npy'.format(joint_folder_path, filename), mmap_mode='r+')
+    if use_memmap_files:
+        os.system('mv {}/group/{}2.npy {}/group/{}.npy'.format(joint_folder_path, filename,
+                                                            joint_folder_path, filename))
+        inds = np.load('{}/group/{}.npy'.format(joint_folder_path, filename), mmap_mode='r+')
+    else:
+        inds = inds2
 
     return inds, size
 

--- a/macauff/make_set_list.py
+++ b/macauff/make_set_list.py
@@ -16,7 +16,7 @@ import scipy.special
 __all__ = ['set_list']
 
 
-def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
+def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool, use_memmap_files):
     '''
     Creates the inter-catalogue groupings between catalogues "a" and "b", based
     on previously determined individual source "overlaps" in astrometry.
@@ -39,6 +39,10 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
         index and overlap arrays are stored.
     n_pool : integer
         Number of multiprocessing pools to use when parallelising.
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
 
     Returns
     -------
@@ -55,14 +59,19 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
         The number of catalogue "b" sources in each island grouping.
     '''
     agroup, bgroup = _initial_group_numbering(aindices, bindices, aoverlap, boverlap,
-                                              joint_folder_path)
+                                              joint_folder_path, use_memmap_files)
     groupmax = max(np.amax(agroup), np.amax(bgroup))
-    agrouplengths = np.lib.format.open_memmap('{}/group/agrplen.npy'.format(joint_folder_path),
-                                              mode='w+', dtype=int, shape=(groupmax,))
-    agrouplengths[:] = 0
-    bgrouplengths = np.lib.format.open_memmap('{}/group/bgrplen.npy'.format(joint_folder_path),
-                                              mode='w+', dtype=int, shape=(groupmax,))
-    bgrouplengths[:] = 0
+
+    if use_memmap_files:
+        agrouplengths = np.lib.format.open_memmap('{}/group/agrplen.npy'.format(joint_folder_path),
+                                                mode='w+', dtype=int, shape=(groupmax,))
+        agrouplengths[:] = 0
+        bgrouplengths = np.lib.format.open_memmap('{}/group/bgrplen.npy'.format(joint_folder_path),
+                                                mode='w+', dtype=int, shape=(groupmax,))
+        bgrouplengths[:] = 0
+    else:
+        agrouplengths = np.zeros(dtype=int, shape=(groupmax,))
+        bgrouplengths = np.zeros(dtype=int, shape=(groupmax,))
 
     for i in range(0, len(agroup)):
         agrouplengths[agroup[i]-1] += 1
@@ -80,8 +89,11 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
     # However we can't do x! / (x-k)! so we do prod(range(x-k+1, x, 1)) for
     # computational simplicity.
     maxiters = 50000
-    grouplengthexceeded = np.lib.format.open_memmap('{}/group/grplenexceed.npy'.format(
-        joint_folder_path), mode='w+', dtype=bool, shape=(len(agrouplengths),))
+    if use_memmap_files:
+        grouplengthexceeded = np.lib.format.open_memmap('{}/group/grplenexceed.npy'.format(
+            joint_folder_path), mode='w+', dtype=bool, shape=(len(agrouplengths),))
+    else:
+        grouplengthexceeded = np.zeros(dtype=bool, shape=(len(agrouplengths),))
     pool = multiprocessing.Pool(n_pool)
     counter = np.arange(0, len(agrouplengths))
     iter_group = zip(counter, agrouplengths, bgrouplengths, itertools.repeat(maxiters))
@@ -112,17 +124,24 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
 
     # Keep track of which sources have "good" group sizes, and the size of each
     # group in the two catalogues (e.g., group 1 has 2 "a" and 3 "b" sources).
-    goodlength = np.lib.format.open_memmap('{}/group/goodlen.npy'.format(
-        joint_folder_path), mode='w+', dtype=bool, shape=(len(agrouplengths),))
+    if use_memmap_files:
+        goodlength = np.lib.format.open_memmap('{}/group/goodlen.npy'.format(
+            joint_folder_path), mode='w+', dtype=bool, shape=(len(agrouplengths),))
+    else:
+        goodlength = np.zeros(dtype=bool, shape=(len(agrouplengths),))
     di = max(1, len(agrouplengths) // 20)
     for i in range(0, len(agrouplengths), di):
         goodlength[i:i+di] = np.logical_not(grouplengthexceeded[i:i+di])
-    acounters = np.lib.format.open_memmap('{}/group/acount.npy'.format(joint_folder_path),
-                                          mode='w+', dtype=int, shape=(groupmax,))
-    acounters[:] = 0
-    bcounters = np.lib.format.open_memmap('{}/group/bcount.npy'.format(joint_folder_path),
-                                          mode='w+', dtype=int, shape=(groupmax,))
-    bcounters[:] = 0
+    if use_memmap_files:
+        acounters = np.lib.format.open_memmap('{}/group/acount.npy'.format(joint_folder_path),
+                                            mode='w+', dtype=int, shape=(groupmax,))
+        acounters[:] = 0
+        bcounters = np.lib.format.open_memmap('{}/group/bcount.npy'.format(joint_folder_path),
+                                            mode='w+', dtype=int, shape=(groupmax,))
+        bcounters[:] = 0
+    else:
+        acounters = np.zeros(dtype=int, shape=(groupmax,))
+        bcounters = np.zeros(dtype=int, shape=(groupmax,))
     # open_memmap requires tuples of ints and np.amax doesn't play nicely with
     # memmapped arrays, making (memmap(result)) variables, so we force the
     # number to a simple int here.
@@ -131,12 +150,16 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
         if np.sum(goodlength[i:i+di]) > 0:
             amaxlen = max(amaxlen, int(np.amax(agrouplengths[i:i+di][goodlength[i:i+di]])))
             bmaxlen = max(bmaxlen, int(np.amax(bgrouplengths[i:i+di][goodlength[i:i+di]])))
-    alist = np.lib.format.open_memmap('{}/group/alist.npy'.format(joint_folder_path), mode='w+',
-                                      dtype=int, shape=(amaxlen, groupmax), fortran_order=True)
-    alist[:, :] = -1
-    blist = np.lib.format.open_memmap('{}/group/blist.npy'.format(joint_folder_path), mode='w+',
-                                      dtype=int, shape=(bmaxlen, groupmax), fortran_order=True)
-    blist[:, :] = -1
+    if use_memmap_files:
+        alist = np.lib.format.open_memmap('{}/group/alist.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(amaxlen, groupmax), fortran_order=True)
+        alist[:, :] = -1
+        blist = np.lib.format.open_memmap('{}/group/blist.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(bmaxlen, groupmax), fortran_order=True)
+        blist[:, :] = -1
+    else:
+        alist = np.full(dtype=int, shape=(amaxlen, groupmax), fill_value=-1, order='F')
+        blist = np.full(dtype=int, shape=(bmaxlen, groupmax), fill_value=-1, order='F')
     # Remember that we started groups from one, so convert to zero-indexing.
     # Loop over each source in turn, skipping any which belong to an island
     # too large to run, updating alist or blist with the corresponding island
@@ -158,15 +181,27 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
         newsecondlen += int(np.sum(goodlength[i:i+di]))
 
     di = max(1, newsecondlen // 20)
+
+    # If not storing arrays on the file system, we need a way to keep track of a/blist and
+    # a/bgrouplengths. Use a dictionary.
+    if not use_memmap_files:
+        setdict = {}
+
     # Essentially do a = a[q], or a = a[:, q], but via memmap.
     for cat_kind, list_array, maxlen, len_array in zip(
             ['a', 'b'], [alist, blist], [amaxlen, bmaxlen], [agrouplengths, bgrouplengths]):
-        new_list_array = np.lib.format.open_memmap(
-            '{}/group/{}list2.npy'.format(joint_folder_path, cat_kind), mode='w+', dtype=int,
-            shape=(maxlen, newsecondlen), fortran_order=True)
-        new_grouplengths = np.lib.format.open_memmap(
-            '{}/group/{}grplen2.npy'.format(joint_folder_path, cat_kind), mode='w+', dtype=int,
-            shape=(newsecondlen,))
+
+        if use_memmap_files:
+            new_list_array = np.lib.format.open_memmap(
+                '{}/group/{}list2.npy'.format(joint_folder_path, cat_kind), mode='w+', dtype=int,
+                shape=(maxlen, newsecondlen), fortran_order=True)
+            new_grouplengths = np.lib.format.open_memmap(
+                '{}/group/{}grplen2.npy'.format(joint_folder_path, cat_kind), mode='w+', dtype=int,
+                shape=(newsecondlen,))
+        else:
+            new_list_array = np.zeros(dtype=int, shape=(maxlen, newsecondlen), order='F')
+            new_grouplengths = np.zeros(dtype=int, shape=(newsecondlen,), order='F')
+
         tick = 0
         for i in range(0, len(len_array), di):
             new_list_array[:, tick:tick+np.sum(goodlength[i:i+di])] = list_array[:, i:i+di][
@@ -175,24 +210,34 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
                 goodlength[i:i+di]]
             tick += np.sum(goodlength[i:i+di])
 
-        os.system('mv {}/group/{}list2.npy {}/group/{}list.npy'.format(
-            joint_folder_path, cat_kind, joint_folder_path, cat_kind))
-        os.system('mv {}/group/{}grplen2.npy {}/group/{}grplen.npy'.format(
-            joint_folder_path, cat_kind, joint_folder_path, cat_kind))
+        if use_memmap_files:
+            os.system('mv {}/group/{}list2.npy {}/group/{}list.npy'.format(
+                joint_folder_path, cat_kind, joint_folder_path, cat_kind))
+            os.system('mv {}/group/{}grplen2.npy {}/group/{}grplen.npy'.format(
+                joint_folder_path, cat_kind, joint_folder_path, cat_kind))
+        else:
+            setdict["{}list".format(cat_kind)] = new_list_array
+            setdict["{}grouplengths".format(cat_kind)] = new_grouplengths
 
-    # Tidy up temporary memmap arrays.
-    for name in ['agroup', 'bgroup', 'grplenexceed', 'goodlen', 'acount', 'bcount']:
-        os.remove('{}/group/{}.npy'.format(joint_folder_path, name))
+    if use_memmap_files:
+        # Tidy up temporary memmap arrays.
+        for name in ['agroup', 'bgroup', 'grplenexceed', 'goodlen', 'acount', 'bcount']:
+            os.remove('{}/group/{}.npy'.format(joint_folder_path, name))
 
-    alist = np.load('{}/group/alist.npy'.format(joint_folder_path), mmap_mode='r+')
-    blist = np.load('{}/group/blist.npy'.format(joint_folder_path), mmap_mode='r+')
-    agrouplengths = np.load('{}/group/agrplen.npy'.format(joint_folder_path), mmap_mode='r+')
-    bgrouplengths = np.load('{}/group/bgrplen.npy'.format(joint_folder_path), mmap_mode='r+')
+        alist = np.load('{}/group/alist.npy'.format(joint_folder_path), mmap_mode='r+')
+        blist = np.load('{}/group/blist.npy'.format(joint_folder_path), mmap_mode='r+')
+        agrouplengths = np.load('{}/group/agrplen.npy'.format(joint_folder_path), mmap_mode='r+')
+        bgrouplengths = np.load('{}/group/bgrplen.npy'.format(joint_folder_path), mmap_mode='r+')
+    else:
+        alist = setdict["alist"]
+        blist = setdict["blist"]
+        agrouplengths = setdict["agrouplengths"]
+        bgrouplengths = setdict["bgrouplengths"]
 
     return alist, blist, agrouplengths, bgrouplengths
 
 
-def _initial_group_numbering(aindices, bindices, aoverlap, boverlap, joint_folder_path):
+def _initial_group_numbering(aindices, bindices, aoverlap, boverlap, joint_folder_path, use_memmap_files):
     '''
     Iterates over the indices mapping overlaps between the two catalogues,
     assigning initial group numbers to sources to be placed in "islands".
@@ -217,6 +262,10 @@ def _initial_group_numbering(aindices, bindices, aoverlap, boverlap, joint_folde
     joint_folder_path : string
         Location of top-level folder containing the "group" folder in which
         index and overlap arrays are stored.
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
 
     Returns
     -------
@@ -225,13 +274,16 @@ def _initial_group_numbering(aindices, bindices, aoverlap, boverlap, joint_folde
     bgroup : numpy.ndarray
         Array detailing the group number of each catalogue "b" source.
     '''
-    agroup = np.lib.format.open_memmap('{}/group/agroup.npy'.format(joint_folder_path), mode='w+',
-                                       dtype=int, shape=(len(aoverlap),))
-    bgroup = np.lib.format.open_memmap('{}/group/bgroup.npy'.format(joint_folder_path), mode='w+',
-                                       dtype=int, shape=(len(boverlap),))
-
-    agroup[:] = 0
-    bgroup[:] = 0
+    if use_memmap_files:
+        agroup = np.lib.format.open_memmap('{}/group/agroup.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(len(aoverlap),))
+        bgroup = np.lib.format.open_memmap('{}/group/bgroup.npy'.format(joint_folder_path), mode='w+',
+                                        dtype=int, shape=(len(boverlap),))
+        agroup[:] = 0
+        bgroup[:] = 0
+    else:
+        agroup = np.zeros(dtype=int, shape=(len(aoverlap),))
+        bgroup = np.zeros(dtype=int, shape=(len(boverlap),))
 
     group_num = 0
     # First search for catalogue "a" sources that are either lonely, with no

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -19,7 +19,7 @@ __all__ = ['make_perturb_aufs', 'create_single_perturb_auf']
 
 
 def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
-                      drho, which_cat, include_perturb_auf, mem_chunk_num,
+                      drho, which_cat, include_perturb_auf, mem_chunk_num, use_memmap_files,
                       tri_download_flag=False, delta_mag_cuts=None, psf_fwhms=None,
                       tri_set_name=None, tri_filt_num=None, tri_filt_names=None,
                       auf_region_frame=None, num_trials=None, j0s=None, density_mags=None,
@@ -63,6 +63,10 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     mem_chunk_num : int
         Number of individual sub-sections to break catalogue into for memory
         saving purposes.
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
     tri_download_flag : boolean, optional
         A ``True``/``False`` flag, whether to re-download TRILEGAL simulated star
         counts or not if a simulation already exists in a given folder. Only
@@ -236,9 +240,12 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
 
     n_sources = len(np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r'))
 
-    modelrefinds = np.lib.format.open_memmap('{}/modelrefinds.npy'.format(auf_folder),
-                                             mode='w+', dtype=int, shape=(3, n_sources),
-                                             fortran_order=True)
+    if use_memmap_files:
+        modelrefinds = np.lib.format.open_memmap('{}/modelrefinds.npy'.format(auf_folder),
+                                                 mode='w+', dtype=int, shape=(3, n_sources),
+                                                 fortran_order=True)
+    else:
+        modelrefinds = np.zeros(dtype=int, shape=(3, n_sources), order='f')
 
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(n_sources*cnum/mem_chunk_num).astype(int)
@@ -259,12 +266,15 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
 
     # Store the length of the density-magnitude combinations in each sky/filter
     # combination for future loading purposes.
-    arraylengths = np.lib.format.open_memmap('{}/arraylengths.npy'.format(auf_folder), mode='w+',
-                                             dtype=int, shape=(len(filters), len(auf_points)),
-                                             fortran_order=True)
+    if use_memmap_files:
+        arraylengths = np.lib.format.open_memmap('{}/arraylengths.npy'.format(auf_folder), mode='w+',
+                                                 dtype=int, shape=(len(filters), len(auf_points)),
+                                                 fortran_order=True)
+    else:
+        arraylengths = np.zeros(dtype=int, shape=(len(filters), len(auf_points)), order='f')
 
     # Overload compute_local_density if it is False but local_N does not exist.
-    if not compute_local_density and not os.path.isfile('{}/local_N.npy'.format(auf_folder)):
+    if not compute_local_density and not os.path.isfile('{}/local_N.npy'.format(auf_folder)) and use_memmap_files:
         compute_local_density = True
 
     if include_perturb_auf:
@@ -273,16 +283,23 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
             a_tot_astro = np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r')
             # Set up the temporary sky slice memmap arrays quickly, as they will
             # be needed in calculate_local_density later.
-            _create_rectangular_slice_arrays(auf_folder, '', len(a_tot_astro))
             memmap_slice_arrays = []
-            for n in ['1', '2', '3', '4', 'combined']:
-                memmap_slice_arrays.append(np.lib.format.open_memmap(
-                    '{}/{}_temporary_sky_slice_{}.npy'.format(auf_folder, '', n), mode='r+',
-                    dtype=bool, shape=(len(a_tot_astro),)))
+            if use_memmap_files:
+                _create_rectangular_slice_arrays(auf_folder, '', len(a_tot_astro))
+                for n in ['1', '2', '3', '4', 'combined']:
+                    memmap_slice_arrays.append(np.lib.format.open_memmap(
+                        '{}/{}_temporary_sky_slice_{}.npy'.format(auf_folder, '', n), mode='r+',
+                        dtype=bool, shape=(len(a_tot_astro),)))
+            else:
+                for _ in range(5):
+                    memmap_slice_arrays.append(np.zeros(dtype=bool, shape=(len(a_tot_astro),)))
 
     if compute_local_density and include_perturb_auf:
-        local_N = np.lib.format.open_memmap('{}/local_N.npy'.format(auf_folder), mode='w+',
-                                            dtype=float, shape=(len(a_tot_astro), len(filters)))
+        if use_memmap_files:
+            local_N = np.lib.format.open_memmap('{}/local_N.npy'.format(auf_folder), mode='w+',
+                                                dtype=float, shape=(len(a_tot_astro), len(filters)))
+        else:
+            local_N = np.zeros(dtype=float, shape=(len(a_tot_astro), len(filters)))
 
     for i in range(len(auf_points)):
         ax1, ax2 = auf_points[i]
@@ -297,7 +314,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
                                          auf_region_frame)
 
         if include_perturb_auf:
-            sky_cut = _load_single_sky_slice(auf_folder, '', i, modelrefinds[2, :])
+            sky_cut = _load_single_sky_slice(auf_folder, '', i, modelrefinds[2, :], use_memmap_files)
             if compute_local_density:
                 # TODO: avoid np.arange by first iterating an np.sum(sky_cut)
                 # and pre-generating a memmapped sub-array, and looping over
@@ -408,14 +425,24 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     if include_perturb_auf:
         longestNm = np.amax(arraylengths)
 
-        Narrays = np.lib.format.open_memmap('{}/narrays.npy'.format(auf_folder), mode='w+',
-                                            dtype=float, shape=(longestNm, len(filters),
-                                            len(auf_points)), fortran_order=True)
-        Narrays[:, :, :] = -1
-        magarrays = np.lib.format.open_memmap('{}/magarrays.npy'.format(auf_folder), mode='w+',
-                                              dtype=float, shape=(longestNm, len(filters),
-                                              len(auf_points)), fortran_order=True)
-        magarrays[:, :, :] = -1
+        if use_memmap_files:
+            Narrays = np.lib.format.open_memmap('{}/narrays.npy'.format(auf_folder), mode='w+',
+                                                dtype=float, shape=(longestNm, len(filters),
+                                                len(auf_points)), fortran_order=True)
+            Narrays[:, :, :] = -1
+        else:
+            Narrays = np.full(dtype=float, shape=(longestNm, len(filters), len(auf_points)),
+                              order='F', fill_value=-1)
+
+        if use_memmap_files:
+            magarrays = np.lib.format.open_memmap('{}/magarrays.npy'.format(auf_folder), mode='w+',
+                                                dtype=float, shape=(longestNm, len(filters),
+                                                len(auf_points)), fortran_order=True)
+            magarrays[:, :, :] = -1
+        else:
+            magarrays = np.full(dtype=float, shape=(longestNm, len(filters), len(auf_points)),
+                                order='F', fill_value=-1)
+
         for i in range(len(auf_points)):
             ax1, ax2 = auf_points[i]
             ax_folder = '{}/{}/{}'.format(auf_folder, ax1, ax2)
@@ -472,11 +499,14 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         n_fracs = len(delta_mag_cuts)
     # Create the 4-D grids that house the perturbation AUF fourier-space
     # representation.
-    create_auf_params_grid(auf_folder, auf_points, filters, 'fourier', len(rho)-1)
+    create_auf_params_grid(auf_folder, auf_points, filters, 'fourier', use_memmap_files,
+                           len(rho)-1, arraylengths)
     # Create the estimated levels of flux contamination and fraction of
     # contaminated source grids.
-    create_auf_params_grid(auf_folder, auf_points, filters, 'frac', n_fracs)
-    create_auf_params_grid(auf_folder, auf_points, filters, 'flux')
+    create_auf_params_grid(auf_folder, auf_points, filters, 'frac', use_memmap_files,
+                           n_fracs, arraylengths)
+    create_auf_params_grid(auf_folder, auf_points, filters, 'flux', use_memmap_files,
+                           arraylengths=arraylengths)
 
     if include_perturb_auf:
         del Narrays, magarrays
@@ -486,6 +516,8 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         # Delete sky slices used to make fourier cutouts.
         os.system('rm {}/*temporary_sky_slice*.npy'.format(auf_folder))
         os.system('rm {}/_small_sky_slice.npy'.format(auf_folder))
+
+    return modelrefinds
 
 
 def download_trilegal_simulation(tri_folder, tri_filter_set, ax1, ax2, mag_num, region_frame,
@@ -554,7 +586,8 @@ def download_trilegal_simulation(tri_folder, tri_filter_set, ax1, ax2, mag_num, 
 
 
 def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_folder,
-                            density_radius, density_mag, memmap_slice_arrays):
+                            density_radius, density_mag, memmap_slice_arrays,
+                            use_memmap_files):
     '''
     Calculates the number of sources above a given brightness within a specified
     radius of each source in a catalogue, to provide a local density for
@@ -584,6 +617,10 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
     memmap_slice_arrays : list of numpy.ndarray
         List of the memmap sky slice arrays, to be used in the loading of the
         rectangular sky patch.
+    use_memmap_files : boolean
+        When set to True, memory mapped files are used for several internal
+        arrays. Reduces memory consumption at the cost of increased I/O
+        contention.
 
     Returns
     -------
@@ -596,16 +633,23 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
     min_lat, max_lat = np.amin(a_astro[:, 1]), np.amax(a_astro[:, 1])
 
     memmap_slice_arrays_2 = []
-    for n in ['1', '2', '3', '4', 'combined']:
-        memmap_slice_arrays_2.append(np.lib.format.open_memmap(
-            '{}/{}_temporary_sky_slice_{}.npy'.format(auf_folder, '2', n), mode='w+',
-            dtype=bool, shape=(len(a_astro),)))
+    if use_memmap_files:
+        for n in ['1', '2', '3', '4', 'combined']:
+            memmap_slice_arrays_2.append(np.lib.format.open_memmap(
+                '{}/{}_temporary_sky_slice_{}.npy'.format(auf_folder, '2', n), mode='w+',
+                dtype=bool, shape=(len(a_astro),)))
+    else:
+        for _ in range(5):
+            memmap_slice_arrays_2.append(np.zeros(dtype=bool, shape=(len(a_tot_astro),)))
 
     overlap_sky_cut = _load_rectangular_slice(auf_folder, '', a_tot_astro, min_lon,
                                               max_lon, min_lat, max_lat, density_radius,
                                               memmap_slice_arrays)
-    cut = np.lib.format.open_memmap('{}/_temporary_slice.npy'.format(
-        auf_folder), mode='w+', dtype=bool, shape=(len(a_tot_astro),))
+    if use_memmap_files:
+        cut = np.lib.format.open_memmap('{}/_temporary_slice.npy'.format(
+            auf_folder), mode='w+', dtype=bool, shape=(len(a_tot_astro),))
+    else:
+        cut = np.zeros(dtype=bool, shape=(len(a_tot_astro),))
     di = max(1, len(cut) // 20)
     for i in range(0, len(a_tot_astro), di):
         cut[i:i+di] = overlap_sky_cut[i:i+di] & (a_tot_photo[i:i+di] <= density_mag)
@@ -613,10 +657,14 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
     a_photo_overlap_cut = a_tot_photo[cut]
 
     memmap_slice_arrays_3 = []
-    for n in ['1', '2', '3', '4', 'combined']:
-        memmap_slice_arrays_3.append(np.lib.format.open_memmap(
-            '{}/{}_temporary_sky_slice_{}.npy'.format(auf_folder, '3', n), mode='w+',
-            dtype=bool, shape=(len(a_astro_overlap_cut),)))
+    if use_memmap_files:
+        for n in ['1', '2', '3', '4', 'combined']:
+            memmap_slice_arrays_3.append(np.lib.format.open_memmap(
+                '{}/{}_temporary_sky_slice_{}.npy'.format(auf_folder, '3', n), mode='w+',
+                dtype=bool, shape=(len(a_astro_overlap_cut),)))
+    else:
+        for _ in range(5):
+            memmap_slice_arrays_3.append(np.zeros(dtype=bool, shape=(len(a_astro_overlap_cut),)))
 
     ax1_loops = np.linspace(min_lon, max_lon, 11)
     # Force the sub-division of the sky area in question to be 100 chunks, or
@@ -641,8 +689,11 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
             overlap_sky_cut = _load_rectangular_slice(auf_folder, '', a_astro_overlap_cut,
                                                       ax1_start, ax1_end, ax2_start, ax2_end,
                                                       density_radius, memmap_slice_arrays_3)
-            cut = np.lib.format.open_memmap('{}/_temporary_slice.npy'.format(
-                auf_folder), mode='w+', dtype=bool, shape=(len(a_astro_overlap_cut),))
+            if use_memmap_files:
+                cut = np.lib.format.open_memmap('{}/_temporary_slice.npy'.format(
+                    auf_folder), mode='w+', dtype=bool, shape=(len(a_astro_overlap_cut),))
+            else:
+                cut = np.zeros(dtype=bool, shape=(len(a_astro_overlap_cut),))
             di = max(1, len(cut) // 20)
             for i in range(0, len(a_astro_overlap_cut), di):
                 cut[i:i+di] = (overlap_sky_cut[i:i+di] &
@@ -673,7 +724,10 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
 
     count_density = full_counts / circle_overlap_area
 
-    os.system('rm {}/_temporary_slice.npy'.format(auf_folder))
+    if use_memmap_files:
+        os.system('rm {}/_temporary_slice.npy'.format(auf_folder))
+    else:
+        del cut
 
     return count_density
 

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -360,7 +360,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
                     localN = calculate_local_density(
                         a_astro_cut[good_mag_slice], a_tot_astro, a_tot_photo[:, j],
                         auf_folder, cat_folder, density_radius, density_mags[j],
-                        memmap_slice_arrays)
+                        memmap_slice_arrays, use_memmap_files)
                     # Because we always calculate the density from the full
                     # catalogue, using just the astrometry, we should be able
                     # to just over-write this N times if there happen to be N

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -273,8 +273,12 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     else:
         arraylengths = np.zeros(dtype=int, shape=(len(filters), len(auf_points)), order='f')
 
-    # Overload compute_local_density if it is False but local_N does not exist.
-    if not compute_local_density and not os.path.isfile('{}/local_N.npy'.format(auf_folder)) and use_memmap_files:
+    if use_memmap_files:
+        # Overload compute_local_density if it is False but local_N does not exist.
+        if not compute_local_density and not os.path.isfile('{}/local_N.npy'.format(auf_folder)):
+            compute_local_density = True
+    # Always compute_local_density if not using memmapped files
+    else:
         compute_local_density = True
 
     if include_perturb_auf:

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -510,12 +510,14 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
 
     if include_perturb_auf:
         del Narrays, magarrays
-        os.remove('{}/narrays.npy'.format(auf_folder))
-        os.remove('{}/magarrays.npy'.format(auf_folder))
 
-        # Delete sky slices used to make fourier cutouts.
-        os.system('rm {}/*temporary_sky_slice*.npy'.format(auf_folder))
-        os.system('rm {}/_small_sky_slice.npy'.format(auf_folder))
+        if use_memmap_files:
+          os.remove('{}/narrays.npy'.format(auf_folder))
+          os.remove('{}/magarrays.npy'.format(auf_folder))
+
+          # Delete sky slices used to make fourier cutouts.
+          os.system('rm {}/*temporary_sky_slice*.npy'.format(auf_folder))
+          os.system('rm {}/_small_sky_slice.npy'.format(auf_folder))
 
     return modelrefinds
 
@@ -640,7 +642,7 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
                 dtype=bool, shape=(len(a_astro),)))
     else:
         for _ in range(5):
-            memmap_slice_arrays_2.append(np.zeros(dtype=bool, shape=(len(a_tot_astro),)))
+            memmap_slice_arrays_2.append(np.zeros(dtype=bool, shape=(len(a_astro),)))
 
     overlap_sky_cut = _load_rectangular_slice(auf_folder, '', a_tot_astro, min_lon,
                                               max_lon, min_lat, max_lat, density_radius,

--- a/macauff/photometric_likelihood.py
+++ b/macauff/photometric_likelihood.py
@@ -215,8 +215,8 @@ def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_
                     b_flen_ind = np.load('{}/group/bflen.npy'.format(joint_folder_path),
                                         mmap_mode='r')[a_inds_cut_unique]
                 else:
-                    a_flen_ind = group_sources_data.aflen
-                    b_flen_ind = group_sources_data.bflen
+                    a_flen_ind = group_sources_data.aflen[b_inds_cut_unique]
+                    b_flen_ind = group_sources_data.bflen[a_inds_cut_unique]
 
             for i in range(0, len(afilts)):
                 if not include_phot_like and not use_phot_priors:

--- a/macauff/tests/test_full_match_process.py
+++ b/macauff/tests/test_full_match_process.py
@@ -130,7 +130,7 @@ def test_naive_bayes_match():
     idx = np.where([ol in line for line in f])[0][0]
     _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                   idx, nl, out_file=os.path.join(os.path.dirname(__file__),
-                  'data/crossmatch_params_.txt'))
+                  'data/chunk0/crossmatch_params_.txt'))
 
     new_ext = [extent[0] - r/3600 - 0.1/3600, extent[1] + r/3600 + 0.1/3600,
                extent[2] - r/3600 - 0.1/3600, extent[3] + r/3600 + 0.1/3600]
@@ -144,7 +144,7 @@ def test_naive_bayes_match():
         f = open(os.path.join(os.path.dirname(__file__),
                               'data/crossmatch_params.txt')).readlines()
         idx = np.where([ol in line for line in f])[0][0]
-        _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/chunk0/crossmatch_params_.txt'),
                       idx, nl)
 
     ol, nl = 'auf_region_points = 131 134 4 -1 1 {}', 'auf_region_points = 131 131 1 0 0 1\n'
@@ -155,7 +155,7 @@ def test_naive_bayes_match():
         idx = np.where([_ol in line for line in f])[0][0]
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/{}.txt'.format(file_name)),
                       idx, nl, out_file=os.path.join(os.path.dirname(__file__),
-                      'data/{}_.txt'.format(file_name)))
+                      'data/chunk0/{}_.txt'.format(file_name)))
 
     for cat, ol, nl in zip(['cat_a_params', 'cat_b_params'], ['cat_folder_path = gaia_folder',
                            'cat_folder_path = wise_folder'], ['cat_folder_path = a_cat\n',
@@ -163,14 +163,10 @@ def test_naive_bayes_match():
         f = open(os.path.join(os.path.dirname(__file__),
                               'data/{}.txt'.format(cat))).readlines()
         idx = np.where([ol in line for line in f])[0][0]
-        _replace_line(os.path.join(os.path.dirname(__file__), 'data/{}_.txt'.format(cat)),
+        _replace_line(os.path.join(os.path.dirname(__file__), 'data/chunk0/{}_.txt'.format(cat)),
                       idx, nl)
 
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                 'data/crossmatch_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                    os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
-
+    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
     cm()
 
     ac = np.load('{}/pairing/ac.npy'.format(cm.joint_folder_path))

--- a/macauff/tests/test_full_match_process.py
+++ b/macauff/tests/test_full_match_process.py
@@ -110,7 +110,7 @@ def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_si
     np.save('{}/test_match_indices.npy'.format(b_cat), b_pair_indices)
 
 
-def test_naive_bayes_match():
+def do_naive_bayes_match(use_memmap_files):
     # Generate a small number of sources randomly, then run through the
     # cross-match process.
     N_a, N_b, N_c = 40, 50, 35
@@ -123,6 +123,9 @@ def test_naive_bayes_match():
 
     generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_sig, b_astro_sig,
                          a_cat, b_cat, seed=9999)
+
+    # Ensure output chunk directory exists
+    os.makedirs(os.path.join(os.path.dirname(__file__), "data/chunk0"), exist_ok=True)
 
     ol, nl = 'run_auf = no', 'run_auf = yes\n'
     f = open(os.path.join(os.path.dirname(__file__),
@@ -166,7 +169,7 @@ def test_naive_bayes_match():
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/chunk0/{}_.txt'.format(cat)),
                       idx, nl)
 
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
+    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files)
     cm()
 
     ac = np.load('{}/pairing/ac.npy'.format(cm.joint_folder_path))
@@ -182,3 +185,11 @@ def test_naive_bayes_match():
         assert b_right_inds[i] in bc
         q = np.where(a_right_inds[i] == ac)[0][0]
         assert np.all([a_right_inds[i], b_right_inds[i]] == [ac[q], bc[q]])
+
+def test_naive_bayes_match_no_memmap():
+   # Test using standard numpy arrays for internal arrays.
+   do_naive_bayes_match(False)
+
+def test_naive_bayes_match_memmap():
+    # Test using mapped files for internal arrays.
+    do_naive_bayes_match(True)

--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -60,7 +60,8 @@ def test_load_fourier_grid_cutouts():
         memmap_arrays.append(np.lib.format.open_memmap('{}/{}_temporary_sky_slice_{}.npy'.format(
                              '.', 'check', n), mode='r+', dtype=bool, shape=(len(a),)))
     _a, _b, _c, _ = _load_fourier_grid_cutouts(a, rect, '.', '.', '.', padding, 'check',
-                                               memmap_arrays, np.array([True]*lena))
+                                               memmap_arrays, np.array([True]*lena),
+                                               modelrefinds=None, use_memmap_files=True)
     assert np.all(_a.shape == (4, 3))
     assert np.all(_a ==
                   np.array([[50, 50, 0.1], [48, 60.02, 0.5], [39.98, 43, 0.2], [45, 45, 0.2]]))
@@ -83,7 +84,8 @@ def test_load_fourier_grid_cutouts():
     # reference index. Hence we only have one unique grid reference now.
     padding = 0
     _a, _b, _c, _ = _load_fourier_grid_cutouts(a, rect, '.', '.', '.', padding, 'check',
-                                               memmap_arrays, np.array([True]*lena))
+                                               memmap_arrays, np.array([True]*lena),
+                                               modelrefinds=None, use_memmap_files=True)
     assert np.all(_a.shape == (2, 3))
     assert np.all(_a == np.array([[50, 50, 0.1], [45, 45, 0.2]]))
     assert np.all(_b.shape == (100, 1, 1, 1))
@@ -270,7 +272,7 @@ def test_clean_overlaps():
         inds[:, 8+10*i] = [2, 2, 2, 2, 2]
         inds[:, 9+10*i] = [1, 1, 2, 3, -1]
 
-    inds2, size2 = _clean_overlaps(inds, size, joint_folder_path, filename, 2)
+    inds2, size2 = _clean_overlaps(inds, size, joint_folder_path, filename, 2, use_memmap_files=True)
     compare_inds2 = np.empty((4, 30), int)
     for i in range(0, 3):
         compare_inds2[:, 0+10*i] = [0, 1, -1, -1]
@@ -293,6 +295,7 @@ class TestMakeIslandGroupings():
         self.max_sep, self.int_fracs = 11, [0.63, 0.9, 0.99]  # max_sep in arcseconds
         self.a_filt_names, self.b_filt_names = ['G', 'RP'], ['W1', 'W2', 'W3']
         self.a_title, self.b_title = 'gaia', 'wise'
+        self.a_modelrefinds = self.b_modelrefinds = None
         self.a_cat_folder_path, self.b_cat_folder_path = 'gaia_cat', 'wise_cat'
         self.a_auf_folder_path, self.b_auf_folder_path = 'gaia_auf', 'wise_auf'
         self.joint_folder_path = 'joint'
@@ -334,7 +337,7 @@ class TestMakeIslandGroupings():
                     os.makedirs(filt_folder, exist_ok=True)
                     fourieroffset = np.ones((len(self.rho) - 1, 1), float, order='F')
                     np.save('{}/fourier.npy'.format(filt_folder), fourieroffset)
-            create_auf_params_grid(auf_folder, auf_points, filters, 'fourier', len(self.rho)-1)
+            create_auf_params_grid(auf_folder, auf_points, filters, 'fourier', True, len(self.rho)-1)
         # 99% is slightly more than 3-sigma of a 2-D Gaussian integral, for
         # int_frac[2] = 0.99
         self.sigma = 0.1
@@ -386,9 +389,10 @@ class TestMakeIslandGroupings():
             np.save('{}/magref.npy'.format(folder), np.zeros((10,), int))
 
         # Also set up an instance of CrossMatch at the same time.
-        self.cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+        self.cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        self.cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                  os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                                  os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
         self.files_per_island_sim = 5
         self.cm.pos_corr_dist = self.max_sep
         self.cm.cross_match_extent = self.ax_lims
@@ -396,6 +400,8 @@ class TestMakeIslandGroupings():
         self.cm.b_filt_names = self.b_filt_names
         self.cm.a_cat_name = self.a_title
         self.cm.b_cat_name = self.b_title
+        self.cm.a_modelrefinds = self.a_modelrefinds
+        self.cm.b_modelrefinds = self.b_modelrefinds
         self.cm.r, self.cm.dr, self.cm.rho, self.cm.drho = self.r, self.dr, self.rho, self.drho
         self.cm.a_auf_folder_path = self.a_auf_folder_path
         self.cm.b_auf_folder_path = self.b_auf_folder_path
@@ -410,6 +416,7 @@ class TestMakeIslandGroupings():
         self.cm.j1s = self.j1s
 
         self.n_pool = 5
+        self.use_memmap_files = True
 
     def _comparisons_in_islands(self, alist, blist, agrplen, bgrplen, N_a, N_b, N_c):
         # Given, say, 25 common sources from 30 'a' and 45 'b' objects, we'd
@@ -478,9 +485,9 @@ class TestMakeIslandGroupings():
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
             self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_pointings,
             self.b_auf_pointings, self.a_filt_names, self.b_filt_names, self.a_title, self.b_title,
-            self.r, self.dr, self.rho, self.drho, self.j1s, self.max_sep, ax_lims,
-            self.int_fracs, self.mem_chunk_num, self.include_phot_like, self.use_phot_prior,
-            self.n_pool)
+            self.a_modelrefinds, self.b_modelrefinds, self.r, self.dr, self.rho, self.drho, self.j1s,
+            self.max_sep, ax_lims, self.int_fracs, self.mem_chunk_num, self.include_phot_like,
+            self.use_phot_prior, self.n_pool, self.use_memmap_files)
 
         alist, blist = np.load('joint/group/alist.npy'), np.load('joint/group/blist.npy')
         agrplen, bgrplen = np.load('joint/group/agrplen.npy'), np.load('joint/group/bgrplen.npy')
@@ -539,9 +546,9 @@ class TestMakeIslandGroupings():
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
             self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_pointings,
             self.b_auf_pointings, self.a_filt_names, self.b_filt_names, self.a_title, self.b_title,
-            self.r, self.dr, self.rho, self.drho, self.j1s, self.max_sep, ax_lims,
-            self.int_fracs, self.mem_chunk_num, self.include_phot_like, self.use_phot_prior,
-            self.n_pool)
+            self.a_modelrefinds, self.b_modelrefinds, self.r, self.dr, self.rho, self.drho,
+            self.j1s, self.max_sep, ax_lims, self.int_fracs, self.mem_chunk_num, self.include_phot_like,
+            self.use_phot_prior, self.n_pool, self.use_memmap_files)
 
         alist, blist = np.load('joint/group/alist.npy'), np.load('joint/group/blist.npy')
         agrplen, bgrplen = np.load('joint/group/agrplen.npy'), np.load('joint/group/bgrplen.npy')
@@ -598,9 +605,9 @@ class TestMakeIslandGroupings():
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
             self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_pointings,
             self.b_auf_pointings, self.a_filt_names, self.b_filt_names, self.a_title, self.b_title,
-            self.r, self.dr, self.rho, self.drho, self.j1s, self.max_sep, self.ax_lims,
-            self.int_fracs, self.mem_chunk_num, include_phot_like, self.use_phot_prior,
-            self.n_pool)
+            self.a_modelrefinds, self.b_modelrefinds,  self.r, self.dr, self.rho, self.drho, self.j1s,
+            self.max_sep, self.ax_lims, self.int_fracs, self.mem_chunk_num, include_phot_like,
+            self.use_phot_prior, self.n_pool, self.use_memmap_files)
 
         # Verify that make_island_groupings doesn't change when the extra arrays
         # are calculated, as an initial test.

--- a/macauff/tests/test_make_set_list.py
+++ b/macauff/tests/test_make_set_list.py
@@ -25,7 +25,8 @@ def test_initial_group_numbering():
                                [11], [12, 19], [13], [14], [], [], [12], [3]]):
         b_overlaps[:len(_inds), _i] = np.array(_inds)
     os.makedirs('./group', exist_ok=True)
-    agroup, bgroup = _initial_group_numbering(a_overlaps, b_overlaps, a_num, b_num, '.')
+    agroup, bgroup = _initial_group_numbering(a_overlaps, b_overlaps, a_num, b_num, '.',
+                                              use_memmap_files=True)
 
     assert np.all(agroup == np.array(
         [18, 1, 2, 19, 3, 4, 5, 6, 7, 8, 9, 10, 20, 11, 12, 13, 14, 15, 18, 20]))
@@ -53,11 +54,11 @@ def test_set_list_maximum_exceeded():
             with pytest.warns(UserWarning, match='1 island, containing {}/{} catalogue a and '
                               '{}/{} catalogue b stars'.format(N_a, N_a+2, N_b, N_b+2)):
                 alist, blist, agrplen, bgrplen = set_list(
-                    a_overlaps, b_overlaps, a_num, b_num, '.', 2)
+                    a_overlaps, b_overlaps, a_num, b_num, '.', 2, use_memmap_files=True)
         else:
             with pytest.warns(None) as record:
                 alist, blist, agrplen, bgrplen = set_list(
-                    a_overlaps, b_overlaps, a_num, b_num, '.', 2)
+                    a_overlaps, b_overlaps, a_num, b_num, '.', 2, use_memmap_files=True)
             # Should be empty if no warnings were raised.
             assert not record
         if i != 2:

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -67,19 +67,20 @@ class TestInputs:
         np.save('{}/magref.npy'.format(self.b_cat_folder_path), np.zeros(2, float))
 
     def test_crossmatch_run_input(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
         with pytest.raises(FileNotFoundError):
-            cm = CrossMatch('./file.txt', './file2.txt', './file3.txt')
+            cm._initialise_chunk('./file.txt', './file2.txt', './file3.txt')
         with pytest.raises(FileNotFoundError):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                            './file2.txt', './file3.txt')
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                 './file2.txt', './file3.txt')
         with pytest.raises(FileNotFoundError):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                            './file3.txt')
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                 './file3.txt')
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.run_auf is False
         assert cm.run_group is False
         assert cm.run_cf is True
@@ -98,15 +99,16 @@ class TestInputs:
                           'data/crossmatch_params_.txt'))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
 
     def test_crossmatch_auf_cf_input(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.cf_region_frame == 'equatorial'
         assert_allclose(cm.cf_region_points,
                         np.array([[131, -1], [132, -1], [133, -1], [134, -1],
@@ -120,9 +122,9 @@ class TestInputs:
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                       idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.a_auf_region_frame == 'equatorial'
         assert_allclose(cm.a_auf_region_points,
                         np.array([[131, -1], [132, -1], [133, -1], [134, -1],
@@ -164,13 +166,13 @@ class TestInputs:
                               'data/{}_.txt'.format(in_file)))
 
                 with pytest.raises(ValueError, match=match_text):
-                    cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                    cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                                                  'data/crossmatch_params{}.txt'.format(
                                                  '_' if 'cf' in kind else '')),
-                                    os.path.join(os.path.dirname(__file__),
+                                         os.path.join(os.path.dirname(__file__),
                                                  'data/cat_a_params{}.txt'.format(
                                                  '_' if 'cf' not in kind else '')),
-                                    os.path.join(os.path.dirname(__file__),
+                                         os.path.join(os.path.dirname(__file__),
                                                  'data/cat_b_params.txt'))
 
             # Check correct and incorrect *_region_points when *_region_type is 'points'
@@ -188,11 +190,11 @@ class TestInputs:
                           out_file=os.path.join(os.path.dirname(__file__),
                                                 'data/{}_2.txt'.format(in_file)))
 
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                 'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
+                                 os.path.join(os.path.dirname(__file__),
+                                 'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
             assert_allclose(getattr(cm, '{}{}points'.format('' if 'cf' in kind
                             else 'a_', kind)), np.array([[131, 0], [133, 0], [132, -1]]))
 
@@ -207,13 +209,13 @@ class TestInputs:
                                                     'data/{}_2.txt'.format(in_file)))
 
                 with pytest.raises(ValueError):
-                    cm = CrossMatch(os.path.join(os.path.dirname(__file__),
+                    cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                                                  'data/crossmatch_params{}.txt'.format(
                                                  '_2' if 'cf' in kind else '')),
-                                    os.path.join(os.path.dirname(__file__),
+                                         os.path.join(os.path.dirname(__file__),
                                                  'data/cat_a_params{}.txt'.format(
                                                  '_2' if 'cf' not in kind else '')),
-                                    os.path.join(os.path.dirname(__file__),
+                                         os.path.join(os.path.dirname(__file__),
                                                  'data/cat_b_params.txt'))
 
             # Check single-length point grids are fine
@@ -225,11 +227,11 @@ class TestInputs:
                           out_file=os.path.join(os.path.dirname(__file__),
                                                 'data/{}_.txt'.format(in_file)))
 
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format('_' if 'cf' in kind else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_' if 'cf' not in kind else '')),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                 'data/crossmatch_params{}.txt'.format('_' if 'cf' in kind else '')),
+                                 os.path.join(os.path.dirname(__file__),
+                                 'data/cat_a_params{}.txt'.format('_' if 'cf' not in kind else '')),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
             assert_allclose(getattr(cm, '{}{}points'.format('' if 'cf' in kind
                             else 'a_', kind)), np.array([[131, 0]]))
 
@@ -248,11 +250,11 @@ class TestInputs:
                           out_file=os.path.join(os.path.dirname(__file__),
                                                 'data/{}_2.txt'.format(in_file)))
 
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                            'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
-                            os.path.join(os.path.dirname(__file__),
-                            'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                 'data/crossmatch_params{}.txt'.format('_2' if 'cf' in kind else '')),
+                                 os.path.join(os.path.dirname(__file__),
+                                 'data/cat_a_params{}.txt'.format('_2' if 'cf' not in kind else '')),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
             assert_allclose(getattr(cm, '{}{}points'.format('' if 'cf' in kind
                             else 'a_', kind)), np.array([[131, 0]]))
 
@@ -268,9 +270,9 @@ class TestInputs:
                           out_file=os.path.join(os.path.dirname(__file__),
                                                 'data/{}_.txt'.format(in_file)))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
         for kind in ['auf_region_', 'cf_region_']:
             assert getattr(cm, '{}{}frame'.format('' if 'cf' in kind
                                                   else 'a_', kind)) == 'galactic'
@@ -281,9 +283,10 @@ class TestInputs:
                                       [131, 1], [132, 1], [133, 1], [134, 1]]))
 
     def test_crossmatch_folder_path_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.joint_folder_path == os.path.join(os.getcwd(), 'test_path')
         assert os.path.isdir(os.path.join(os.getcwd(), 'test_path'))
         assert cm.a_auf_folder_path == os.path.join(os.getcwd(), 'gaia_auf_folder')
@@ -308,18 +311,19 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(error, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params{}.txt'.format(
-                                '_' if 'h_p' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params{}.txt'.format(
+                                     '_' if 'h_p' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_tri_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert not hasattr(cm, 'a_tri_set_name')
 
         f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
@@ -330,9 +334,9 @@ class TestInputs:
                       'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.a_tri_set_name == 'gaiaDR2'
         assert np.all(cm.b_tri_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
         assert cm.a_tri_filt_num == 1
@@ -357,17 +361,18 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_psf_param_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.b_filt_names == np.array(['W1', 'W2', 'W3', 'W4']))
 
         f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
@@ -378,9 +383,9 @@ class TestInputs:
                       'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.a_psf_fwhms == np.array([0.12, 0.12, 0.12]))
 
         # List of simple one line config file replacements for error message checking
@@ -402,17 +407,18 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_cat_name_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.b_cat_name == 'WISE'
         assert os.path.exists('{}/test_path/WISE'.format(os.getcwd()))
 
@@ -426,14 +432,15 @@ class TestInputs:
 
         match_text = 'Missing key cat_name from catalogue "a"'
         with pytest.raises(ValueError, match=match_text):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
 
     def test_crossmatch_search_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.pos_corr_dist == 11
         assert not hasattr(cm, 'a_dens_dist')
         assert not hasattr(cm, 'b_dens_mags')
@@ -444,9 +451,9 @@ class TestInputs:
         _replace_line(os.path.join(os.path.dirname(__file__),
                       'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.a_dens_mags == np.array([20, 20, 20]))
         assert not hasattr(cm, 'b_dens_dist')
 
@@ -457,7 +464,7 @@ class TestInputs:
         _replace_line(os.path.join(os.path.dirname(__file__),
                       'data/crossmatch_params_.txt'), idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_2.txt'))
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_2.txt'),
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_2.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                         os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.a_dens_mags == np.array([20, 20, 20]))
@@ -486,13 +493,13 @@ class TestInputs:
                           'data/{}_{}.txt'.format(in_file, '3' if 'h_p' in in_file else '')))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params{}.txt'.format(
-                                '_3' if 'h_p' in in_file else '_2')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params{}.txt'.format(
+                                     '_3' if 'h_p' in in_file else '_2')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_perturb_auf_inputs(self):
         f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
@@ -503,9 +510,10 @@ class TestInputs:
                       'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.num_trials == 10000
         assert not cm.compute_local_density
         assert cm.dm_max == 10
@@ -535,12 +543,12 @@ class TestInputs:
                                   'data/crossmatch_params_2.txt')).readlines()
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_2.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params.txt'))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_2.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params.txt'))
 
         for cat_reg, cat_name in zip(['"a"', '"b"'], ['cat_a_params', 'cat_b_params']):
             f = open(os.path.join(os.path.dirname(__file__),
@@ -553,12 +561,12 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(cat_name)))
             with pytest.raises(ValueError,
                                match='Missing key fit_gal_flag from catalogue {}'.format(cat_reg)):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if 'a' in cat_reg else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if 'b' in cat_reg else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if 'a' in cat_reg else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if 'b' in cat_reg else '')))
 
         f = open(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt')).readlines()
         old_line = 'fit_gal_flag = no'
@@ -583,12 +591,12 @@ class TestInputs:
                       new_line, out_file=os.path.join(os.path.dirname(__file__),
                       'data/cat_b_params_.txt'))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                        'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__),
-                        'data/cat_a_params_.txt'),
-                        os.path.join(os.path.dirname(__file__),
-                        'data/cat_b_params_.txt'))
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                             'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__),
+                             'data/cat_a_params_.txt'),
+                             os.path.join(os.path.dirname(__file__),
+                             'data/cat_b_params_.txt'))
         assert_allclose(cm.a_gal_zmax, np.array([4.5, 4.5, 5.0]))
         assert np.all(cm.b_gal_nzs == np.array([33, 41, 11, 41]))
         assert np.all(cm.a_gal_filternames == ['gaiadr2-BP', 'gaiadr2-G', 'gaiadr2-RP'])
@@ -602,12 +610,12 @@ class TestInputs:
                           'data/cat_b_params__.txt'))
             with pytest.raises(ValueError,
                                match='Missing key {} from catalogue "b"'.format(key)):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params_.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params__.txt'))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params__.txt'))
 
         for old_line, new_line, match_text, file in zip(
                 ['gal_wavs = 0.513 0.641 0.778', 'gal_aboffsets = 0.5 0.5 0.5 0.5',
@@ -636,17 +644,18 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}__.txt'.format(file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_b_' in file else '__')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_a_' in file else '__')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_b_' in file else '__')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_a_' in file else '__')))
 
     def test_crossmatch_fourier_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.real_hankel_points == 10000
         assert cm.four_hankel_points == 10000
         assert cm.four_max_rho == 100
@@ -665,15 +674,16 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params_.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params_.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
 
     def test_crossmatch_frame_equality(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.a_auf_region_frame == 'equatorial'
         assert cm.b_auf_region_frame == 'equatorial'
         assert cm.cf_region_frame == 'equatorial'
@@ -694,18 +704,19 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params{}.txt'.format(
-                                '_' if 'h_p' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params{}.txt'.format(
+                                     '_' if 'h_p' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_cross_match_extent(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.cross_match_extent == np.array([131, 138, -3, 3]))
 
         # List of simple one line config file replacements for error message checking
@@ -724,18 +735,19 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params{}.txt'.format(
-                                '_' if 'h_p' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params{}.txt'.format(
+                                     '_' if 'h_p' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_int_fracs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.int_fracs == np.array([0.63, 0.9, 0.99]))
 
         # List of simple one line config file replacements for error message checking
@@ -753,18 +765,19 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params{}.txt'.format(
-                                '_' if 'h_p' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params{}.txt'.format(
+                                     '_' if 'h_p' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_chunk_num(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.mem_chunk_num == 10)
 
         # List of simple one line config file replacements for error message checking
@@ -782,27 +795,29 @@ class TestInputs:
                           os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
 
             with pytest.raises(ValueError, match=match_text):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params{}.txt'.format(
-                                '_' if 'h_p' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
-                                os.path.join(os.path.dirname(__file__),
-                                'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params{}.txt'.format(
+                                     '_' if 'h_p' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_a_params{}.txt'.format('_' if '_a_' in in_file else '')),
+                                     os.path.join(os.path.dirname(__file__),
+                                     'data/cat_b_params{}.txt'.format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_shared_data(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.r == np.linspace(0, 11, 10000))
         assert_allclose(cm.dr, np.ones(9999, float) * 11/9999)
         assert np.all(cm.rho == np.linspace(0, 100, 10000))
         assert_allclose(cm.drho, np.ones(9999, float) * 100/9999)
 
     def test_cat_folder_path(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert os.path.exists(self.a_cat_folder_path)
         assert os.path.exists(self.b_cat_folder_path)
         assert cm.a_cat_folder_path == self.a_cat_folder_path
@@ -815,16 +830,16 @@ class TestInputs:
 
         os.system('rm -rf {}'.format(self.a_cat_folder_path))
         with pytest.raises(OSError, match="a_cat_folder_path does not exist."):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         self.setup_class()
 
         os.system('rm -rf {}'.format(self.b_cat_folder_path))
         with pytest.raises(OSError, match="b_cat_folder_path does not exist."):
-            cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                            os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+            cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                 os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         self.setup_class()
 
         for catpath, file in zip([self.a_cat_folder_path, self.b_cat_folder_path],
@@ -832,10 +847,10 @@ class TestInputs:
             os.system('rm {}/{}.npy'.format(catpath, file))
             with pytest.raises(FileNotFoundError,
                                match='{} file not found in catalogue '.format(file)):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
             self.setup_class()
 
         for name, data, match in zip(['con_cat_astro', 'con_cat_photo', 'con_cat_astro',
@@ -855,16 +870,17 @@ class TestInputs:
                                       'Consolidated catalogue arrays for catalogue "b"']):
             np.save('{}/{}.npy'.format(self.b_cat_folder_path, name), data)
             with pytest.raises(ValueError, match=match):
-                cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                'data/crossmatch_params.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                                os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                     'data/crossmatch_params.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                     os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
             self.setup_class()
 
     def test_calculate_cf_areas(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         cm.cross_match_extent = np.array([131, 134, -1, 1])
         cm.cf_region_points = np.array([[a, b] for a in [131.5, 132.5, 133.5]
                                         for b in [-0.5, 0.5]])

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -45,7 +45,8 @@ def test_create_fourier_offsets_grid():
             np.save('{}/{}/{}/fourier.npy'.format(ax1, ax2, filt),
                     (i + len(filt_names)*j)*np.ones((len(r[:-1]), a_len[i, j]), float))
 
-    create_auf_params_grid('.', auf_pointings, filt_names, 'fourier', len(r)-1)
+    create_auf_params_grid('.', auf_pointings, filt_names, 'fourier',
+                           use_memmap_files=True, len_first_axis=len(r)-1)
     a = np.lib.format.open_memmap('{}/fourier_grid.npy'.format(
         '.'), mode='r', dtype=float, shape=(9, 15, 2, 3), fortran_order=True)
     assert np.all(a.shape == (9, 15, 2, 3))
@@ -99,7 +100,7 @@ def test_hav_dist_constant_lat():
 
 def test_large_small_index():
     inds = np.array([0, 10, 15, 10, 35])
-    a, b = map_large_index_to_small_index(inds, 40, '.')
+    a, b = map_large_index_to_small_index(inds, 40, '.', use_memmap_files=True)
     assert np.all(a == np.array([0, 1, 2, 1, 3]))
     assert np.all(b == np.array([0, 10, 15, 35]))
 
@@ -136,5 +137,5 @@ def test_load_single_sky_slice():
 
     rng = np.random.default_rng(6123123)
     sky_inds = rng.choice(5, size=5000)
-    sky_cut = _load_single_sky_slice(folder_path, cat_name, ind, sky_inds)
+    sky_cut = _load_single_sky_slice(folder_path, cat_name, ind, sky_inds, use_memmap_files=True)
     assert np.all(sky_cut == (sky_inds == ind))

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -21,9 +21,10 @@ class TestCreatePerturbAUF:
     def setup_class(self):
         os.makedirs('gaia_auf_folder', exist_ok=True)
         os.makedirs('wise_auf_folder', exist_ok=True)
-        self.cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
+        self.cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        self.cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
+                                  os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
+                                  os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         self.cm.a_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
         self.cm.b_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
         self.cm.mem_chunk_num = 4
@@ -86,6 +87,7 @@ class TestCreatePerturbAUF:
         os.system("rm -rf {}/*".format(self.cm.a_auf_folder_path))
         os.system("rm -rf {}/*".format(self.cm.b_auf_folder_path))
         self.cm.run_auf = False
+
         with pytest.warns(UserWarning, match='Incorrect number of files in catalogue "a"'):
             self.cm.create_perturb_auf(self.files_per_auf_sim)
 
@@ -347,7 +349,7 @@ class TestMakePerturbAUFs():
 
         self.args = [self.auf_folder, self.cat_folder, self.filters, self.auf_points,
                      self.r, self.dr, self.rho, self.drho, self.which_cat,
-                     self.include_perturb_auf, self.mem_chunk_num]
+                     self.include_perturb_auf, self.mem_chunk_num, True]
 
         self.files_per_auf_sim = 7
 
@@ -680,10 +682,11 @@ class TestMakePerturbAUFs():
             _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'),
                           idx, nl)
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                     'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                          'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
 
         cm.a_auf_region_points = new_auf_points
         cm.b_auf_region_points = new_auf_points
@@ -834,10 +837,11 @@ class TestMakePerturbAUFs():
             _replace_line(os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'),
                           idx, nl)
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__),
-                                     'data/crossmatch_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
-                        os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                                          'data/crossmatch_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params_.txt'),
+                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
 
         cm.a_auf_region_points = self.auf_points
         cm.b_auf_region_points = self.auf_points

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from numpy.distutils.core import Extension, setup
 
 names = ['group_sources_fortran', 'misc_functions_fortran', 'counterpart_pairing_fortran',
          'photometric_likelihood_fortran', 'perturbation_auf_fortran']
-f90_args = ["-Wall", "-Wextra", "-Werror", "-pedantic", "-fbacktrace", "-O0", "-g", "-fcheck=all",
+f90_args = ["-Wall", "-Wextra", "-Werror", "-pedantic", "-fbacktrace", "-O3", "-g", "-fcheck=all",
             "-fopenmp"]
 
 extension = [Extension(name='macauff.{}'.format(name), sources=['macauff/{}.f90'.format(name)],

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
 	pandas
 	skypy
 	speclite
-	mpi4py
 	cov: coverage
 	build_docs: sphinx-fortran
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
 	pandas
 	skypy
 	speclite
+	mpi4py
 	cov: coverage
 	build_docs: sphinx-fortran
 


### PR DESCRIPTION
This pull request contains:

- MPI parallelisation
- Resume file capability
- Walltime monitoring
- Worker recovery
- All open_memmap() calls guarded by "if use_memmap_files:"
- New class "StageData" which holds outputs to pass between each pipeline stage
- Changes to test_full_match_process.py to test both use_memmap_files=True and use_memmap_files=False
- Skeleton of a post-processing function for chunks
- O3 optimisation of the Fortran routines