### PR TITLE
Fixes to GitHub CI Actions

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -21,16 +21,16 @@ jobs:
           - name: Linux, Python 3.9
             os: ubuntu-latest
             python-version: 3.9
-            # Include at least one coverage option for codecov.
-            toxenv: py39-test-cov
+            toxenv: py39-test
           - name: macOS, Python 3.8
-            os: macOS-11
+            os: macOS-latest
             python-version: 3.8
             toxenv: py38-test
-          - name: macOS, Python 3.9
-            os: macOS-11
-            python-version: 3.9
-            toxenv: py39-test
+          - name: macOS, Python 3.10, coverage
+            os: macOS-latest
+            python-version: "3.10"
+            # Include at least one coverage option for codecov.
+            toxenv: py310-test-cov
 
     steps:
       - uses: actions/checkout@v2

--- a/macauff/derive_psf_auf_params.py
+++ b/macauff/derive_psf_auf_params.py
@@ -133,6 +133,7 @@ class FitPSFPerturbations:
             dd[i, j, 1] = self.di[j]
 
         pool.close()
+        pool.join()
         np.save('{}/dd_Ld.npy'.format(self.data_save_folder), dd)
 
     def min_parallel_dd_fit(self, iterable):
@@ -321,6 +322,7 @@ class FitPSFPerturbations:
                     res = return_res
                     min_val = return_res.fun
             pool.close()
+            pool.join()
 
             dd_skew_pars[i, :-1] = res.x
             dd_skew_pars[i, -1] = cutr
@@ -509,6 +511,7 @@ class FitPSFPerturbations:
                     dd_params[j, i, :N, k] = res
 
             pool.close()
+            pool.join()
 
         # Keep track of the total goodness-of-fit values across all di-Li
         # combinations, as well as the goodness-of-fits just for individual
@@ -858,6 +861,7 @@ class FitPSFPerturbations:
             diff[i, 5] = dx_fit
 
         pool.close()
+        pool.join()
 
         ax = plt.subplot(gs[0, 3])
         hist, bins = np.histogram(diff[:, 0], bins='auto')

--- a/macauff/fit_astrometry.py
+++ b/macauff/fit_astrometry.py
@@ -437,6 +437,7 @@ class AstrometricCorrections:
                         ax1.set_ylabel('log10(SNR)', color='b')
 
             pool.close()
+            pool.join()
 
             if self.make_plots:
                 plt.tight_layout()
@@ -969,6 +970,7 @@ class AstrometricCorrections:
                     fit_nnf[i, 1] = np.sqrt(cov[1, 1])
 
             pool.close()
+            pool.join()
 
             resses = np.array(resses, dtype=object)
 
@@ -1289,6 +1291,7 @@ class AstrometricCorrections:
                 x2s[index, :, :] = chi_sq
 
         pool.close()
+        pool.join()
 
         if fit_x2_flag:
             np.save('{}/npy/fit_x2s.npy'.format(self.save_folder), np.array(x2s))
@@ -1560,6 +1563,7 @@ def create_densities(lmid, bmid, b, minmag, maxmag, lon_slice, lat_slice, lmin, 
             overlap_number[i] = len_query
 
         pool.close()
+        pool.join()
 
         area = paf.get_circle_area_overlap(
             b[:, 0], b[:, 1], search_radius/3600, lmin, lmax, bmin, bmax)

--- a/macauff/galactic_proper_motions.py
+++ b/macauff/galactic_proper_motions.py
@@ -101,6 +101,7 @@ def calculate_proper_motions(d, l, b, temp, N):
         pm[j, :, :, 3] = mu_b
 
     pool.close()
+    pool.join()
 
     return pm, type_fracs
 

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -462,8 +462,6 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     num_good_checks = 0
     num_a_failed_checks = 0
     num_b_failed_checks = 0
-    # Initialise the multiprocessing loop setup:
-    pool = multiprocessing.Pool(n_pool)
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(islelen*cnum/mem_chunk_num).astype(int)
         highind = np.floor(islelen*(cnum+1)/mem_chunk_num).astype(int)
@@ -495,6 +493,8 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
         expand_constants = [itertools.repeat(item) for item in [
             a_, b_, alist_1, blist_1, agrplen_small, bgrplen_small, ax_lims, max_sep]]
         iter_group = zip(counter, *expand_constants)
+        # Initialise the multiprocessing loop setup:
+        pool = multiprocessing.Pool(n_pool)
         for return_items in pool.imap_unordered(_distance_check, iter_group,
                                                 chunksize=max(1, len(counter) // n_pool)):
             i, dist_check, a, b = return_items
@@ -509,7 +509,8 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                 num_a_failed_checks += len(a)
                 num_b_failed_checks += len(b)
 
-    pool.close()
+        pool.close()
+        pool.join()
 
     # If set_list returned any rejected sources, then add any sources too close
     # to match extent to those now. Ensure that we only reject the unique source IDs
@@ -765,6 +766,7 @@ def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool, use_memmap_
         size[i] = y
 
     pool.close()
+    pool.join()
 
     # We ideally want to basically do np.asfortranarray(inds[:maxsize, :]), but
     # this would involve a copy instead of a read so we have to loop.

--- a/macauff/make_set_list.py
+++ b/macauff/make_set_list.py
@@ -103,6 +103,7 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool, 
         grouplengthexceeded[i] = len_exceeded_flag
 
     pool.close()
+    pool.join()
 
     if np.any(grouplengthexceeded):
         nremoveisland = np.sum(grouplengthexceeded)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py{38,39}-test{,-cov}
+	py{38,39,310}-test{,-cov}
 	build_docs
 
 isolated_build = true
@@ -34,6 +34,3 @@ commands =
 changedir = docs
 extras = docs
 commands = sphinx-build -W -b html . _build/html
-
-[coverage:run]
-sigterm = true


### PR DESCRIPTION
A number of fixes and improvements to ensure the GitHub CI run more reliably.
Following the bump from 3.7 to 3.8 due to multiprocessing issues, more issues were revealed with the interactions of `pytest` and `coverage`. To alleviate this,
1) `pool.join()` is always called after `pool.close()` to better allow workers to close nicely,
2) `coverage` no longer uses `sigterm` as this has related problems where `multiprocessing` can hang.
3) Coverage runs (`test-cov`) were moved from ubuntu to macOS as this appears, for now at least, to still allow for coverage of lines hit through `multiprocessing`, but this may be temporary and in future those lines may need to be covered separately to in smaller unittests to ensure trustworthy test/coverage results,
4) At the same time, tested Python was bumped to 3.10 for more complete coverage.