### PR TITLE
Fix TRILEGAL parameters in make_perturb_aufs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Pass ``tri_maglim_bright``, ``tri_maglim_faint``, ``tri_num_bright``, and
+  ``tri_num_faint`` through to ``make_perturb_aufs`` in ``CrossMatch`` call. [#56]
+
 - Replaced ``datetime.strptime`` in the ``CrossMatch`` constructor with a
   string ``split`` to fix a crash when given walltime is greater than
   ``24:00:00``. [#52]
@@ -121,6 +124,13 @@ Bug Fixes
 
 API Changes
 ^^^^^^^^^^^
+
+- ``tri_maglim_bright``, ``tri_maglim_faint``, ``tri_num_bright``, and
+  ``tri_num_faint`` are only required if ``tri_download_flag`` is ``True``. [#56]
+
+- ``tri_filt_num``, ``tri_set_name``, and ``auf_region_frame`` updated to be
+  necessary inputs into ``make_perturb_aufs`` even if ``tri_download_flag``
+  is not set. [#56]
 
 - Added ``run_fw_auf``, ``run_psf_auf``, ``mag_h_params_path``,
   ``tri_maglim_bright``, ``tri_maglim_faint``, ``tri_num_bright``, and

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -995,7 +995,11 @@ class CrossMatch():
                            'd_mag': self.d_mag, 'tri_filt_names': self.a_tri_filt_names,
                            'compute_local_density': self.compute_local_density,
                            'run_fw': self.a_run_fw_auf, 'run_psf': self.a_run_psf_auf,
-                           'mag_h_params': self.a_mag_h_params}
+                           'mag_h_params': self.a_mag_h_params,
+                           'tri_maglim_bright': self.a_tri_maglim_bright,
+                           'tri_maglim_faint': self.a_tri_maglim_faint,
+                           'tri_num_bright': self.a_tri_num_bright,
+                           'tri_num_faint': self.a_tri_num_faint}
                 missing_tri_check = np.any(
                     [[not os.path.isfile('{}/{}/{}/trilegal_auf_simulation_{}.dat'.format(
                      self.a_auf_folder_path, a, b, t)) for (a, b) in self.a_auf_region_points]
@@ -1069,7 +1073,11 @@ class CrossMatch():
                            'd_mag': self.d_mag, 'tri_filt_names': self.b_tri_filt_names,
                            'compute_local_density': self.compute_local_density,
                            'run_fw': self.b_run_fw_auf, 'run_psf': self.b_run_psf_auf,
-                           'mag_h_params': self.b_mag_h_params}
+                           'mag_h_params': self.b_mag_h_params,
+                           'tri_maglim_bright': self.b_tri_maglim_bright,
+                           'tri_maglim_faint': self.b_tri_maglim_faint,
+                           'tri_num_bright': self.b_tri_num_bright,
+                           'tri_num_faint': self.b_tri_num_faint}
                 missing_tri_check = np.any(
                     [[not os.path.isfile('{}/{}/{}/trilegal_auf_simulation_{}.dat'.format(
                      self.b_auf_folder_path, a, b, t)) for (a, b) in self.b_auf_region_points]

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -999,19 +999,13 @@ class CrossMatch():
                            'tri_maglim_bright': self.a_tri_maglim_bright,
                            'tri_maglim_faint': self.a_tri_maglim_faint,
                            'tri_num_bright': self.a_tri_num_bright,
-                           'tri_num_faint': self.a_tri_num_faint}
-                missing_tri_check = np.any(
-                    [[not os.path.isfile('{}/{}/{}/trilegal_auf_simulation_{}.dat'.format(
-                     self.a_auf_folder_path, a, b, t)) for (a, b) in self.a_auf_region_points]
-                     for t in ['bright', 'faint']])
+                           'tri_num_faint': self.a_tri_num_faint,
+                           'tri_set_name': self.a_tri_set_name,
+                           'tri_filt_num': self.a_tri_filt_num,
+                           'auf_region_frame': self.a_auf_region_frame}
                 if self.a_run_psf_auf:
                     _kwargs = dict(_kwargs, **{'dd_params': self.a_dd_params,
                                                'l_cut': self.a_l_cut})
-                if self.a_download_tri or missing_tri_check:
-                    _kwargs = dict(_kwargs,
-                                   **{'tri_set_name': self.a_tri_set_name,
-                                      'tri_filt_num': self.a_tri_filt_num,
-                                      'auf_region_frame': self.a_auf_region_frame})
                 if self.a_fit_gal_flag:
                     _kwargs = dict(_kwargs,
                                    **{'fit_gal_flag': self.a_fit_gal_flag,
@@ -1077,19 +1071,14 @@ class CrossMatch():
                            'tri_maglim_bright': self.b_tri_maglim_bright,
                            'tri_maglim_faint': self.b_tri_maglim_faint,
                            'tri_num_bright': self.b_tri_num_bright,
-                           'tri_num_faint': self.b_tri_num_faint}
-                missing_tri_check = np.any(
-                    [[not os.path.isfile('{}/{}/{}/trilegal_auf_simulation_{}.dat'.format(
-                     self.b_auf_folder_path, a, b, t)) for (a, b) in self.b_auf_region_points]
-                     for t in ['bright', 'faint']])
+                           'tri_num_faint': self.b_tri_num_faint,
+                           'tri_set_name': self.b_tri_set_name,
+                           'tri_filt_num': self.b_tri_filt_num,
+                           'auf_region_frame': self.b_auf_region_frame}
                 if self.b_run_psf_auf:
                     _kwargs = dict(_kwargs, **{'dd_params': self.b_dd_params,
                                                'l_cut': self.b_l_cut})
-                if self.b_download_tri or missing_tri_check:
-                    _kwargs = dict(_kwargs,
-                                   **{'tri_set_name': self.b_tri_set_name,
-                                      'tri_filt_num': self.b_tri_filt_num,
-                                      'auf_region_frame': self.b_auf_region_frame})
+
                 if self.b_fit_gal_flag:
                     _kwargs = dict(_kwargs,
                                    **{'fit_gal_flag': self.b_fit_gal_flag,

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -90,7 +90,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     tri_filt_names : list or array of strings, optional
         List of filter names in the TRILEGAL filterset defined in ``tri_set_name``,
         in the same order as provided in ``psf_fwhms``. If ``include_perturb_auf``
-        and ``tri_download_flag`` are ``True``, this must be set.
+        is ``True``, this must be set.
     tri_maglim_bright : float
         Magnitude in the primary ``tri_filt_num`` filter to simulate sources to
         in the smaller "bright" simulation, used to ensure accurate statistics

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -82,12 +82,11 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         required if ``include_perturb_auf`` is True; defaults to ``None``.
     tri_set_name : string, optional
         Name of the filter set to generate simulated TRILEGAL Galactic source
-        counts from. If ``include_perturb_auf`` and ``tri_download_flag`` are
-        ``True``, this must be set.
+        counts from. If ``include_perturb_auf`` is ``True``, this must be set.
     tri_filt_num : string, optional
         Column number of the filter defining the magnitude limit of simulated
-        TRILEGAL Galactic sources. If ``include_perturb_auf`` and
-        ``tri_download_flag`` are ``True``, this must be set.
+        TRILEGAL Galactic sources. If ``include_perturb_auf`` is ``True``, this
+        must be set.
     tri_filt_names : list or array of strings, optional
         List of filter names in the TRILEGAL filterset defined in ``tri_set_name``,
         in the same order as provided in ``psf_fwhms``. If ``include_perturb_auf``
@@ -116,8 +115,8 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     auf_region_frame : string, optional
         Coordinate reference frame in which sky coordinates are defined, either
         ``equatorial`` or ``galactic``, used to define the coordinates TRILEGAL
-        simulations are generated in. If ``include_perturb_auf`` and
-        ``tri_download_flag`` are ``True``, this must be set.
+        simulations are generated in. If ``include_perturb_auf`` is ``True``,
+        this must be set.
     num_trials : integer, optional
         The number of simulated PSFs to compute in the derivation of the
         perturbation component of the AUF. Must be given if ``include_perturb_auf``
@@ -219,18 +218,14 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
     .. [3] Blanton M. R., Roweis S. (2007), AJ, 133, 734
 
     """
-    if include_perturb_auf and tri_download_flag and tri_set_name is None:
-        raise ValueError("tri_set_name must be given if include_perturb_auf and tri_download_flag "
-                         "are both True.")
-    if include_perturb_auf and tri_download_flag and tri_filt_num is None:
-        raise ValueError("tri_filt_num must be given if include_perturb_auf and tri_download_flag "
-                         "are both True.")
-    if include_perturb_auf and tri_download_flag and auf_region_frame is None:
-        raise ValueError("auf_region_frame must be given if include_perturb_auf and "
-                         "tri_download_flag are both True.")
-
+    if include_perturb_auf and tri_set_name is None:
+        raise ValueError("tri_set_name must be given if include_perturb_auf is True.")
+    if include_perturb_auf and tri_filt_num is None:
+        raise ValueError("tri_filt_num must be given if include_perturb_auf is True.")
     if include_perturb_auf and tri_filt_names is None:
         raise ValueError("tri_filt_names must be given if include_perturb_auf is True.")
+    if include_perturb_auf and auf_region_frame is None:
+        raise ValueError("auf_region_frame must be given if include_perturb_auf is True.")
     if include_perturb_auf and delta_mag_cuts is None:
         raise ValueError("delta_mag_cuts must be given if include_perturb_auf is True.")
     if include_perturb_auf and psf_fwhms is None:

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -95,23 +95,21 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         Magnitude in the primary ``tri_filt_num`` filter to simulate sources to
         in the smaller "bright" simulation, used to ensure accurate statistics
         at the bright end of the dynamic survey range. If ``include_perturb_auf``
-        and ``tri_download_flag`` are ``True``, this must be set.
+        is ``True``, this must be set.
     tri_maglim_faint : float
         Magnitude in the primary TRILEGAL filter to simulate sources down to for
         the main, "faint" simulation, used to capture the differential source
-        counts at all appropriate magnitudes. If ``include_perturb_auf`` and
-        ``tri_download_flag`` are ``True``, this must be set.
+        counts at all appropriate magnitudes. If ``include_perturb_auf`` is
+        ``True``, this must be set.
     tri_num_bright : integer
         Number of objects to simulate in the bright TRILEGAL simulation. Should
         be large enough to capture robust number statistics at bright, low
         source count brightnesses, but low enough to be realistic in runtime.
-        If ``include_perturb_auf`` and ``tri_download_flag`` are ``True``, this
-        must be set.
+        If ``include_perturb_auf`` is ``True``, this must be set.
     tri_num_faint : integer
         Number of objects to simulate in the main TRILEGAL simulation. Should
         capture sufficient numbers to be accurate without overrunning simulation
-        times. If ``include_perturb_auf`` and ``tri_download_flag`` are ``True``,
-        this must be set.
+        times. If ``include_perturb_auf`` is ``True``, this must be set.
     auf_region_frame : string, optional
         Coordinate reference frame in which sky coordinates are defined, either
         ``equatorial`` or ``galactic``, used to define the coordinates TRILEGAL
@@ -224,6 +222,14 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
         raise ValueError("tri_filt_num must be given if include_perturb_auf is True.")
     if include_perturb_auf and tri_filt_names is None:
         raise ValueError("tri_filt_names must be given if include_perturb_auf is True.")
+    if include_perturb_auf and tri_maglim_bright is None:
+        raise ValueError("tri_maglim_bright must be given if include_perturb_auf is True.")
+    if include_perturb_auf and tri_maglim_faint is None:
+        raise ValueError("tri_maglim_faint must be given if include_perturb_auf is True.")
+    if include_perturb_auf and tri_num_bright is None:
+        raise ValueError("tri_num_bright must be given if include_perturb_auf is True.")
+    if include_perturb_auf and tri_num_faint is None:
+        raise ValueError("tri_num_faint must be given if include_perturb_auf is True.")
     if include_perturb_auf and auf_region_frame is None:
         raise ValueError("auf_region_frame must be given if include_perturb_auf is True.")
     if include_perturb_auf and delta_mag_cuts is None:

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -464,130 +464,193 @@ class TestMakePerturbAUFs():
 
     def test_raise_value_errors(self):
         with pytest.raises(ValueError, match='tri_set_name must be given if include_perturb_auf ' +
-                           'and tri_download_flag are both True'):
-            make_perturb_aufs(*self.args, tri_download_flag=True)
+                           'is True'):
+            make_perturb_aufs(*self.args)
         with pytest.raises(ValueError, match='tri_filt_num must be given if include_perturb_auf ' +
-                           'and tri_download_flag are both True'):
-            make_perturb_aufs(*self.args, tri_download_flag=True, tri_set_name='WISE')
-        with pytest.raises(ValueError, match='auf_region_frame must be given if ' +
-                           'include_perturb_auf and tri_download_flag are both True'):
-            make_perturb_aufs(*self.args, tri_download_flag=True, tri_set_name='WISE',
-                              tri_filt_num=1)
-
+                           'is True'):
+            make_perturb_aufs(*self.args, tri_set_name='WISE')
         with pytest.raises(ValueError, match='tri_filt_names must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args)
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1)
+        with pytest.raises(ValueError, match='tri_maglim_bright must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1)
+        with pytest.raises(ValueError, match='tri_maglim_faint must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1)
+        with pytest.raises(ValueError, match='tri_num_bright must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1)
+        with pytest.raises(ValueError, match='tri_num_faint must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1)
+        with pytest.raises(ValueError, match='auf_region_frame must be given if ' +
+                           'include_perturb_auf is True'):
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1)
         with pytest.raises(ValueError, match='delta_mag_cuts must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1)
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1)
         with pytest.raises(ValueError, match='psf_fwhms must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1)
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1)
         with pytest.raises(ValueError, match='num_trials must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1)
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1)
         with pytest.raises(ValueError, match='j0s must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1)
         with pytest.raises(ValueError, match='density_mags must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1)
         with pytest.raises(ValueError, match='d_mag must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1)
         with pytest.raises(ValueError, match='run_fw must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1, d_mag=1)
         with pytest.raises(ValueError, match='run_psf must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1, d_mag=1, run_fw=1)
         with pytest.raises(ValueError, match='dd_params must be given if ' +
                            'include_perturb_auf and run_psf are True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1, d_mag=1, run_fw=1, run_psf=1)
         with pytest.raises(ValueError, match='l_cut must be given if ' +
                            'include_perturb_auf and run_psf are True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1, d_mag=1, run_fw=1, run_psf=1,
                               dd_params=1)
         with pytest.raises(ValueError, match='mag_h_params must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1, d_mag=1, run_fw=1, run_psf=1,
                               dd_params=1, l_cut=1)
         with pytest.raises(ValueError, match='compute_local_density must be given if ' +
                            'include_perturb_auf is True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1, psf_fwhms=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1, psf_fwhms=1,
                               num_trials=1, j0s=1, density_mags=1, d_mag=1, run_fw=1, run_psf=1,
                               dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='density_radius must be given if ' +
                            'include_perturb_auf and compute_local_density are both True'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=True, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1,
                               mag_h_params=1)
         with pytest.raises(ValueError, match='fit_gal_flag must not be None if include_'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1,
                               mag_h_params=1)
         with pytest.raises(ValueError, match='cmau_array must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, run_fw=1, run_psf=1,
                               dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='wavs must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, run_fw=1,
                               run_psf=1, dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='z_maxs must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               run_fw=1, run_psf=1, dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='nzs must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='ab_offsets must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, nzs=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1,
                               mag_h_params=1)
         with pytest.raises(ValueError, match='filter_names must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, nzs=1, ab_offsets=1, run_fw=1, run_psf=1, dd_params=1,
                               l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='al_avs must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, run_fw=1, run_psf=1,
                               dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='alpha0 must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, run_fw=1,
                               run_psf=1, dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='alpha1 must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, alpha0=1,
                               run_fw=1, run_psf=1, dd_params=1, l_cut=1, mag_h_params=1)
         with pytest.raises(ValueError, match='alpha_weight must be given if fit_gal_flag is True.'):
-            make_perturb_aufs(*self.args, tri_filt_names=1, delta_mag_cuts=1,
+            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
+                              tri_maglim_bright=1, tri_maglim_faint=1, tri_num_bright=1,
+                              tri_num_faint=1, auf_region_frame=1, delta_mag_cuts=1,
                               compute_local_density=False, psf_fwhms=1, num_trials=1, j0s=1,
                               density_mags=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
                               z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, alpha0=1,

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -727,11 +727,14 @@ class TestMakePerturbAUFs():
 
         N = 15
         for i in range(N):
-            make_perturb_aufs(*self.args, psf_fwhms=self.psf_fwhms, num_trials=self.num_trials,
-                              j0s=self.j0s, density_mags=cutoff_mags, d_mag=d_mag,
-                              delta_mag_cuts=self.delta_mag_cuts, compute_local_density=False,
-                              tri_filt_names=self.tri_filt_names, fit_gal_flag=False,
-                              run_fw=True, run_psf=False, mag_h_params=mag_h_params)
+            make_perturb_aufs(
+                *self.args, tri_set_name='WISE', tri_filt_num=11,
+                tri_filt_names=self.tri_filt_names, tri_maglim_bright=15, tri_maglim_faint=32,
+                tri_num_bright=10000, tri_num_faint=1000000, auf_region_frame='galactic',
+                psf_fwhms=self.psf_fwhms, num_trials=self.num_trials, j0s=self.j0s,
+                density_mags=cutoff_mags, d_mag=d_mag, delta_mag_cuts=self.delta_mag_cuts,
+                compute_local_density=False, fit_gal_flag=False, run_fw=True, run_psf=False,
+                mag_h_params=mag_h_params)
 
             if i == 0:
                 for name, size in zip(
@@ -849,12 +852,14 @@ class TestMakePerturbAUFs():
             l_cut = np.load(os.path.join(os.path.dirname(__file__), 'data/l_cut.npy'))
             dd_params = np.load(os.path.join(os.path.dirname(__file__), 'data/dd_params.npy'))
             run_fw = False if mag < 19 else True
-            make_perturb_aufs(*self.args, psf_fwhms=self.psf_fwhms, num_trials=self.num_trials,
-                              j0s=self.j0s, density_mags=cutoff_mags, d_mag=d_mag,
-                              delta_mag_cuts=self.delta_mag_cuts, compute_local_density=False,
-                              tri_filt_names=self.tri_filt_names, fit_gal_flag=False,
-                              run_fw=run_fw, run_psf=True, mag_h_params=mag_h_params,
-                              dd_params=dd_params, l_cut=l_cut)
+            make_perturb_aufs(
+                *self.args, tri_set_name='WISE', tri_filt_num=11,
+                tri_filt_names=self.tri_filt_names, tri_maglim_bright=15, tri_maglim_faint=32,
+                tri_num_bright=10000, tri_num_faint=1000000, auf_region_frame='galactic',
+                psf_fwhms=self.psf_fwhms, num_trials=self.num_trials, j0s=self.j0s,
+                density_mags=cutoff_mags, d_mag=d_mag, delta_mag_cuts=self.delta_mag_cuts,
+                compute_local_density=False, fit_gal_flag=False, run_fw=run_fw, run_psf=True,
+                mag_h_params=mag_h_params, dd_params=dd_params, l_cut=l_cut)
 
             for name, size in zip(
                     ['frac', 'flux', 'offset', 'cumulative', 'fourier', 'N', 'mag'],


### PR DESCRIPTION
Bugfix PR to:
1) Add checks for tri_[maglim/num]_[bright/faint] within ``make_perturb_aufs`` in cases where ``None`` is passed
2) Fix specific cases where ``download_trilegal_simulation`` might be called due to missing input files but keywords where not available
3) Fix small cases in docstrings where they don't match error checks
4) Pass tri_*_* through from ``CrossMatch``