### PR TITLE
Fix gfortran symlink issues

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           sudo ln -s /usr/local/bin/gfortran-9 /usr/local/bin/gfortran
           sudo mkdir /usr/local/gfortran
-          sudo ln -s /usr/local/Cellar/gcc@9/9.3.0_1/lib/gcc/9 /usr/local/gfortran/lib
+          sudo ln -s /usr/local/Cellar/gcc@9/*/lib/gcc/9 /usr/local/gfortran/lib
       - if: runner.os == 'Linux'
         name: ubuntu gfortran
         run: sudo ln -sf /usr/bin/gfortran-9 /usr/bin/gfortran

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -23,11 +23,11 @@ jobs:
             python-version: 3.9
             toxenv: py39-test
           - name: macOS, Python 3.8
-            os: macOS-latest
+            os: macOS-11
             python-version: 3.8
             toxenv: py38-test
           - name: macOS, Python 3.10, coverage
-            os: macOS-latest
+            os: macOS-11
             python-version: "3.10"
             # Include at least one coverage option for codecov.
             toxenv: py310-test-cov


### PR DESCRIPTION
A github runner-related PR, minor fix to the CI workflow, in which `macOS-latest` bumping to macOS 12 caused issues with `gfortran-9` being dropped. For the minute, instead of worrying about upping our minimum gfortran version number, just drop back to `macOS-11`. Also generalised the gfortran number used during symlink, just in case that changes down the line.