### PR TITLE
Fix issue with `tox` 4 and errors due to no folder

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -59,7 +59,9 @@ jobs:
           pip install numpy
           pip install tox
       - name: Run tests with remote
-        run: tox -e ${{ matrix.toxenv }} -- --remote-data
+        run: |
+          mkdir ./.tmp/${{ matrix. toxenv }}
+          tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation
         run: tox -e build_docs
       - name: Upload coverage to codecov

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -60,6 +60,7 @@ jobs:
           pip install tox
       - name: Run tests with remote
         run: |
+          mkdir ./.tmp
           mkdir ./.tmp/${{ matrix. toxenv }}
           tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation


### PR DESCRIPTION
Minor PR to explicitly make the `changedir` directory before starting `pytest` within `tox` due to it not being created anymore.