### PR TITLE
Restructure `AstrometricCorrections` to be able to perform fits to astrometry in `CrossMatch`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,6 +138,12 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Added parameters ... to inputs to ``CrossMatch`` to allow for astrometric corrections
+  through ``AstrometricCorrections`` directly before a cross-match. [#62]
+
+- Requirements for ... inputs to ``CrossMatch`` changed to either require
+  ``include_perturb_auf`` or ``correct_astrometry``. [#62]
+
 - Removed expectation of parameters ``tri_num_bright`` and ``tri_maglim_bright`` from
   ``CrossMatch`` input parameter files. Currently only expect the "faint" versions
   due to limits with requesting significant numbers of bright TRILEGAL objects. [#61]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,10 +153,10 @@ API Changes
 - Added parameters ``correct_astrometry``, ``best_mag_index``, ``nn_radius``,
   ``correct_astro_save_folder``, ``csv_cat_file_string``,
   ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``,
-  ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, and
-  ``mag_unc_indices`` as catalogue-level inputs to ``CrossMatch`` to allow for
-  astrometric corrections through ``AstrometricCorrections`` directly before a
-  cross-match. [#62]
+  ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``,
+  ``mag_unc_indices``, ``chunk_overlap_col``, and ``best_mag_index_col`` as
+  catalogue-level inputs to ``CrossMatch`` to allow for astrometric corrections
+  through ``AstrometricCorrections`` directly before a cross-match. [#62]
 
 - Requirements for ``num_trials``, ``d_mag``, ``run_fw_auf``, ``run_psf_auf``,
   ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- ``mag_h_params`` renamed to ``snr_mag_params`` to ensure commonality of the
+  reference and parameter without the codebase. [#62]
+
 - ``AstrometricCorrections`` makes a correctly multi-magnitude SNR model
   array. [#59]
 
@@ -138,11 +141,31 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
-- Added parameters ... to inputs to ``CrossMatch`` to allow for astrometric corrections
-  through ``AstrometricCorrections`` directly before a cross-match. [#62]
+- In ``AstrometricCorrections``, ``triname`` now requires either one or two
+  ``{}`` Python string formats, depending on ``coord_or_chunk``. [#62]
 
-- Requirements for ... inputs to ``CrossMatch`` changed to either require
-  ``include_perturb_auf`` or ``correct_astrometry``. [#62]
+- All ``recreate`` flags all removed from ``AstrometricCorrections``, which now
+  loops on a per-sightline basis instead of using per-step loops. [#62]
+
+- Added ``n_pool`` as input to ``CrossMatch`` to control the number of threads used
+  in ``multiprocessing`` calls. [#62]
+
+- Added parameters ``correct_astrometry``, ``best_mag_index``, ``nn_radius``,
+  ``correct_astro_save_folder``, ``csv_cat_file_string``,
+  ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``,
+  ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, and
+  ``mag_unc_indices`` as catalogue-level inputs to ``CrossMatch`` to allow for
+  astrometric corrections through ``AstrometricCorrections`` directly before a
+  cross-match. [#62]
+
+- Requirements for ``num_trials``, ``d_mag``, ``run_fw_auf``, ``run_psf_auf``,
+  ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``,
+  ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``,
+  ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``,
+  ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``,
+  ``gal_filternames``, and ``gal_al_avs`` inputs to ``CrossMatch`` changed to
+  either require ``include_perturb_auf`` (and lower-level input criteria) or
+  ``correct_astrometry``. [#62]
 
 - Removed expectation of parameters ``tri_num_bright`` and ``tri_maglim_bright`` from
   ``CrossMatch`` input parameter files. Currently only expect the "faint" versions

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -59,7 +59,8 @@ and those options which only need to be supplied if ``include_perturb_auf`` is `
 
 ``num_trials``, ``compute_local_density``, and ``d_mag``.
 
-Note that ``num_trials`` and ``d_mag`` currently need to be supplied if either ``correct_astrometry`` option in the two `Catalogue-specific Parameters`_ config files is ``True`` as well.
+.. note::
+    ``num_trials`` and ``d_mag`` currently need to be supplied if either ``correct_astrometry`` option in the two `Catalogue-specific Parameters`_ config files is ``True`` as well.
 
 Common Parameter Description
 ----------------------------
@@ -185,7 +186,8 @@ and the inputs required if ``correct_astrometry`` is ``True``:
 
 ``best_mag_index``, ``nn_radius``, ``correct_astro_save_folder``, ``csv_cat_file_string``, ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``, ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, and ``mag_unc_indices``.
 
-Note that ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``, ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs`` are all currently required if ``correct_astrometry`` is ``True``, bypassing the nested flags above. For example, ``dens_dist`` is required as an input if ``compute_local_density`` and ``include_perturb_auf`` are both ``True``, or if ``correct_astrometry`` is set. This means that ``AstrometricCorrections`` implicitly always runs and fits for a full Astrometric Uncertainty Function.
+.. note::
+    ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``, ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs`` are all currently required if ``correct_astrometry`` is ``True``, bypassing the nested flags above. For example, ``dens_dist`` is required as an input if ``compute_local_density`` and ``include_perturb_auf`` are both ``True``, or if ``correct_astrometry`` is set. This means that ``AstrometricCorrections`` implicitly always runs and fits for a full Astrometric Uncertainty Function.
 
 
 Catalogue Parameter Description

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -53,7 +53,7 @@ These parameters are only provided in the single, common-parameter input file, a
 
 There are some parameters that must be given in all runs:
 
-``joint_folder_path``, ``run_auf``, ``run_group``, ``run_cf``, ``run_source``, ``include_perturb_auf``, ``include_phot_like``, ``use_phot_priors``, ``cross_match_extent``, ``mem_chunk_num``, ``pos_corr_dist``, ``cf_region_type``, ``cf_region_frame``, ``cf_region_points``, ``real_hankel_points``, ``four_hankel_points``, ``four_max_rho``, and ``int_fracs``;
+``joint_folder_path``, ``run_auf``, ``run_group``, ``run_cf``, ``run_source``, ``include_perturb_auf``, ``include_phot_like``, ``use_phot_priors``, ``cross_match_extent``, ``mem_chunk_num``, ``pos_corr_dist``, ``cf_region_type``, ``cf_region_frame``, ``cf_region_points``, ``real_hankel_points``, ``four_hankel_points``, ``four_max_rho``, ``int_fracs``, and ``n_pool``;
 
 and those options which only need to be supplied if ``include_perturb_auf`` is ``True``:
 
@@ -133,6 +133,10 @@ The integer number of points for approximating the inverse Hankel transformation
 
 The largest fourier-space value, up to which inverse Hankel transformation integrals are considered. Should typically be larger than the inverse of the smallest typical centroiding Gaussian one-dimensional uncertainty.
 
+``n_pool``
+
+Determines how many CPUs are used when parallelising within ``Python`` using ``multiprocessing``.
+
 ``int_fracs``
 
 The integral fractions of the various so-called "error circles" used in the cross-match process. Should be space-separated floats, in the order of: bright error circle fraction, "field" error circle fraction, and potential counterpart cutoff limit.
@@ -157,7 +161,7 @@ These parameters are required in two separate files, one per catalogue to be cro
 
 These can be divided into those inputs that are always required:
 
-``cat_folder_path``, ``cat_name``, ``filt_names``, ``auf_folder_path``, ``auf_region_type``, ``auf_region_frame``, and ``auf_region_points``;
+``cat_folder_path``, ``cat_name``, ``filt_names``, ``auf_folder_path``, ``auf_region_type``, ``auf_region_frame``, ``auf_region_points``, and ``correct_astrometry``;
 
 those that are only required if the `Joint Parameters`_ option ``include_perturb_auf`` is ``True``:
 
@@ -167,13 +171,17 @@ parameters required if ``run_psf_auf`` is ``True``:
 
 ``dd_params_path`` and ``l_cut_path``;
 
-the parameter only needed if `Joint Parameters`_ option ``compute_local_density`` is ``True``:
+the parameter needed if `Joint Parameters`_ option ``compute_local_density`` is ``True`` (and hence ``include_perturb_auf`` is ``True``) or if ``correct_astrometry`` is ``True``:
 
 ``dens_dist``;
 
-and the inputs required in each catalogue parameters file if ``fit_gal_flag`` is ``True``:
+the inputs required in each catalogue parameters file if ``fit_gal_flag`` is ``True`` (and hence ``include_perturb_auf`` is ``True``):
 
-``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs``.
+``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs``;
+
+and the inputs required if ``correct_astrometry`` is ``True``:
+
+``best_mag_index``, ``nn_radius``, ``correct_astro_save_folder``, ``csv_cat_file_string``, ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``, ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, and ``mag_unc_indices``.
 
 
 Catalogue Parameter Description
@@ -206,6 +214,10 @@ As with ``auf_region_frame``, this flag indicates which frame the data, and thus
 ``auf_region_points``
 
 Based on ``auf_region_type``, this must either by six space-separated floats, controlling the start and end, and number of, longitude and latitude points in ``start lon end lon # steps start lat end lat #steps`` order (see ``cf_region_points``), or a series of comma-separated tuples cf. ``(a, b), (c, d)``.
+
+``correct_astrometry``
+
+In cases where catalogues have unreliable *centroid* uncertainties, before catalogue matching occurs the dataset can be fit for systematic corrections to its quoted astrometric precisions through ensemble match separation distance distributions to a higher-precision dataset (see the :doc:`Processing<pre_post_process>` section). This flag controls whether this is performed on a chunk-by-chunk basis during the initialisation step of ``CrossMatch``.
 
 ``fit_gal_flag``
 
@@ -290,6 +302,50 @@ Name of each filter as appropriate for providing to ``speclite`` for each filter
 ``gal_al_avs``
 
 Differential extinction relative to the V-band for each filter, a set of space-separated floats. Must be provided if ``fit_gal_flag`` is ``True``.
+
+``best_mag_index``
+
+For the purposes of correcting systematic biases in a given catalogue, a single photometric band is used. ``best_mag_index`` indicates which filter to use -- e.g., ``best_mag_index = 0`` says to use the first filter as given in ``filt_names`` or ``mag_indices``. Must be a single integer value no larger than ``len(filt_names)-1``.
+
+``nn_radius``
+
+Nearest neighbour radius out to which to search for potential counterparts for the purposes of ensemble match separation distributions; should be a single float.
+
+``correct_astro_save_folder``
+
+File path, relative or absolute, into which to save files as generated by the astrometric correction process.
+
+``csv_cat_file_string``
+
+Path and filename, all in a single string, containing the location of each correction sightline's dataset to test. Must contain the appropriate number of string format ``{}`` identifiers depending on ``coord_or_chunk`` -- in this case, a single "chunk" identifier for corrections done through ``CrossMatch``. For example, ``/your/path/to/file/data_{}.csv`` where each "chunk" is saved into a csv file called ``data_1``, ``data_2``, ``data_104`` etc.
+
+``ref_csv_cat_file_string``
+
+Similar to ``csv_cat_file_string``, but the path and filename of the *reference* dataset used in the matching process. These chunks should correspond one-to-one with those used in ``csv_cat_file_string`` -- i.e., ``data_1.csv`` in ``/your/path/to/file`` should be the same region of the sky as the reference catalogue in ``/another/path/to/elsewhere/reference_data_1.csv``, potentially with some buffer overlap to avoid false matches at the edges.
+
+``correct_mag_array``
+
+List of magnitudes at which to evaluate the distribution of matches to the higher-astrometric-precision dataset in the chosen ``best_mag_index`` filter. Accepts a list of floats.
+
+``correct_mag_slice``
+
+Corresponding to each magnitude in ``correct_mag_array``, each element of this list of floats should be a width around each ``correct_mag_array`` element to select sources, ensuring a small sub-set of similar brightness objects are used to determine the Astrometric Uncertainty Function of.
+
+``correct_sig_slice``
+
+Elementwise with ``correct_mag_array`` and ``correct_mag_slice``, a list of floats of widths of astrometric precision to select a robust sub-sample of objects in each magnitude bin for, ensuring a self-similar AUF.
+
+``pos_and_err_indices``
+
+A list of six integers, the first three elements of which are the zero-indexed indices into the *reference* catalogue .csv file (``ref_csv_cat_file_string``) for the longitudinal coordinate, latitudinal coordinate, and circular astrometric precision respectively, followed by the lon/lat/uncert of the *input* catalogue. For example, ``0 1 2 10 9 8`` suggests that the reference catalogue begins with the position and uncertainty of its objects while the catalogue "a" or "b" sources have, in their original .csv file, a backwards list of coordinates and precisions towards the final columns of the filing system.
+
+``mag_indices``
+
+Just for the input catalogue, a list of ``len(filt_names)`` space-separated integers detailing the zero-indexed column number of the magnitudes in the dataset.
+
+``mag_unc_indices``
+
+Similar to ``mag_indices``, a list of ``len(mag_indices)`` space-separated integers, one for each column in ``mag_indices`` for where the corresponding uncertainty column is held for each magnitude in the input .csv file.
 
 .. rubric:: Footnotes
 

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -184,7 +184,7 @@ the inputs required in each catalogue parameters file if ``fit_gal_flag`` is ``T
 
 and the inputs required if ``correct_astrometry`` is ``True``:
 
-``best_mag_index``, ``nn_radius``, ``correct_astro_save_folder``, ``csv_cat_file_string``, ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``, ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, and ``mag_unc_indices``.
+``best_mag_index``, ``nn_radius``, ``correct_astro_save_folder``, ``csv_cat_file_string``, ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``, ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, ``mag_unc_indices``, ``chunk_overlap_col``, and ``best_mag_index_col``.
 
 .. note::
     ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``, ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs`` are all currently required if ``correct_astrometry`` is ``True``, bypassing the nested flags above. For example, ``dens_dist`` is required as an input if ``compute_local_density`` and ``include_perturb_auf`` are both ``True``, or if ``correct_astrometry`` is set. This means that ``AstrometricCorrections`` implicitly always runs and fits for a full Astrometric Uncertainty Function.
@@ -352,6 +352,15 @@ Just for the input catalogue, a list of ``len(filt_names)`` space-separated inte
 ``mag_unc_indices``
 
 Similar to ``mag_indices``, a list of ``len(mag_indices)`` space-separated integers, one for each column in ``mag_indices`` for where the corresponding uncertainty column is held for each magnitude in the input .csv file.
+
+``chunk_overlap_col``
+
+Column number in the original csv file for the column containing the boolean flag indicating whether sources are in the "halo" or "core" of the chunk. Used within ``CrossMatch`` after calling ``AstrometricCorrections`` to create final npy files via ``csv_to_npy``. Should be a single integer number.
+
+``best_mag_index_col``
+
+The zero-indexed integer column number in the original input csv file used in ``AstrometricCorrections`` that corresponds to the column containing the highest quality detection for each source in the catalogue, used when calling ``csv_to_npy``.
+
 
 .. rubric:: Footnotes
 

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -59,6 +59,8 @@ and those options which only need to be supplied if ``include_perturb_auf`` is `
 
 ``num_trials``, ``compute_local_density``, and ``d_mag``.
 
+Note that ``num_trials`` and ``d_mag`` currently need to be supplied if either ``correct_astrometry`` option in the two `Catalogue-specific Parameters`_ config files is ``True`` as well.
+
 Common Parameter Description
 ----------------------------
 
@@ -165,13 +167,13 @@ These can be divided into those inputs that are always required:
 
 those that are only required if the `Joint Parameters`_ option ``include_perturb_auf`` is ``True``:
 
-``fit_gal_flag``, ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``dens_mags``, ``mag_h_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, and ``tri_num_faint``;
+``fit_gal_flag``, ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, and ``tri_num_faint``;
 
 parameters required if ``run_psf_auf`` is ``True``:
 
 ``dd_params_path`` and ``l_cut_path``;
 
-the parameter needed if `Joint Parameters`_ option ``compute_local_density`` is ``True`` (and hence ``include_perturb_auf`` is ``True``) or if ``correct_astrometry`` is ``True``:
+the parameter needed if `Joint Parameters`_ option ``compute_local_density`` is ``True`` (and hence ``include_perturb_auf`` is ``True``):
 
 ``dens_dist``;
 
@@ -182,6 +184,8 @@ the inputs required in each catalogue parameters file if ``fit_gal_flag`` is ``T
 and the inputs required if ``correct_astrometry`` is ``True``:
 
 ``best_mag_index``, ``nn_radius``, ``correct_astro_save_folder``, ``csv_cat_file_string``, ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``, ``correct_sig_slice``, ``pos_and_err_indices``, ``mag_indices``, and ``mag_unc_indices``.
+
+Note that ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``dens_mags``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``, ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs`` are all currently required if ``correct_astrometry`` is ``True``, bypassing the nested flags above. For example, ``dens_dist`` is required as an input if ``compute_local_density`` and ``include_perturb_auf`` are both ``True``, or if ``correct_astrometry`` is set. This means that ``AstrometricCorrections`` implicitly always runs and fits for a full Astrometric Uncertainty Function.
 
 
 Catalogue Parameter Description
@@ -239,9 +243,9 @@ The Full-Width-At-Half-Maximum of each filter's Point Spread Function (PSF), in 
 
 The magnitude, in each bandpass -- the same order as ``filt_names`` -- down to which to count the number of nearby sources when deriving the local normalising density of each object. Should be space-separated floats, of the same number as those given in ``filt_names``.
 
-``mag_h_params_path``
+``snr_mag_params_path``
 
-File path, either absolute or relative to the location of the script the cross-matches are run from, of a binary ``.npy`` file containing the parameterisation of the signal-to-noise ratio of sources as a function of magnitude, in a series of given sightlines. Must be of shape ``(N, M, 5)`` where ``N`` is the number of filters in ``filt_names`` order, ``M`` is the number of sightlines for which SNR vs mag has been derived, and the 5 entries for each filter-sightline combination must be in order ``a``, ``b``, ``c``, ``coord1`` (e.g. RA), and ``coord2`` (e.g. Dec). See pre-processing for more information on the meaning of those terms and how ``mag_h_params`` is used.
+File path, either absolute or relative to the location of the script the cross-matches are run from, of a binary ``.npy`` file containing the parameterisation of the signal-to-noise ratio of sources as a function of magnitude, in a series of given sightlines. Must be of shape ``(N, M, 5)`` where ``N`` is the number of filters in ``filt_names`` order, ``M`` is the number of sightlines for which SNR vs mag has been derived, and the 5 entries for each filter-sightline combination must be in order ``a``, ``b``, ``c``, ``coord1`` (e.g. RA), and ``coord2`` (e.g. Dec). See pre-processing for more information on the meaning of those terms and how ``snr_mag_params`` is used.
 
 ``download_tri``
 

--- a/macauff/fit_astrometry.py
+++ b/macauff/fit_astrometry.py
@@ -1474,6 +1474,11 @@ class AstrometricCorrections:
         return m_sig, n_sig
 
     def finalise_summary_plot(self):
+        """
+        After running all of the sightlines' fits, generate a final
+        summary plot of the sig-sig relations, quality of fits, and
+        resulting "m" and "n" scaling parameters.
+        """
         ax_d = plt.subplot(self.gs[1])
         q = ~np.isnan(self.x2s[:, 0])
         chi_sqs, dofs = self.x2s[:, 0][q].flatten(), self.x2s[:, 1][q].flatten()

--- a/macauff/fit_astrometry.py
+++ b/macauff/fit_astrometry.py
@@ -405,19 +405,92 @@ class AstrometricCorrections:
         if not self.pregenerate_cutouts:
             self.make_catalogue_cutouts()
 
-        self.make_snr_model()
+        # Making coords/cutouts happens for all sightlines, and then we
+        # loop through each individually:
+        if self.coord_or_chunk == 'coord':
+            zip_list = (self.ax1_mids, self.ax2_mids, self.ax1_mins, self.ax1_maxs,
+                        self.ax2_mins, self.ax2_maxs)
+        else:
+            zip_list = (self.ax1_mids, self.ax2_mids, self.ax1_mins, self.ax1_maxs, self.ax2_mins,
+                        self.ax2_maxs, self.chunks)
+        # TODO: add checkpointing -- some kind of saved binary file?
+        # TODO: memmap save abc_array to also checkpoint its determination
+        abc_array = np.empty((len(self.mag_indices), len(self.ax1_mids), 3), float)
+        # TODO: memmap save m_sigs/n_sigs to also checkpoint them
+        m_sigs = np.empty_like(self.ax1_mids)
+        n_sigs = np.empty_like(self.ax1_mids)
 
-        self.make_star_galaxy_counts()
-        if self.make_plots:
-            self.plot_star_galaxy_counts()
-        self.calculate_local_densities_and_nearest_neighbours()
-        self.simulate_aufs()
-        self.create_auf_pdfs()
-        self.fit_uncertainty()
-        if self.make_plots or (self.fit_x2s_recreate or not
-                               os.path.isfile('{}/npy/fit_x2s.npy'.format(self.save_folder))):
+        if self.make_summary_plot:
+            self.gs = self.make_gridspec('12312', 2, 2, 0.8, 10)
+            self.ax_b = plt.subplot(self.gs[0])
+
+            self.ylims = [999, 0]
+
+            self.cols = ['k', 'r', 'b', 'g', 'c', 'm', 'orange', 'brown', 'purple', 'grey', 'olive',
+                         'cornflowerblue', 'deeppink', 'maroon', 'palevioletred', 'teal', 'crimson',
+                         'chocolate', 'darksalmon', 'steelblue', 'slateblue', 'tan', 'yellowgreen',
+                         'silver']
+
+        for index_, list_of_things in enumerate(zip(*zip_list)):
+            print('Running astrometry fits for sightline {}/{}...'.format(
+                index_+1, len(self.ax1_mids)))
+
+            if self.coord_or_chunk == 'coord':
+                ax1_mid, ax2_mid, _, _, _, _ = list_of_things
+                cat_args = (ax1_mid, ax2_mid)
+                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
+            else:
+                ax1_mid, ax2_mid, _, _, _, _, chunk = list_of_things
+                cat_args = (chunk,)
+                file_name = '{}'.format(chunk)
+            self.list_of_things = list_of_things
+            self.cat_args = cat_args
+            self.file_name = file_name
+
+            self.a = self.load_catalogue('a', self.cat_args)
+            self.b = self.load_catalogue('b', self.cat_args)
+
+            self.a_array, self.b_array, self.c_array = self.make_snr_model()
+            abc_array[:, index_, 0] = self.a_array
+            abc_array[:, index_, 1] = self.b_array
+            abc_array[:, index_, 2] = self.c_array
+
+            self.make_star_galaxy_counts()
+            if self.make_plots:
+                self.plot_star_galaxy_counts()
+            self.calculate_local_densities_and_nearest_neighbours()
+            self.simulate_aufs()
+            self.create_auf_pdfs()
+            self.fit_uncertainty()
             self.plot_fits_calculate_chi_sq()
-        self.make_ma_fits_snr_h_plot()
+            m_sig, n_sig = self.make_ma_fits_snr_h_plot()
+            m_sigs[index_] = m_sig
+            n_sigs[index_] = n_sig
+            if self.make_summary_plot:
+                plt.figure('12312')
+                c = self.cols[index_ % len(self.cols)]
+                self.ax_b.errorbar(self.avg_sig[~self.skip_flags, 0],
+                                   self.fit_sigs[~self.skip_flags, 0],
+                                   linestyle='None', c=c, marker='.')
+                self.ylims[0] = min(self.ylims[0], np.amin(self.fit_sigs[:, 0]))
+                self.ylims[1] = max(self.ylims[1], np.amax(self.fit_sigs[:, 0]))
+
+        np.save('{}/npy/snr_mag_params.npy'.format(self.save_folder), abc_array)
+        np.save('{}/npy/m_sigs_array.npy'.format(self.save_folder), m_sigs)
+        np.save('{}/npy/n_sigs_array.npy'.format(self.save_folder), n_sigs)
+        self.m_sigs, self.n_sigs = m_sigs, n_sigs
+        if self.make_summary_plot:
+            plt.figure('12312')
+            x_array = np.linspace(0, self.ax_b.get_xlim()[1], 100)
+            self.ax_b.plot(x_array, x_array, 'g:')
+            self.ax_b.set_ylim(0.95 * self.ylims[0], 1.05 * self.ylims[1])
+            if usetex:
+                self.ax_b.set_xlabel(r'Input astrometric $\sigma$ / "')
+                self.ax_b.set_ylabel(r'Fit astrometric $\sigma$ / "')
+            else:
+                self.ax_b.set_xlabel(r'Input astrometric sigma / "')
+                self.ax_b.set_ylabel(r'Fit astrometric sigma / "')
+            self.finalise_summary_plot()
 
     def make_ax_coords(self):
         """
@@ -550,74 +623,66 @@ class AstrometricCorrections:
         :math:`S = 10^{-M/2.5}`, and hence typical magnitude-SNR
         relations are completely described by ``a``, ``b``, and ``c``.
         """
-        if (self.snr_model_recreate or not
-                os.path.isfile('{}/npy/snr_mag_params.npy'.format(self.save_folder))):
-            print("Making SNR model...")
-            abc_array = np.empty((len(self.mag_indices), len(self.ax1_mids), 3), float)
-            for j in range(len(self.mag_indices)):
-                if self.make_plots:
-                    gs = self.make_gridspec('2', self.ax2_grid_length, self.ax1_grid_length, 0.8, 8)
 
-                pool = multiprocessing.Pool(self.n_pool)
-                counter = np.arange(0, len(self.ax1_mids))
-                if self.coord_or_chunk == 'coord':
-                    iter_group = zip(counter, self.ax1_mids, self.ax2_mids, itertools.repeat(j))
+        print("Making SNR model...")
+        a_array = np.ones(len(self.mag_indices), float) * np.nan
+        b_array = np.ones(len(self.mag_indices), float) * np.nan
+        c_array = np.ones(len(self.mag_indices), float) * np.nan
+        if self.coord_or_chunk == 'coord':
+            ax1_mid, ax2_mid, _, _, _, _ = self.list_of_things
+        else:
+            ax1_mid, ax2_mid, _, _, _, _, _ = self.list_of_things
+        if self.make_plots:
+            gs = self.make_gridspec('2', self.n_mag_cols, self.n_mag_rows, 0.8, 8)
+        for j in range(len(self.mag_indices)):
+            (res, s_bins, s_d_snr_med,
+             s_d_snr_dmed, snr_med, snr_dmed) = self.fit_snr_model(j)
+
+            a, b, c = 10**res.x
+            a_array[j] = a
+            b_array[j] = b
+            c_array[j] = c
+
+            if self.make_plots:
+                q = ~np.isnan(s_d_snr_med)
+                _x = np.linspace(s_bins[0], s_bins[-1], 10000)
+
+                ax = plt.subplot(gs[j])
+                ax.plot(_x, np.log10(np.sqrt(c * 10**_x + b + (a * 10**_x)**2)),
+                        'r-', zorder=5)
+
+                ax.errorbar((s_bins[:-1]+np.diff(s_bins)/2)[q], s_d_snr_med[q], fmt='k.',
+                            yerr=s_d_snr_dmed[q], zorder=3)
+
+                ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
+                ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
+                ax.set_title('{} = {}, {} = {}\na = {:.2e}, b = {:.2e}, c = {:.2e}'
+                             .format(ax1_name, ax1_mid, ax2_name, ax2_mid, a, b, c),
+                             fontsize=28)
+
+                if usetex:
+                    ax.set_xlabel('log$_{10}$(S)')
+                    ax.set_ylabel('log$_{10}$(S / SNR)')
                 else:
-                    iter_group = zip(counter, self.chunks, itertools.repeat(j))
+                    ax.set_xlabel('log10(S)')
+                    ax.set_ylabel('log10(S / SNR)')
 
-                for results in pool.imap_unordered(self.fit_snr_model, iter_group, chunksize=2):
-                    i, res, s_bins, s_d_snr_med, s_d_snr_dmed, snr_med, snr_dmed = results
-                    a, b, c = 10**res.x
-                    abc_array[j, i, 0] = a
-                    abc_array[j, i, 1] = b
-                    abc_array[j, i, 2] = c
+                ax1 = ax.twinx()
+                ax1.errorbar((s_bins[:-1]+np.diff(s_bins)/2)[q], snr_med[q], fmt='b.',
+                             yerr=snr_dmed[q], zorder=3)
+                ax1.plot(_x, np.log10(10**_x / np.sqrt(c * 10**_x + b + (a * 10**_x)**2)),
+                         'r--', zorder=5)
+                if usetex:
+                    ax1.set_ylabel('log$_{10}$(SNR)', color='b')
+                else:
+                    ax1.set_ylabel('log10(SNR)', color='b')
 
-                    ax1_mid, ax2_mid = self.ax1_mids[i], self.ax2_mids[i]
+            if self.make_plots:
+                plt.tight_layout()
+                plt.savefig('{}/pdf/s_vs_snr_{}.pdf'.format(self.save_folder, self.file_name))
+                plt.close()
 
-                    if self.make_plots:
-                        q = ~np.isnan(s_d_snr_med)
-                        _x = np.linspace(s_bins[0], s_bins[-1], 10000)
-
-                        ax = plt.subplot(gs[i])
-                        ax.plot(_x, np.log10(np.sqrt(c * 10**_x + b + (a * 10**_x)**2)),
-                                'r-', zorder=5)
-
-                        ax.errorbar((s_bins[:-1]+np.diff(s_bins)/2)[q], s_d_snr_med[q], fmt='k.',
-                                    yerr=s_d_snr_dmed[q], zorder=3)
-
-                        ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
-                        ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
-                        ax.set_title('{} = {}, {} = {}\na = {:.2e}, b = {:.2e}, c = {:.2e}'
-                                     .format(ax1_name, ax1_mid, ax2_name, ax2_mid, a, b, c),
-                                     fontsize=28)
-
-                        if usetex:
-                            ax.set_xlabel('log$_{10}$(S)')
-                            ax.set_ylabel('log$_{10}$(S / SNR)')
-                        else:
-                            ax.set_xlabel('log10(S)')
-                            ax.set_ylabel('log10(S / SNR)')
-
-                        ax1 = ax.twinx()
-                        ax1.errorbar((s_bins[:-1]+np.diff(s_bins)/2)[q], snr_med[q], fmt='b.',
-                                     yerr=snr_dmed[q], zorder=3)
-                        ax1.plot(_x, np.log10(10**_x / np.sqrt(c * 10**_x + b + (a * 10**_x)**2)),
-                                 'r--', zorder=5)
-                        if usetex:
-                            ax1.set_ylabel('log$_{10}$(SNR)', color='b')
-                        else:
-                            ax1.set_ylabel('log10(SNR)', color='b')
-
-                pool.close()
-                pool.join()
-
-                if self.make_plots:
-                    plt.tight_layout()
-                    plt.savefig('{}/pdf/s_vs_snr_{}.pdf'.format(self.save_folder,
-                                                                self.mag_names[j]))
-                    plt.close()
-
-            np.save('{}/npy/snr_mag_params.npy'.format(self.save_folder), abc_array)
+        return a_array, b_array, c_array
 
     def make_gridspec(self, name, y, x, ratio, z, **kwargs):
         """
@@ -648,22 +713,18 @@ class AstrometricCorrections:
 
         return gs
 
-    def fit_snr_model(self, iterable):
+    def fit_snr_model(self, j):
         """
         Function to derive the scaling relation between magnitude via flux
         and SNR.
 
         Parameters
         ----------
-        iterable : list
-            List of input parameters as passed through ``multiprocessing``.
-            Includes central and corner coordinates of region, and the
-            name of the catalogue on disk.
+        j : integer
+            Index into ``self.mag_indices``.
 
         Returns
         -------
-        i : integer
-            Index into ``self.ax1_mids``.
         res : ~scipy.optimize.OptimizeResult`
             Contains the results of the minimisation, as determined by `scipy`.
         s_bins : numpy.ndarray
@@ -715,16 +776,9 @@ class AstrometricCorrections:
             return np.sum((f - y)**2), np.array([np.sum(2 * (f - y) * i)
                                                  for i in [dfda, dfdb, dfdc]])
 
-        if self.coord_or_chunk == 'coord':
-            i, ax1_mid, ax2_mid, j = iterable
-            b = self.load_catalogue('b', (ax1_mid, ax2_mid))
-        else:
-            i, chunk, j = iterable
-            b = self.load_catalogue('b', (chunk,))
-
-        s = 10**(-1/2.5 * b[:, self.mag_indices[j]])
+        s = 10**(-1/2.5 * self.b[:, self.mag_indices[j]])
         # Based on a naive dm = 2.5 log10((S+N)/S).
-        snr = 1 / (10**(b[:, self.mag_unc_indices[j]] / 2.5) - 1)
+        snr = 1 / (10**(self.b[:, self.mag_unc_indices[j]] / 2.5) - 1)
 
         q = ~np.isnan(s) & ~np.isnan(snr) & (snr > 2)
         s, snr = s[q], snr[q]
@@ -765,7 +819,7 @@ class AstrometricCorrections:
                        s_d_snr_med[q]), x0=[a_guess, b_guess, c_guess], jac=True,
                        method='SLSQP')
 
-        return i, res, s_bins, s_d_snr_med, s_d_snr_dmed, snr_med, snr_dmed
+        return res, s_bins, s_d_snr_med, s_d_snr_dmed, snr_med, snr_dmed
 
     def make_star_galaxy_counts(self):
         """
@@ -793,204 +847,146 @@ class AstrometricCorrections:
         self.gal_alphaweight = [[3.47e+09, 3.31e+06, 2.13e+09, 1.64e+10, 1.01e+09],
                                 [3.84e+09, 1.57e+06, 3.91e+08, 4.66e+10, 3.03e+07]]
 
+        print('Creating simulated star+galaxy counts...')
         if self.coord_or_chunk == 'coord':
-            zip_list = (self.ax1_mids, self.ax2_mids)
+            ax1_mid, ax2_mid, _, _, _, _ = self.list_of_things
         else:
-            zip_list = (self.ax1_mids, self.ax2_mids, self.chunks)
-        for index_, list_of_things in enumerate(zip(*zip_list)):
-            print('Creating simulated star+galaxy counts... {}/{}'.format(
-                  index_+1, len(self.ax1_mids)), end='\r')
-            if self.coord_or_chunk == 'coord':
-                ax1_mid, ax2_mid = list_of_things
-                cat_args = (ax1_mid, ax2_mid)
-                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
-            else:
-                ax1_mid, ax2_mid, chunk = list_of_things
-                cat_args = (chunk,)
-                file_name = '{}'.format(chunk)
-            if not self.count_recreate and \
-                    os.path.isfile('{}/npy/sim_counts_{}.npz'.format(
-                                   self.save_folder, file_name)):
-                continue
+            ax1_mid, ax2_mid, _, _, _, _, _ = self.list_of_things
 
-            if (self.tri_download or not
-                    os.path.isfile('{}/{}_faint.dat'.format(
-                        self.trifolder, self.triname.format(ax1_mid, ax2_mid)))):
-                download_trilegal_simulation('.', self.trifilterset, ax1_mid, ax2_mid, self.magnum,
-                                             self.coord_system, self.maglim_f,
-                                             total_objs=self.tri_num_faint)
-                os.system('mv trilegal_auf_simulation.dat {}/{}_faint.dat'
-                          .format(self.trifolder, self.triname.format(ax1_mid, ax2_mid)))
+        if (self.tri_download or not
+                os.path.isfile('{}/{}_faint.dat'.format(
+                    self.trifolder, self.triname.format(ax1_mid, ax2_mid)))):
+            download_trilegal_simulation('.', self.trifilterset, ax1_mid, ax2_mid, self.magnum,
+                                         self.coord_system, self.maglim_f,
+                                         total_objs=self.tri_num_faint)
+            os.system('mv trilegal_auf_simulation.dat {}/{}_faint.dat'
+                      .format(self.trifolder, self.triname.format(ax1_mid, ax2_mid)))
 
-            tri_hist, tri_mags, _, dtri_mags, tri_uncert, tri_av = make_tri_counts(
-                self.trifolder, self.triname.format(ax1_mid, ax2_mid), self.trifiltname, self.dm)
-            gal_dNs = create_galaxy_counts(
-                self.gal_cmau_array, tri_mags+dtri_mags/2, np.linspace(0, 4, 41),
-                self.gal_wav_micron, self.gal_alpha0, self.gal_alpha1, self.gal_alphaweight,
-                self.gal_ab_offset, self.gal_filtname, self.gal_alav*tri_av)
+        tri_hist, tri_mags, _, dtri_mags, tri_uncert, tri_av = make_tri_counts(
+            self.trifolder, self.triname.format(ax1_mid, ax2_mid), self.trifiltname, self.dm)
+        gal_dNs = create_galaxy_counts(
+            self.gal_cmau_array, tri_mags+dtri_mags/2, np.linspace(0, 4, 41),
+            self.gal_wav_micron, self.gal_alpha0, self.gal_alpha1, self.gal_alphaweight,
+            self.gal_ab_offset, self.gal_filtname, self.gal_alav*tri_av)
 
-            log10y = np.log10(tri_hist + gal_dNs)
-            new_uncert = np.sqrt(tri_uncert**2 + (0.05*gal_dNs)**2)
-            dlog10y = 1/np.log(10) * new_uncert / (tri_hist + gal_dNs)
+        log10y = np.log10(tri_hist + gal_dNs)
+        new_uncert = np.sqrt(tri_uncert**2 + (0.05*gal_dNs)**2)
+        dlog10y = 1/np.log(10) * new_uncert / (tri_hist + gal_dNs)
 
-            b = self.load_catalogue('b', cat_args)
-            mag_ind = self.mag_indices[self.best_mag_index]
-            hist_mag, bins = np.histogram(b[~np.isnan(b[:, mag_ind]), mag_ind], bins='auto')
-            minmag = bins[0]
-            # Ensure that we're only counting sources for normalisation purposes
-            # down to specified bright_mag or the completeness turnover,
-            # whichever is brighter.
-            maxmag = min(self.bright_mag, bins[:-1][np.argmax(hist_mag)])
+        mag_ind = self.mag_indices[self.best_mag_index]
+        hist_mag, bins = np.histogram(self.b[~np.isnan(self.b[:, mag_ind]), mag_ind], bins='auto')
+        minmag = bins[0]
+        # Ensure that we're only counting sources for normalisation purposes
+        # down to specified bright_mag or the completeness turnover,
+        # whichever is brighter.
+        maxmag = min(self.bright_mag, bins[:-1][np.argmax(hist_mag)])
 
-            mag_slice = (tri_mags >= minmag) & (tri_mags+dtri_mags <= maxmag)
-            N_norm = np.sum(10**log10y[mag_slice] * dtri_mags[mag_slice])
-            np.savez('{}/npy/sim_counts_{}.npz'.format(
-                     self.save_folder, file_name), log10y, dlog10y, tri_hist, tri_mags,
-                     dtri_mags, tri_uncert, [tri_av], gal_dNs, [minmag], [maxmag], [N_norm])
-        print('')
+        mag_slice = (tri_mags >= minmag) & (tri_mags+dtri_mags <= maxmag)
+        N_norm = np.sum(10**log10y[mag_slice] * dtri_mags[mag_slice])
+        self.log10y, self.dlog10y = log10y, dlog10y
+        self.tri_hist, self.tri_mags, self.dtri_mags = tri_hist, tri_mags, dtri_mags
+        self.tri_uncert, self.tri_av, self.gal_dNs = tri_uncert, tri_av, gal_dNs
+        self.minmag, self.maxmag, self.N_norm = minmag, maxmag, N_norm
 
     def plot_star_galaxy_counts(self):
         """
         Plotting routine to display data and model differential source counts,
         for verification purposes.
         """
-        if (self.count_recreate or self.cat_recreate or not
-                os.path.isfile('{}/pdf/counts_comparison.pdf'.format(self.save_folder))):
-            gs = self.make_gridspec('123123', self.ax2_grid_length, self.ax1_grid_length, 0.8, 15)
-            if self.coord_or_chunk == 'coord':
-                zip_list = (self.ax1_mids, self.ax2_mids, self.ax1_mins, self.ax1_maxs,
-                            self.ax2_mins, self.ax2_maxs)
-            else:
-                zip_list = (self.ax1_mids, self.ax2_mids, self.ax1_mins, self.ax1_maxs,
-                            self.ax2_mins, self.ax2_maxs, self.chunks)
-            for index_, list_of_things in enumerate(zip(*zip_list)):
-                print('Plotting data and model counts... {}/{}'.format(
-                      index_+1, len(self.ax1_mids)), end='\r')
+        gs = self.make_gridspec('123123', 1, 1, 0.8, 15)
+        print('Plotting data and model counts...')
 
-                if self.coord_or_chunk == 'coord':
-                    ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max = list_of_things
-                    cat_args = (ax1_mid, ax2_mid)
-                    file_name = '{}_{}'.format(ax1_mid, ax2_mid)
-                else:
-                    ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max, chunk = list_of_things
-                    cat_args = (chunk,)
-                    file_name = '{}'.format(chunk)
+        if self.coord_or_chunk == 'coord':
+            ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max = self.list_of_things
+        else:
+            ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max, _ = self.list_of_things
 
-                b = self.load_catalogue('b', cat_args)
-                npyfilez = np.load('{}/npy/sim_counts_{}.npz'.format(
-                                   self.save_folder, file_name))
-                (log10y, dlog10y, tri_hist, tri_mags, dtri_mags, tri_uncert, [tri_av], gal_dNs,
-                 [minmag], [maxmag], [N_norm]) = [npyfilez['arr_{}'.format(ii)] for ii in range(11)]
+        # Unit area is cos(t) dt dx for 0 <= t <= 90deg, 0 <= x <= 360 deg,
+        # integrated between ax2_min < t < ax2_max, ax1_min < x < ax1_max, converted
+        # to degrees.
+        rect_area = (ax1_max - (ax1_min)) * (
+            np.sin(np.radians(ax2_max)) - np.sin(np.radians(ax2_min))) * 180/np.pi
 
-                # Unit area is cos(t) dt dx for 0 <= t <= 90deg, 0 <= x <= 360 deg,
-                # integrated between ax2_min < t < ax2_max, ax1_min < x < ax1_max, converted
-                # to degrees.
-                rect_area = (ax1_max - (ax1_min)) * (
-                    np.sin(np.radians(ax2_max)) - np.sin(np.radians(ax2_min))) * 180/np.pi
+        mag_ind = self.mag_indices[self.best_mag_index]
+        data_mags = self.b[~np.isnan(self.b[:, mag_ind]), mag_ind]
+        # Correction to model is the ratio of data counts per unit area
+        # to model source density.
+        correction = np.sum((data_mags >= self.minmag) &
+                            (data_mags <= self.maxmag)) / rect_area / self.N_norm
 
-                mag_ind = self.mag_indices[self.best_mag_index]
-                data_mags = b[~np.isnan(b[:, mag_ind]), mag_ind]
-                # Correction to model is the ratio of data counts per unit area
-                # to model source density.
-                correction = np.sum((data_mags >= minmag) &
-                                    (data_mags <= maxmag)) / rect_area / N_norm
+        ax = plt.subplot(gs[0])
+        ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
+        ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
+        ax.set_title('{} = {}, {} = {}'.format(ax1_name, ax1_mid, ax2_name, ax2_mid))
+        ax.errorbar(self.tri_mags+self.dtri_mags/2, self.log10y + np.log10(correction),
+                    yerr=self.dlog10y, c='k', marker='.', zorder=1, ls='None')
 
-                ax = plt.subplot(gs[index_])
-                ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
-                ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
-                ax.set_title('{} = {}, {} = {}'.format(ax1_name, ax1_mid, ax2_name, ax2_mid))
-                ax.errorbar(tri_mags+dtri_mags/2, log10y + np.log10(correction), yerr=dlog10y,
-                            c='k', marker='.', zorder=1, ls='None')
+        data_hist, data_bins = np.histogram(data_mags, bins='auto')
+        d_hc = np.where(data_hist > 3)[0]
+        data_hist = data_hist[d_hc]
+        data_dbins = np.diff(data_bins)[d_hc]
+        data_bins = data_bins[d_hc]
 
-                data_hist, data_bins = np.histogram(data_mags, bins='auto')
-                d_hc = np.where(data_hist > 3)[0]
-                data_hist = data_hist[d_hc]
-                data_dbins = np.diff(data_bins)[d_hc]
-                data_bins = data_bins[d_hc]
+        data_uncert = np.sqrt(data_hist) / data_dbins / rect_area
+        data_hist = data_hist / data_dbins / rect_area
+        data_loghist = np.log10(data_hist)
+        data_dloghist = 1/np.log(10) * data_uncert / data_hist
+        ax.errorbar(data_bins+data_dbins/2, data_loghist, yerr=data_dloghist, c='r',
+                    marker='.', zorder=1, ls='None')
 
-                data_uncert = np.sqrt(data_hist) / data_dbins / rect_area
-                data_hist = data_hist / data_dbins / rect_area
-                data_loghist = np.log10(data_hist)
-                data_dloghist = 1/np.log(10) * data_uncert / data_hist
-                ax.errorbar(data_bins+data_dbins/2, data_loghist, yerr=data_dloghist, c='r',
-                            marker='.', zorder=1, ls='None')
+        lims = ax.get_ylim()
+        ax.plot(self.tri_mags+self.dtri_mags/2, np.log10(self.tri_hist) + np.log10(correction),
+                'b--')
+        ax.plot(self.tri_mags+self.dtri_mags/2, np.log10(self.gal_dNs) + np.log10(correction), 'b:')
+        ax.set_ylim(*lims)
 
-                lims = ax.get_ylim()
-                ax.plot(tri_mags+dtri_mags/2, np.log10(tri_hist) + np.log10(correction), 'b--')
-                ax.plot(tri_mags+dtri_mags/2, np.log10(gal_dNs) + np.log10(correction), 'b:')
-                ax.set_ylim(*lims)
+        ax.set_xlabel('Magnitude')
+        if usetex:
+            ax.set_ylabel(r'log$_{10}\left(\mathrm{D}\ /\ \mathrm{mag}^{-1}\,'
+                          r'\mathrm{deg}^{-2}\right)$')
+        else:
+            ax.set_ylabel(r'log10(D / mag^-1 deg^-2)')
 
-                ax.set_xlabel('Magnitude')
-                if usetex:
-                    ax.set_ylabel(r'log$_{10}\left(\mathrm{D}\ /\ \mathrm{mag}^{-1}\,'
-                                  r'\mathrm{deg}^{-2}\right)$')
-                else:
-                    ax.set_ylabel(r'log10(D / mag^-1 deg^-2)')
-            print('')
-            plt.figure('123123')
-            plt.tight_layout()
-            plt.savefig('{}/pdf/counts_comparison.pdf'.format(self.save_folder))
-            plt.close()
+        plt.figure('123123')
+        plt.tight_layout()
+        plt.savefig('{}/pdf/counts_comparison_{}.pdf'.format(self.save_folder, self.file_name))
+        plt.close()
 
     def calculate_local_densities_and_nearest_neighbours(self):
         """
         Calculate local normalising catalogue densities and catalogue-catalogue
         nearest neighbour match pairings for each cutout region.
         """
+        print('Creating local densities and nearest neighbour matches...')
+
         if self.coord_or_chunk == 'coord':
-            zip_list = (self.ax1_mids, self.ax2_mids, self.ax1_mins, self.ax1_maxs,
-                        self.ax2_mins, self.ax2_maxs)
+            ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max = self.list_of_things
         else:
-            zip_list = (self.ax1_mids, self.ax2_mids, self.ax1_mins, self.ax1_maxs, self.ax2_mins,
-                        self.ax2_maxs, self.chunks)
-        for index_, list_of_things in enumerate(zip(*zip_list)):
-            print('Creating local densities and nearest neighbour matches... {}/{}'.format(
-                index_+1, len(self.ax1_mids)), end='\r')
+            ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max, _ = self.list_of_things
 
-            if self.coord_or_chunk == 'coord':
-                ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max = list_of_things
-                cat_args = (ax1_mid, ax2_mid)
-                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
-            else:
-                ax1_mid, ax2_mid, ax1_min, ax1_max, ax2_min, ax2_max, chunk = list_of_things
-                cat_args = (chunk,)
-                file_name = '{}'.format(chunk)
+        lon_slice = np.linspace(ax1_min, ax1_max, int(np.floor((ax1_max-ax1_min)*2 + 1)))
+        lat_slice = np.linspace(ax2_min, ax2_max, int(np.floor((ax2_max-ax2_min)*2 + 1)))
 
-            if (os.path.isfile('{}/npy/local_dens_nn_matches_{}.npz'.format(
-                               self.save_folder, file_name)) and not
-                    self.dens_recreate and not self.nn_recreate):
-                continue
+        Narray = create_densities(
+            ax1_mid, ax2_mid, self.b, self.minmag, self.maxmag, lon_slice, lat_slice, ax1_min,
+            ax1_max, ax2_min, ax2_max, self.dens_search_radius, self.n_pool, self.dens_recreate,
+            self.save_folder, self.mag_indices[self.best_mag_index],
+            self.pos_and_err_indices[1][0], self.pos_and_err_indices[1][1], self.coord_system)
 
-            a = self.load_catalogue('a', cat_args)
-            b = self.load_catalogue('b', cat_args)
-            npyfilez = np.load('{}/npy/sim_counts_{}.npz'.format(self.save_folder, file_name))
-            _, _, _, _, _, _, _, _, [minmag], [maxmag], _ = \
-                [npyfilez['arr_{}'.format(ii)] for ii in range(11)]
+        _, bmatch, dists = create_distances(
+            self.a, self.b, ax1_mid, ax2_mid, self.nn_radius, self.nn_recreate, self.save_folder,
+            self.pos_and_err_indices[0][0], self.pos_and_err_indices[0][1],
+            self.pos_and_err_indices[1][0], self.pos_and_err_indices[1][1], self.coord_system)
 
-            lon_slice = np.linspace(ax1_min, ax1_max, int(np.floor((ax1_max-ax1_min)*2 + 1)))
-            lat_slice = np.linspace(ax2_min, ax2_max, int(np.floor((ax2_max-ax2_min)*2 + 1)))
+        # TODO: extend to 3-D search around N-m-sig to find as many good
+        # enough bins as possible, instead of only keeping one N-sig bin
+        # per magnitude?
+        _h, _b = np.histogram(Narray[bmatch], bins='auto')
+        modeN = (_b[:-1]+np.diff(_b)/2)[np.argmax(_h)]
+        dN = 0.05*modeN
 
-            Narray = create_densities(
-                ax1_mid, ax2_mid, b, minmag, maxmag, lon_slice, lat_slice, ax1_min, ax1_max,
-                ax2_min, ax2_max, self.dens_search_radius, self.n_pool, self.dens_recreate,
-                self.save_folder, self.mag_indices[self.best_mag_index],
-                self.pos_and_err_indices[1][0], self.pos_and_err_indices[1][1], self.coord_system)
-
-            _, bmatch, dists = create_distances(
-                a, b, ax1_mid, ax2_mid, self.nn_radius, self.nn_recreate, self.save_folder,
-                self.pos_and_err_indices[0][0], self.pos_and_err_indices[0][1],
-                self.pos_and_err_indices[1][0], self.pos_and_err_indices[1][1], self.coord_system)
-
-            # TODO: extend to 3-D search around N-m-sig to find as many good
-            # enough bins as possible, instead of only keeping one N-sig bin
-            # per magnitude?
-            _h, _b = np.histogram(Narray[bmatch], bins='auto')
-            modeN = (_b[:-1]+np.diff(_b)/2)[np.argmax(_h)]
-            dN = 0.05*modeN
-
-            np.savez('{}/npy/local_dens_nn_matches_{}.npz'.format(
-                     self.save_folder, file_name), Narray, dists, bmatch, [modeN], [dN])
-        print('')
+        self.Narray, self.dists, self.bmatch = Narray, dists, bmatch
+        self.modeN, self.dN = modeN, dN
 
     def simulate_aufs(self):
         """
@@ -998,65 +994,39 @@ class AstrometricCorrections:
         combination, for both aperture photometry and background-dominated PSF
         algorithms.
         """
-        abc_array = np.load('{}/npy/snr_mag_params.npy'.format(self.save_folder))
-        if self.coord_or_chunk == 'coord':
-            zip_list = (self.ax1_mids, self.ax2_mids)
-        else:
-            zip_list = (self.chunks,)
-        for index_, list_of_things in enumerate(zip(*zip_list)):
-            print('Creating AUF simulations... {}/{}'.format(index_+1, len(self.ax1_mids)),
-                  end='\r')
-            if self.coord_or_chunk == 'coord':
-                ax1_mid, ax2_mid = list_of_things
-                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
-            else:
-                chunk, = list_of_things
-                file_name = '{}'.format(chunk)
+        print('Creating AUF simulations...')
 
-            if not self.auf_sim_recreate and os.path.isfile(
-                    '{}/npy/four_auf_{}.npz'.format(
-                    self.save_folder, file_name)):
-                continue
+        a = self.a_array[self.best_mag_index]
+        b = self.b_array[self.best_mag_index]
+        c = self.c_array[self.best_mag_index]
+        B = 0.05
+        # Self-consistent, non-zeropointed "flux", based on the relation
+        # given in make_snr_model.
+        flux = 10**(-1/2.5 * self.mag_array)
+        snr = flux / np.sqrt(c * 10**flux + b + (a * 10**flux)**2)
+        dm_max = _calculate_magnitude_offsets(
+            self.modeN*np.ones_like(self.mag_array), self.mag_array, B, snr, self.tri_mags,
+            self.log10y, self.dtri_mags, self.R, self.N_norm)
 
-            npyfilez = np.load('{}/npy/local_dens_nn_matches_{}.npz'.format(
-                self.save_folder, file_name))
-            _, _, _, [modeN], _ = [npyfilez['arr_{}'.format(ii)] for ii in range(5)]
-            npyfilez = np.load('{}/npy/sim_counts_{}.npz'.format(
-                               self.save_folder, file_name))
-            log10y, _, _, tri_mags, dtri_mags, _, _, _, _, _, [N_norm] = \
-                [npyfilez['arr_{}'.format(ii)] for ii in range(11)]
+        seed = np.random.default_rng().choice(100000, size=(paf.get_random_seed_size(),
+                                                            len(self.mag_array)))
+        _, _, four_off_fw, _, _ = \
+            paf.perturb_aufs(
+                self.modeN*np.ones_like(self.mag_array), self.mag_array, self.r[:-1]+self.dr/2,
+                self.dr, self.r, self.j0s.T, self.tri_mags+self.dtri_mags/2, self.dtri_mags,
+                self.log10y, self.N_norm, (dm_max/self.dm).astype(int), self.dmcut, self.R,
+                self.psfsig, self.numtrials, seed, self.dd_params, self.l_cut, 'fw')
 
-            a, b, c = abc_array[self.best_mag_index, index_]
-            B = 0.05
-            # Self-consistent, non-zeropointed "flux", based on the relation
-            # given in make_snr_model.
-            flux = 10**(-1/2.5 * self.mag_array)
-            snr = flux / np.sqrt(c * 10**flux + b + (a * 10**flux)**2)
-            dm_max = _calculate_magnitude_offsets(
-                modeN*np.ones_like(self.mag_array), self.mag_array, B, snr, tri_mags, log10y,
-                dtri_mags, self.R, N_norm)
+        seed = np.random.default_rng().choice(100000, size=(paf.get_random_seed_size(),
+                                                            len(self.mag_array)))
+        _, _, four_off_ps, _, _ = \
+            paf.perturb_aufs(
+                self.modeN*np.ones_like(self.mag_array), self.mag_array, self.r[:-1]+self.dr/2,
+                self.dr, self.r, self.j0s.T, self.tri_mags+self.dtri_mags/2, self.dtri_mags,
+                self.log10y, self.N_norm, (dm_max/self.dm).astype(int), self.dmcut, self.R,
+                self.psfsig, self.numtrials, seed, self.dd_params, self.l_cut, 'psf')
 
-            seed = np.random.default_rng().choice(100000, size=(paf.get_random_seed_size(),
-                                                                len(self.mag_array)))
-            _, _, four_off_fw, _, _ = \
-                paf.perturb_aufs(
-                    modeN*np.ones_like(self.mag_array), self.mag_array, self.r[:-1]+self.dr/2,
-                    self.dr, self.r, self.j0s.T, tri_mags+dtri_mags/2, dtri_mags, log10y, N_norm,
-                    (dm_max/self.dm).astype(int), self.dmcut, self.R, self.psfsig,
-                    self.numtrials, seed, self.dd_params, self.l_cut, 'fw')
-
-            seed = np.random.default_rng().choice(100000, size=(paf.get_random_seed_size(),
-                                                                len(self.mag_array)))
-            _, _, four_off_ps, _, _ = \
-                paf.perturb_aufs(
-                    modeN*np.ones_like(self.mag_array), self.mag_array, self.r[:-1]+self.dr/2,
-                    self.dr, self.r, self.j0s.T, tri_mags+dtri_mags/2, dtri_mags, log10y, N_norm,
-                    (dm_max/self.dm).astype(int), self.dmcut, self.R, self.psfsig,
-                    self.numtrials, seed, self.dd_params, self.l_cut, 'psf')
-
-            np.savez('{}/npy/four_auf_{}.npz'.format(
-                     self.save_folder, file_name), four_off_fw, four_off_ps)
-        print('')
+        self.four_off_fw, self.four_off_ps = four_off_fw, four_off_ps
 
     def create_auf_pdfs(self):
         """
@@ -1064,174 +1034,107 @@ class AstrometricCorrections:
         of perturbation distance for all cutout regions, as well as recording key
         statistics such as average magnitude or SNR.
         """
-        if self.coord_or_chunk == 'coord':
-            zip_list = (self.ax1_mids, self.ax2_mids)
-        else:
-            zip_list = (self.chunks,)
-        for index_, list_of_things in enumerate(zip(*zip_list)):
-            print('Creating catalogue AUF probability densities... {}/{}'.format(
-                  index_+1, len(self.ax1_mids)), end='\r')
-            if self.coord_or_chunk == 'coord':
-                ax1_mid, ax2_mid = list_of_things
-                cat_args = (ax1_mid, ax2_mid)
-                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
-            else:
-                chunk, = list_of_things
-                cat_args = (chunk,)
-                file_name = '{}'.format(chunk)
-            if not self.auf_pdf_recreate and os.path.isfile(
-                    '{}/npy/auf_pdf_{}.npz'.format(self.save_folder, file_name)):
+        print('Creating catalogue AUF probability densities...')
+        b_matches = self.b[self.bmatch]
+
+        skip_flags = np.zeros_like(self.mag_array, dtype=bool)
+
+        pdfs, pdf_uncerts, q_pdfs, pdf_bins = [], [], [], []
+
+        avg_sig = np.empty((len(self.mag_array), 3), float)
+        avg_snr = np.empty((len(self.mag_array), 3), float)
+        avg_mag = np.empty((len(self.mag_array), 3), float)
+
+        mag_ind = self.mag_indices[self.best_mag_index]
+        for i in range(len(self.mag_array)):
+            mag_cut = ((b_matches[:, mag_ind] <= self.mag_array[i]+self.mag_slice[i]) &
+                       (b_matches[:, mag_ind] >= self.mag_array[i]-self.mag_slice[i]))
+            if np.sum(mag_cut) == 0:
+                skip_flags[i] = 1
+                pdfs.append([-1])
+                pdf_uncerts.append([-1])
+                q_pdfs.append([-1])
+                pdf_bins.append([-1])
+                continue
+            sig = np.percentile(b_matches[mag_cut, self.pos_and_err_indices[1][2]], 50)
+            sig_cut = ((b_matches[:, self.pos_and_err_indices[1][2]] <= sig+self.sig_slice[i]) &
+                       (b_matches[:, self.pos_and_err_indices[1][2]] >= sig-self.sig_slice[i]))
+            N_cut = (self.Narray[self.bmatch] >= self.modeN-self.dN) & (
+                self.Narray[self.bmatch] <= self.modeN+self.dN)
+
+            final_slice = sig_cut & mag_cut & N_cut & (self.dists <= 20*sig)
+            final_dists = self.dists[final_slice]
+            if len(final_dists) < 100:
+                skip_flags[i] = 1
+                pdfs.append([-1])
+                pdf_uncerts.append([-1])
+                q_pdfs.append([-1])
+                pdf_bins.append([-1])
                 continue
 
-            b = self.load_catalogue('b', cat_args)
-            npyfilez = np.load('{}/npy/local_dens_nn_matches_{}.npz'.format(
-                               self.save_folder, file_name))
-            Narray, dists, bmatch, [modeN], [dN] = [npyfilez['arr_{}'.format(ii)] for ii in
-                                                    range(5)]
+            bm = b_matches[final_slice]
+            snr = 1 / (10**(bm[:, self.mag_unc_indices[self.best_mag_index]] / 2.5) - 1)
+            avg_snr[i, 0] = np.median(snr)
+            avg_snr[i, [1, 2]] = np.abs(np.percentile(snr, [16, 84]) - np.median(snr))
+            avg_mag[i, 0] = np.median(bm[:, mag_ind])
+            avg_mag[i, [1, 2]] = np.abs(np.percentile(bm[:, mag_ind], [16, 84]) -
+                                        np.median(bm[:, mag_ind]))
+            avg_sig[i, 0] = np.median(bm[:, self.pos_and_err_indices[1][2]])
+            avg_sig[i, [1, 2]] = np.abs(np.percentile(bm[:, self.pos_and_err_indices[1][2]],
+                                                      [16, 84]) -
+                                        np.median(bm[:, self.pos_and_err_indices[1][2]]))
 
-            b_matches = b[bmatch]
+            h, bins = np.histogram(final_dists, bins='auto')
+            num = np.sum(h)
+            pdf = h / np.diff(bins) / num
+            pdf_uncert = np.sqrt(h) / np.diff(bins) / num
+            q_pdf = h > 3
 
-            skip_flags = np.zeros_like(self.mag_array, dtype=bool)
+            pdfs.append(pdf)
+            pdf_uncerts.append(pdf_uncert)
+            q_pdfs.append(q_pdf)
+            pdf_bins.append(bins)
 
-            pdfs, pdf_uncerts, q_pdfs, pdf_bins = [], [], [], []
-
-            avg_sig = np.empty((len(self.mag_array), 3), float)
-            avg_snr = np.empty((len(self.mag_array), 3), float)
-            avg_mag = np.empty((len(self.mag_array), 3), float)
-
-            mag_ind = self.mag_indices[self.best_mag_index]
-            for i in range(len(self.mag_array)):
-                mag_cut = ((b_matches[:, mag_ind] <= self.mag_array[i]+self.mag_slice[i]) &
-                           (b_matches[:, mag_ind] >= self.mag_array[i]-self.mag_slice[i]))
-                if np.sum(mag_cut) == 0:
-                    skip_flags[i] = 1
-                    pdfs.append([-1])
-                    pdf_uncerts.append([-1])
-                    q_pdfs.append([-1])
-                    pdf_bins.append([-1])
-                    continue
-                sig = np.percentile(b_matches[mag_cut, self.pos_and_err_indices[1][2]], 50)
-                sig_cut = ((b_matches[:, self.pos_and_err_indices[1][2]] <= sig+self.sig_slice[i]) &
-                           (b_matches[:, self.pos_and_err_indices[1][2]] >= sig-self.sig_slice[i]))
-                N_cut = (Narray[bmatch] >= modeN-dN) & (Narray[bmatch] <= modeN+dN)
-
-                final_slice = sig_cut & mag_cut & N_cut & (dists <= 20*sig)
-                final_dists = dists[final_slice]
-                if len(final_dists) < 100:
-                    skip_flags[i] = 1
-                    pdfs.append([-1])
-                    pdf_uncerts.append([-1])
-                    q_pdfs.append([-1])
-                    pdf_bins.append([-1])
-                    continue
-
-                bm = b_matches[final_slice]
-                snr = 1 / (10**(bm[:, self.mag_unc_indices[self.best_mag_index]] / 2.5) - 1)
-                avg_snr[i, 0] = np.median(snr)
-                avg_snr[i, [1, 2]] = np.abs(np.percentile(snr, [16, 84]) - np.median(snr))
-                avg_mag[i, 0] = np.median(bm[:, mag_ind])
-                avg_mag[i, [1, 2]] = np.abs(np.percentile(bm[:, mag_ind], [16, 84]) -
-                                            np.median(bm[:, mag_ind]))
-                avg_sig[i, 0] = np.median(bm[:, self.pos_and_err_indices[1][2]])
-                avg_sig[i, [1, 2]] = np.abs(np.percentile(bm[:, self.pos_and_err_indices[1][2]],
-                                                          [16, 84]) -
-                                            np.median(bm[:, self.pos_and_err_indices[1][2]]))
-
-                h, bins = np.histogram(final_dists, bins='auto')
-                num = np.sum(h)
-                pdf = h / np.diff(bins) / num
-                pdf_uncert = np.sqrt(h) / np.diff(bins) / num
-                q_pdf = h > 3
-
-                pdfs.append(pdf)
-                pdf_uncerts.append(pdf_uncert)
-                q_pdfs.append(q_pdf)
-                pdf_bins.append(bins)
-
-            pdfs, pdf_uncerts, q_pdfs, pdf_bins = (
-                np.array(pdfs, dtype=object), np.array(pdf_uncerts, dtype=object),
-                np.array(q_pdfs, dtype=object), np.array(pdf_bins, dtype=object))
-
-            np.savez('{}/npy/auf_pdf_{}.npz'.format(self.save_folder, file_name),
-                     avg_snr, avg_mag, avg_sig, pdfs, pdf_uncerts, q_pdfs, pdf_bins, skip_flags)
-
-        print('')
+        self.avg_snr, self.avg_mag, self.avg_sig = avg_snr, avg_mag, avg_sig
+        self.pdfs, self.pdf_uncerts = pdfs, pdf_uncerts
+        self.q_pdfs, self.pdf_bins = q_pdfs, pdf_bins
+        self.skip_flags = skip_flags
 
     def fit_uncertainty(self):
         """
         For each magnitude-sightline combination, fit for the empirical centroid
         uncertainty describing the distribution of match separations.
         """
-        a_array = np.load('{}/npy/snr_mag_params.npy'.format(self.save_folder))[
-            self.best_mag_index, :, 0]
-        if self.coord_or_chunk == 'coord':
-            zip_list = (self.ax1_mids, self.ax2_mids, a_array)
-        else:
-            zip_list = (self.chunks, a_array)
-        for index_, list_of_things in enumerate(zip(*zip_list)):
-            print('Creating joint H/sig fits... {}/{}'.format(index_+1, len(self.ax1_mids)),
-                  end='\r')
-            if self.coord_or_chunk == 'coord':
-                ax1_mid, ax2_mid, _a = list_of_things
-                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
+        print('Creating joint H/sig fits...')
+
+        fit_sigs = np.zeros((len(self.mag_array), 2), float)
+
+        resses = [0]*len(self.mag_array)
+        # Use the lower of the number of magnitues to run in parallel and the
+        # maximum specified number of threads to call.
+        n_pool = min(self.n_pool, len(self.mag_array))
+        pool = multiprocessing.Pool(n_pool)
+        counter = np.arange(0, len(self.mag_array))
+        iter_group = zip(counter, itertools.repeat([
+            self.pdfs, self.pdf_uncerts, self.rho, self.drho, self.r, self.dr, self.four_off_fw,
+            self.four_off_ps, self.q_pdfs, self.pdf_bins, self.avg_sig[:, 0], self.avg_snr[:, 0],
+            self.j0s, self.modeN/3600**2, self.a_array[self.best_mag_index]]))
+        for s in pool.imap_unordered(self.fit_auf, iter_group,
+                                     chunksize=max(1, len(self.mag_array) // n_pool)):
+            res, i = s
+            resses[i] = res
+            if res == -1:
+                self.skip_flags[i] = 1
             else:
-                chunk, _a = list_of_things
-                file_name = '{}'.format(chunk)
-            if not self.h_o_fit_recreate and os.path.isfile(
-                    '{}/npy/h_o_fit_res_{}.npz'.format(
-                    self.save_folder, file_name)):
-                continue
+                fit_sig, _ = resses[i].x
+                cov = resses[i].hess_inv.todense()
+                fit_sigs[i, 0] = fit_sig / 10
+                fit_sigs[i, 1] = np.sqrt(cov[0, 0]) / 10
 
-            fit_sigs = np.zeros((len(self.mag_array), 2), float)
-            fit_nnf = np.zeros((len(self.mag_array), 2), float)
+        pool.close()
+        pool.join()
 
-            npyfilez = np.load('{}/npy/auf_pdf_{}.npz'.format(
-                               self.save_folder, file_name), allow_pickle=True)
-            avg_snr, avg_mag, avg_sig, pdfs, pdf_uncerts, q_pdfs, pdf_bins, skip_flags = \
-                [npyfilez['arr_{}'.format(ii)] for ii in range(8)]
-            npyfilez = np.load('{}/npy/four_auf_{}.npz'.format(
-                               self.save_folder, file_name))
-            four_off_fw, four_off_ps = [npyfilez['arr_{}'.format(ii)] for ii in range(2)]
-
-            npyfilez = np.load('{}/npy/local_dens_nn_matches_{}.npz'.format(self.save_folder,
-                               file_name))
-            _, _, _, [modeN], _ = [npyfilez['arr_{}'.format(ii)] for ii in range(5)]
-
-            resses = [0]*len(self.mag_array)
-            # Use the lower of the number of magnitues to run in parallel and the
-            # maximum specified number of threads to call.
-            n_pool = min(self.n_pool, len(self.mag_array))
-            pool = multiprocessing.Pool(n_pool)
-            counter = np.arange(0, len(self.mag_array))
-            iter_group = zip(counter, itertools.repeat([pdfs, pdf_uncerts, self.rho, self.drho,
-                                                        self.r, self.dr, four_off_fw, four_off_ps,
-                                                        q_pdfs, pdf_bins, avg_sig[:, 0],
-                                                        avg_snr[:, 0], self.j0s,
-                                                        modeN/3600**2, _a]))
-            for s in pool.imap_unordered(self.fit_auf, iter_group,
-                                         chunksize=max(1, len(self.mag_array) // n_pool)):
-                res, i = s
-                resses[i] = res
-                if res == -1:
-                    skip_flags[i] = 1
-                else:
-                    fit_sig, nn_frac = resses[i].x
-                    cov = resses[i].hess_inv.todense()
-                    fit_sigs[i, 0] = fit_sig / 10
-                    fit_sigs[i, 1] = np.sqrt(cov[0, 0]) / 10
-
-                    fit_nnf[i, 0] = nn_frac
-                    fit_nnf[i, 1] = np.sqrt(cov[1, 1])
-
-            pool.close()
-            pool.join()
-
-            resses = np.array(resses, dtype=object)
-
-            np.savez('{}/npy/h_o_fit_res_{}.npz'.format(
-                     self.save_folder, file_name), resses, fit_sigs, skip_flags)
-
-        print('')
+        self.resses, self.fit_sigs = resses, fit_sigs
 
     def fit_auf(self, iterable):
         """
@@ -1358,70 +1261,32 @@ class AstrometricCorrections:
 
         return res, i
 
-    def make_plot_calc_chisq(self, iterable):
+    def plot_fits_calculate_chi_sq(self):
         """
-        Make an individual sightline's verification plot, or calculate the
-        goodness-of-fit of its best-fitting model.
-
-        Parameters
-        ----------
-        iterable : list
-            List of parameters passed through from ``multiprocessing``. Includes
-            the index, central and corner coordinate, systematic signal-to-noise
-            ratio, and flag indicating whether or not to fit for chi-squareds.
-
-        Returns
-        -------
-        index : integer
-            Index into ``ax1_mids`` for the run. Only returned if ``fit_x2_flag``
-            is ``True``.
-        x2s : numpy.ndarray
-            The chi-squared goodness-of-fit results from all fits performed
-            in this sightline. Only returned if ``fit_x2_flag`` is ``True``.
+        Calculate chi-squared value and create verification plots showing the
+        quality of the fits.
         """
-        if self.coord_or_chunk == 'coord':
-            index, ax1_mid, ax2_mid, _a, (fit_x2_flag) = iterable
-            cat_args = (ax1_mid, ax2_mid)
-            file_name = '{}_{}'.format(ax1_mid, ax2_mid)
+        x2s = np.ones((len(self.mag_array), 2), float) * np.nan
+
+        if self.make_plots:
+            print('Creating individual AUF figures and calculating goodness-of-fits...')
         else:
-            index, chunk, _a, (fit_x2_flag) = iterable
-            cat_args = (chunk,)
-            file_name = '{}'.format(chunk)
+            print('Calculating goodness-of-fits...')
+
         if self.make_plots:
             # Grid just big enough square to cover mag_array entries.
             gs1 = self.make_gridspec('34242b', self.n_mag_rows, self.n_mag_cols, 0.8, 15)
             ax1s = [plt.subplot(gs1[i]) for i in range(len(self.mag_array))]
 
-        npyfilez = np.load('{}/npy/auf_pdf_{}.npz'.format(
-                           self.save_folder, file_name), allow_pickle=True)
-        avg_snr, avg_mag, avg_sig, pdfs, pdf_uncerts, q_pdfs, pdf_bins, _ = \
-            [npyfilez['arr_{}'.format(ii)] for ii in range(8)]
-
-        npyfilez = np.load('{}/npy/four_auf_{}.npz'.format(
-                           self.save_folder, file_name))
-        four_off_fw, four_off_ps = [npyfilez['arr_{}'.format(ii)] for ii in range(2)]
-
-        b = self.load_catalogue('b', cat_args)
-        npyfilez = np.load('{}/npy/local_dens_nn_matches_{}.npz'.format(
-                           self.save_folder, file_name))
-        Narray, dists, bmatch, [modeN], [dN] = [npyfilez['arr_{}'.format(ii)] for ii in
-                                                range(5)]
-
-        b_matches = b[bmatch]
-
-        npyfilez = np.load('{}/npy/h_o_fit_res_{}.npz'.format(
-                           self.save_folder, file_name), allow_pickle=True)
-        resses, _, skip_flags = [npyfilez['arr_{}'.format(ii)] for ii in range(3)]
-
-        if fit_x2_flag:
-            x2s = np.ones((len(self.mag_array), 2), float) * np.nan
+        b_matches = self.b[self.bmatch]
 
         for i in range(len(self.mag_array)):
             if self.make_plots:
                 ax = ax1s[i]
-            if skip_flags[i]:
+            if self.skip_flags[i]:
                 continue
-            pdf, pdf_uncert, q_pdf, pdf_bin = (pdfs[i], pdf_uncerts[i], q_pdfs[i], pdf_bins[i])
+            pdf, pdf_uncert, q_pdf, pdf_bin = (
+                self.pdfs[i], self.pdf_uncerts[i], self.q_pdfs[i], self.pdf_bins[i])
             if self.make_plots:
                 ax.errorbar((pdf_bin[:-1]+np.diff(pdf_bin)/2)[q_pdf], pdf[q_pdf],
                             yerr=pdf_uncert[q_pdf], c='k', marker='.', zorder=1, ls='None')
@@ -1433,15 +1298,17 @@ class AstrometricCorrections:
             bsig = np.percentile(b_matches[mag_cut, pos_err_ind], 50)
             sig_cut = ((b_matches[:, pos_err_ind] <= bsig+self.sig_slice[i]) &
                        (b_matches[:, pos_err_ind] >= bsig-self.sig_slice[i]))
-            N_cut = (Narray[bmatch] >= modeN-dN) & (Narray[bmatch] <= modeN+dN)
-            final_slice = sig_cut & mag_cut & N_cut & (dists <= 20*bsig)
+            N_cut = (self.Narray[self.bmatch] >= self.modeN-self.dN) & (
+                self.Narray[self.bmatch] <= self.modeN+self.dN)
+            final_slice = sig_cut & mag_cut & N_cut & (self.dists <= 20*bsig)
             bm = b_matches[final_slice]
 
-            _N = np.percentile(Narray[bmatch][final_slice], 50)/3600**2
-            fit_sig, nn_frac = resses[i].x
+            _N = np.percentile(self.Narray[self.bmatch][final_slice], 50)/3600**2
+            fit_sig, nn_frac = self.resses[i].x
             fit_sig /= 10
 
-            H = 1 - np.sqrt(1 - min(1, _a**2 * avg_snr[i, 0]**2))
+            H = 1 - np.sqrt(1 - min(1,
+                                    self.a_array[self.best_mag_index]**2 * self.avg_snr[i, 0]**2))
 
             if self.make_plots:
                 ax = ax1s[i]
@@ -1459,7 +1326,7 @@ class AstrometricCorrections:
                     continue
                 four_gauss = np.exp(-2 * np.pi**2 * (self.rho[:-1]+self.drho/2)**2 * sig**2)
 
-                four_hist = _H * four_off_fw[:, i] + (1 - _H) * four_off_ps[:, i]
+                four_hist = _H * self.four_off_fw[:, i] + (1 - _H) * self.four_off_ps[:, i]
                 convolve_hist = paf.fourier_transform(
                     four_hist*four_gauss, self.rho[:-1]+self.drho/2, self.drho, self.j0s)
 
@@ -1478,7 +1345,7 @@ class AstrometricCorrections:
 
                 int_modely = np.sum(modely[q_pdf] / int_convhist * np.diff(pdf_bin)[q_pdf])
 
-                if fit_x2_flag and j == 0:
+                if j == 0:
                     x2s[i, 0] = np.sum((pdf[q_pdf] - modely[q_pdf] / int_convhist / int_modely)**2 /
                                        pdf_uncert[q_pdf]**2)
                     # Fit for sig and false match fraction.
@@ -1497,21 +1364,21 @@ class AstrometricCorrections:
                     1 - np.exp(-np.pi * r_arr[-1]**2 * _N))
                 ax.plot(r_arr, nn_dist, c='g', ls='-')
 
-                cov = resses[i].hess_inv.todense()
+                cov = self.resses[i].hess_inv.todense()
                 if usetex:
                     ax.set_title(r'mag = {}, H = {:.2f}, $\sigma$ = {:.3f}$\pm${:.3f} ({:.3f})"; '
                                  r'$F$ = {:.2f}; SNR = {:.2f}$^{{+{:.2f}}}_{{-{:.2f}}}$; '
                                  r'N = {}'.format(self.mag_array[i], H, fit_sig,
                                                   np.sqrt(cov[0, 0])/10, bsig, nn_frac,
-                                                  avg_snr[i, 0], avg_snr[i, 2], avg_snr[i, 1],
-                                                  len(bm)), fontsize=22)
+                                                  self.avg_snr[i, 0], self.avg_snr[i, 2],
+                                                  self.avg_snr[i, 1], len(bm)), fontsize=22)
                 else:
                     ax.set_title(r'mag = {}, H = {:.2f}, sigma = {:.3f}+/-{:.3f} ({:.3f})"; '
                                  r'F = {:.2f}; SNR = {:.2f}+{:.2f}/-{:.2f}; '
                                  r'N = {}'.format(self.mag_array[i], H, fit_sig,
                                                   np.sqrt(cov[0, 0])/10, bsig, nn_frac,
-                                                  avg_snr[i, 0], avg_snr[i, 2], avg_snr[i, 1],
-                                                  len(bm)), fontsize=22)
+                                                  self.avg_snr[i, 0], self.avg_snr[i, 2],
+                                                  self.avg_snr[i, 1], len(bm)), fontsize=22)
                 ax.legend(fontsize=15)
                 ax.set_xlabel('Radius / arcsecond')
                 if usetex:
@@ -1520,48 +1387,10 @@ class AstrometricCorrections:
                     ax.set_ylabel('PDF / arcsecond^-1')
         if self.make_plots:
             plt.tight_layout()
-            plt.savefig('{}/pdf/auf_fits_{}.pdf'.format(self.save_folder, file_name))
+            plt.savefig('{}/pdf/auf_fits_{}.pdf'.format(self.save_folder, self.file_name))
             plt.close()
 
-        if fit_x2_flag:
-            return index, x2s
-
-    def plot_fits_calculate_chi_sq(self):
-        """
-        Calculate chi-squared values for each magnitude-sightline combination,
-        and create verification plots showing the quality of the fits.
-        """
-        fit_x2_flag = (self.fit_x2s_recreate or not
-                       os.path.isfile('{}/npy/fit_x2s.npy'.format(self.save_folder)))
-        if fit_x2_flag:
-            x2s = np.ones((len(self.ax1_mids), len(self.mag_array), 2), float) * np.nan
-
-        a_array = np.load('{}/npy/snr_mag_params.npy'.format(self.save_folder))[
-            self.best_mag_index, :, 0]
-        if self.make_plots and fit_x2_flag:
-            print('Creating individual AUF figures and calculating goodness-of-fits...')
-        elif self.make_plots:
-            print('Creating individual AUF figures ...')
-        elif fit_x2_flag:
-            print('Calculating goodness-of-fits...')
-        pool = multiprocessing.Pool(self.n_pool)
-        counter = np.arange(0, len(self.ax1_mids))
-        if self.coord_or_chunk == 'coord':
-            iter_group = zip(counter, self.ax1_mids, self.ax2_mids, a_array,
-                             itertools.repeat(fit_x2_flag))
-        else:
-            iter_group = zip(counter, self.chunks, a_array, itertools.repeat(fit_x2_flag))
-        for results in pool.imap_unordered(self.make_plot_calc_chisq, iter_group,
-                                           chunksize=len(self.ax1_mids)//self.n_pool):
-            if fit_x2_flag:
-                index, chi_sq = results
-                x2s[index, :, :] = chi_sq
-
-        pool.close()
-        pool.join()
-
-        if fit_x2_flag:
-            np.save('{}/npy/fit_x2s.npy'.format(self.save_folder), np.array(x2s))
+        self.x2s = x2s
 
     def make_ma_fits_snr_h_plot(self):
         """
@@ -1601,147 +1430,94 @@ class AstrometricCorrections:
 
             return np.sum((y - modely)**2 / o**2)
 
-        x2s = np.load('{}/npy/fit_x2s.npy'.format(self.save_folder))
-
-        if not (self.make_plots or self.make_summary_plot):
+        if not self.make_plots:
             print("Creating sig-sig relations...")
         else:
-            print("Creating sig-sig relations and SNR-H summary figure...")
-            gs_s = self.make_gridspec('123123b', self.ax2_grid_length, self.ax1_grid_length,
-                                      0.8, 15)
-            gs = self.make_gridspec('12312', 2, 2, 0.8, 10)
-            ax_b = plt.subplot(gs[0])
-            ax_d = plt.subplot(gs[1])
-
-            ylims = [999, 0]
-
-            cols = ['k', 'r', 'b', 'g', 'c', 'm', 'orange', 'brown', 'purple', 'grey', 'olive',
-                    'cornflowerblue', 'deeppink', 'maroon', 'palevioletred', 'teal', 'crimson',
-                    'chocolate', 'darksalmon', 'steelblue', 'slateblue', 'tan', 'yellowgreen',
-                    'silver']
-
-        m_sigs = np.empty_like(self.ax1_mids)
-        n_sigs = np.empty_like(self.ax1_mids)
+            print("Creating sig-sig relations and figure...")
+            gs_s = self.make_gridspec('123123b', 1, 1, 0.8, 15)
 
         if self.coord_or_chunk == 'coord':
-            zip_list = (self.ax1_mids, self.ax2_mids)
+            ax1_mid, ax2_mid, _, _, _, _ = self.list_of_things
         else:
-            zip_list = (self.ax1_mids, self.ax2_mids, self.chunks)
+            ax1_mid, ax2_mid, _, _, _, _, _ = self.list_of_things
 
-        for i, list_of_things in enumerate(zip(*zip_list)):
-            if self.coord_or_chunk == 'coord':
-                ax1_mid, ax2_mid = list_of_things
-                file_name = '{}_{}'.format(ax1_mid, ax2_mid)
+        if self.make_plots:
+            ax1 = plt.subplot(gs_s[0])
+            ax1.errorbar(self.avg_sig[~self.skip_flags, 0], self.fit_sigs[~self.skip_flags, 0],
+                         xerr=self.avg_sig[~self.skip_flags, 1:].T,
+                         yerr=self.fit_sigs[~self.skip_flags, 1],
+                         linestyle='None', c='k', marker='.')
+            ax1.set_ylim(0.95*np.amin(self.fit_sigs[~self.skip_flags, 0]),
+                         1.05*np.amax(self.fit_sigs[~self.skip_flags, 0]))
+
+        res_sig = minimize(quad_sig_fit, x0=[1, 0], args=(self.avg_sig[~self.skip_flags, 0],
+                           self.fit_sigs[~self.skip_flags, 0], self.fit_sigs[~self.skip_flags, 1]),
+                           method='L-BFGS-B', options={'ftol': 1e-12},
+                           bounds=[(0, None), (0, None)])
+
+        m_sig, n_sig = res_sig.x
+
+        if self.make_plots:
+            x_array = np.linspace(0, ax1.get_xlim()[1], 100)
+            ax1.plot(x_array, x_array, 'g:', label='y=x')
+            ax1.plot(x_array, np.sqrt((m_sig*x_array)**2 + n_sig**2), 'r-.',
+                     alpha=0.8, label='Fit ma')
+
+            if usetex:
+                ax1.set_xlabel(r'Input astrometric $\sigma$ / "')
+                ax1.set_ylabel(r'Fit astrometric $\sigma$ / "')
             else:
-                ax1_mid, ax2_mid, chunk = list_of_things
-                file_name = '{}'.format(chunk)
-            npyfilez = np.load('{}/npy/auf_pdf_{}.npz'.format(
-                               self.save_folder, file_name), allow_pickle=True)
-            _, _, data_sigs, _, _, _, _, _ = \
-                [npyfilez['arr_{}'.format(ii)] for ii in range(8)]
-
-            npyfilez = np.load('{}/npy/h_o_fit_res_{}.npz'.format(
-                               self.save_folder, file_name), allow_pickle=True)
-            _, fit_sigs, skip_flags = [npyfilez['arr_{}'.format(ii)] for ii in range(3)]
-
-            if self.make_plots or self.make_summary_plot:
-                c = cols[i % len(cols)]
-
-                plt.figure('123123b')
-                ax1 = plt.subplot(gs_s[i])
-                ax1.errorbar(data_sigs[~skip_flags, 0], fit_sigs[~skip_flags, 0],
-                             xerr=data_sigs[~skip_flags, 1:].T, yerr=fit_sigs[~skip_flags, 1],
-                             linestyle='None', c='k', marker='.')
-                ax1.set_ylim(0.95*np.amin(fit_sigs[~skip_flags, 0]),
-                             1.05*np.amax(fit_sigs[~skip_flags, 0]))
-
-            res_sig = minimize(quad_sig_fit, x0=[1, 0], args=(data_sigs[~skip_flags, 0],
-                               fit_sigs[~skip_flags, 0], fit_sigs[~skip_flags, 1]),
-                               method='L-BFGS-B', options={'ftol': 1e-12},
-                               bounds=[(0, None), (0, None)])
-
-            m_sig, n_sig = res_sig.x
-
-            m_sigs[i] = m_sig
-            n_sigs[i] = n_sig
-
-            if self.make_plots or self.make_summary_plot:
-                x_array = np.linspace(0, ax1.get_xlim()[1], 100)
-                ax1.plot(x_array, x_array, 'g:', label='y=x')
-                ax1.plot(x_array, np.sqrt((m_sig*x_array)**2 + n_sig**2), 'r-.',
-                         alpha=0.8, label='Fit ma')
-
-                if usetex:
-                    ax1.set_xlabel(r'Input astrometric $\sigma$ / "')
-                    ax1.set_ylabel(r'Fit astrometric $\sigma$ / "')
-                else:
-                    ax1.set_xlabel(r'Input astrometric sigma / "')
-                    ax1.set_ylabel(r'Fit astrometric sigma / "')
-                ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
-                ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
-                ax1.set_title('{} = {}, {} = {}\nm = {:.2f}, a = {:.2f}'.format(
-                              ax1_name, ax1_mid, ax2_name, ax2_mid, m_sig, n_sig))
-                ax1.legend()
-                plt.figure('12312')
-                ax_b.errorbar(data_sigs[~skip_flags, 0], fit_sigs[~skip_flags, 0],
-                              linestyle='None', c=c, marker='.')
-                ylims[0] = min(ylims[0], np.amin(fit_sigs[:, 0]))
-                ylims[1] = max(ylims[1], np.amax(fit_sigs[:, 0]))
-
-        np.save('{}/npy/m_sigs_array.npy'.format(self.save_folder), m_sigs)
-        np.save('{}/npy/n_sigs_array.npy'.format(self.save_folder), n_sigs)
-
-        if self.make_plots or self.make_summary_plot:
+                ax1.set_xlabel(r'Input astrometric sigma / "')
+                ax1.set_ylabel(r'Fit astrometric sigma / "')
+            ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
+            ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
+            ax1.set_title('{} = {}, {} = {}\nm = {:.2f}, a = {:.2f}'.format(
+                          ax1_name, ax1_mid, ax2_name, ax2_mid, m_sig, n_sig))
+            ax1.legend()
             plt.figure('123123b')
             plt.tight_layout()
-            plt.savefig('{}/pdf/sig_fit_comparisons.pdf'.format(self.save_folder))
+            plt.savefig('{}/pdf/sig_fit_comparisons_{}.pdf'.format(
+                self.save_folder, self.file_name))
             plt.close()
-            plt.figure('12312')
 
-            q = ~np.isnan(x2s[:, :, 0])
-            chi_sqs, dofs = x2s[:, :, 0][q].flatten(), x2s[:, :, 1][q].flatten()
-            chi_sq_cdf = np.empty(np.sum(q), float)
-            for i, (chi_sq, dof) in enumerate(zip(chi_sqs, dofs)):
-                chi_sq_cdf[i] = chi2.cdf(chi_sq, dof)
-            # Under the hypothesis all CDFs are "true" we should expect
-            # the distribution of CDFs to be linear with fraction of the way
-            # through the sorted list of CDFs -- that is, the CDF ranked 30%
-            # in order should be ~0.3.
-            q_sort = np.argsort(chi_sq_cdf)
-            filter_log_nans = chi_sq_cdf[q_sort] < 1
-            true_hypothesis_cdf_dist = (np.arange(1, len(chi_sq_cdf)+1, 1) - 0.5) / len(chi_sq_cdf)
-            ax_d.plot(np.log10(1 - chi_sq_cdf[q_sort][filter_log_nans]),
-                      true_hypothesis_cdf_dist[filter_log_nans], 'k.')
-            ax_d.plot(np.log10(1 - true_hypothesis_cdf_dist), true_hypothesis_cdf_dist, 'r--')
-            if usetex:
-                ax_d.set_xlabel(r'$\log_{10}(1 - \mathrm{CDF})$')
-            else:
-                ax_d.set_xlabel(r'log10(1 - CDF)')
-            ax_d.set_ylabel('Fraction')
+        return m_sig, n_sig
 
-            x_array = np.linspace(0, ax_b.get_xlim()[1], 100)
-            ax_b.plot(x_array, x_array, 'g:')
-            ax_b.set_ylim(0.95 * ylims[0], 1.05 * ylims[1])
-            if usetex:
-                ax_b.set_xlabel(r'Input astrometric $\sigma$ / "')
-                ax_b.set_ylabel(r'Fit astrometric $\sigma$ / "')
-            else:
-                ax_b.set_xlabel(r'Input astrometric sigma / "')
-                ax_b.set_ylabel(r'Fit astrometric sigma / "')
+    def finalise_summary_plot(self):
+        ax_d = plt.subplot(self.gs[1])
+        q = ~np.isnan(self.x2s[:, 0])
+        chi_sqs, dofs = self.x2s[:, 0][q].flatten(), self.x2s[:, 1][q].flatten()
+        chi_sq_cdf = np.empty(np.sum(q), float)
+        for i, (chi_sq, dof) in enumerate(zip(chi_sqs, dofs)):
+            chi_sq_cdf[i] = chi2.cdf(chi_sq, dof)
+        # Under the hypothesis all CDFs are "true" we should expect
+        # the distribution of CDFs to be linear with fraction of the way
+        # through the sorted list of CDFs -- that is, the CDF ranked 30%
+        # in order should be ~0.3.
+        q_sort = np.argsort(chi_sq_cdf)
+        filter_log_nans = chi_sq_cdf[q_sort] < 1
+        true_hypothesis_cdf_dist = (np.arange(1, len(chi_sq_cdf)+1, 1) - 0.5) / len(chi_sq_cdf)
+        ax_d.plot(np.log10(1 - chi_sq_cdf[q_sort][filter_log_nans]),
+                  true_hypothesis_cdf_dist[filter_log_nans], 'k.')
+        ax_d.plot(np.log10(1 - true_hypothesis_cdf_dist), true_hypothesis_cdf_dist, 'r--')
+        if usetex:
+            ax_d.set_xlabel(r'$\log_{10}(1 - \mathrm{CDF})$')
+        else:
+            ax_d.set_xlabel(r'log10(1 - CDF)')
+        ax_d.set_ylabel('Fraction')
 
-            for i, (f, label) in enumerate(zip([m_sigs, n_sigs], ['m', 'n'])):
-                ax = plt.subplot(gs[i+2])
-                img = ax.scatter(self.ax1_mids, self.ax2_mids, c=f, cmap='viridis')
-                c = plt.colorbar(img, ax=ax, use_gridspec=True)
-                c.ax.set_ylabel(label)
-                ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
-                ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
-                ax.set_xlabel('{} / deg'.format(ax1_name))
-                ax.set_ylabel('{} / deg'.format(ax2_name))
+        for i, (f, label) in enumerate(zip([self.m_sigs, self.n_sigs], ['m', 'n'])):
+            ax = plt.subplot(self.gs[i+2])
+            img = ax.scatter(self.ax1_mids, self.ax2_mids, c=f, cmap='viridis')
+            c = plt.colorbar(img, ax=ax, use_gridspec=True)
+            c.ax.set_ylabel(label)
+            ax1_name = 'l' if self.coord_system == 'galactic' else 'RA'
+            ax2_name = 'b' if self.coord_system == 'galactic' else 'Dec'
+            ax.set_xlabel('{} / deg'.format(ax1_name))
+            ax.set_ylabel('{} / deg'.format(ax2_name))
 
-            plt.tight_layout()
-            plt.savefig('{}/pdf/sig_h_stats.pdf'.format(self.save_folder))
-            plt.close()
+        plt.tight_layout()
+        plt.savefig('{}/pdf/sig_h_stats.pdf'.format(self.save_folder))
+        plt.close()
 
     def load_catalogue(self, cat_type, sub_cat_id):
         """

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -170,7 +170,7 @@ class CrossMatch():
             ax_dimension = 2
             a_npy_or_csv = 'csv'
             a_coord_or_chunk = 'chunk'
-            a_correct_astro_tri_name = '{}/{}/trilegal_auf_simulation_faint.dat'
+            a_correct_astro_tri_name = '{}/{}/trilegal_auf_simulation'
             ac = AstrometricCorrections(
                 self.a_psf_fwhms[acbi], self.num_trials, self.a_nn_radius,
                 self.a_dens_dist, self.a_correct_astro_save_folder, self.a_auf_folder_path,

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -1030,52 +1030,52 @@ class CrossMatch():
                             raise ValueError("Missing key {} from catalogue {} metadata file."
                                              .format(check_flag, catname))
 
-                    # snr_mag_params, dd_params, and l_cut should all be numpy arrays in
-                    # specified paths.
-                    for path, f, warn_message in zip(['snr_mag_params_path', 'dd_params_path',
-                                                      'l_cut_path'], ['snr_mag_params', 'dd_params',
-                                                                      'l_cut'],
-                                                     ['astrometry corrections',
-                                                      'PSF photometry perturbations',
-                                                      'PSF photometry perturbations']):
-                        # Only need dd_params or l_cut if we're using run_psf_auf or
-                        # correct_astrometry is True.
-                        if ('snr_mag' not in path and not
-                                getattr(self, '{}run_psf_auf'.format(flag)) and not correct_astro):
-                            continue
-                        if not os.path.exists(config[path]):
-                            raise OSError('{}{} does not exist. Please ensure that path for '
-                                          'catalogue {} is correct.'.format(flag, path, catname))
-                        # If we are correcting the astrometry, we will be
-                        # re-making the SNR-mag relations so skip loading that
-                        # for now.
-                        if not ('snr_mag' in path and correct_astro):
-                            if not os.path.isfile('{}/{}.npy'.format(config[path], f)):
-                                raise FileNotFoundError('{} file not found in catalogue {} path. '
-                                                        'Please ensure {} are pre-generated.'
-                                                        .format(f, catname, warn_message))
-                        if 'snr_mag' in path and not correct_astro:
-                            a = np.load('{}/snr_mag_params.npy'.format(
-                                        config['snr_mag_params_path']))
-                            if not (len(a.shape) == 3 and a.shape[2] == 5 and
-                                    a.shape[0] == len(getattr(self, '{}filt_names'.format(flag)))):
-                                raise ValueError('{}snr_mag_params should be of shape (X, Y, 5).'
-                                                 .format(flag))
-                        else:
-                            setattr(self, '{}{}'.format(flag, path), config[path])
-                        if 'dd_params' in path:
-                            a = np.load('{}/dd_params.npy'.format(config['dd_params_path']))
-                            if not (len(a.shape) == 3 and a.shape[0] == 5 and a.shape[2] == 2):
-                                raise ValueError('{}dd_params should be of shape (5, X, 2).'
-                                                 .format(flag))
-                        if 'l_cut' in path:
-                            a = np.load('{}/l_cut.npy'.format(config['l_cut_path']))
-                            if not (len(a.shape) == 1 and a.shape[0] == 3):
-                                raise ValueError('{}l_cut should be of shape (3,) only.'
-                                                 .format(flag))
-                        if (('snr_mag' in path and not correct_astro) or 'dd_params' in path or
-                                'l_cut' in path):
-                            setattr(self, '{}{}'.format(flag, f), a)
+                # snr_mag_params, dd_params, and l_cut should all be numpy arrays in
+                # specified paths.
+                for path, f, warn_message in zip(['snr_mag_params_path', 'dd_params_path',
+                                                  'l_cut_path'], ['snr_mag_params', 'dd_params',
+                                                                  'l_cut'],
+                                                 ['astrometry corrections',
+                                                  'PSF photometry perturbations',
+                                                  'PSF photometry perturbations']):
+                    # Only need dd_params or l_cut if we're using run_psf_auf or
+                    # correct_astrometry is True.
+                    if ('snr_mag' not in path and not
+                            getattr(self, '{}run_psf_auf'.format(flag)) and not correct_astro):
+                        continue
+                    if not os.path.exists(config[path]):
+                        raise OSError('{}{} does not exist. Please ensure that path for '
+                                      'catalogue {} is correct.'.format(flag, path, catname))
+                    # If we are correcting the astrometry, we will be
+                    # re-making the SNR-mag relations so skip loading that
+                    # for now.
+                    if not ('snr_mag' in path and correct_astro):
+                        if not os.path.isfile('{}/{}.npy'.format(config[path], f)):
+                            raise FileNotFoundError('{} file not found in catalogue {} path. '
+                                                    'Please ensure {} are pre-generated.'
+                                                    .format(f, catname, warn_message))
+                    if 'snr_mag' in path and not correct_astro:
+                        a = np.load('{}/snr_mag_params.npy'.format(
+                                    config['snr_mag_params_path']))
+                        if not (len(a.shape) == 3 and a.shape[2] == 5 and
+                                a.shape[0] == len(getattr(self, '{}filt_names'.format(flag)))):
+                            raise ValueError('{}snr_mag_params should be of shape (X, Y, 5).'
+                                             .format(flag))
+                    else:
+                        setattr(self, '{}{}'.format(flag, path), config[path])
+                    if 'dd_params' in path:
+                        a = np.load('{}/dd_params.npy'.format(config['dd_params_path']))
+                        if not (len(a.shape) == 3 and a.shape[0] == 5 and a.shape[2] == 2):
+                            raise ValueError('{}dd_params should be of shape (5, X, 2).'
+                                             .format(flag))
+                    if 'l_cut' in path:
+                        a = np.load('{}/l_cut.npy'.format(config['l_cut_path']))
+                        if not (len(a.shape) == 1 and a.shape[0] == 3):
+                            raise ValueError('{}l_cut should be of shape (3,) only.'
+                                             .format(flag))
+                    if (('snr_mag' in path and not correct_astro) or 'dd_params' in path or
+                            'l_cut' in path):
+                        setattr(self, '{}{}'.format(flag, f), a)
 
                 try:
                     a = config['tri_filt_num']

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -1010,10 +1010,6 @@ class CrossMatch():
                 setattr(self, '{}tri_filt_names'.format(flag),
                         np.array(config['tri_filt_names'].split()))
 
-                for check_flag in ['psf_fwhms']:
-                    if check_flag not in config:
-                        raise ValueError("Missing key {} from catalogue {} metadata file.".format(
-                                         check_flag, catname))
                 a = config['psf_fwhms'].split()
                 try:
                     b = np.array([float(f) for f in a])

--- a/macauff/tests/data/cat_a_params.txt
+++ b/macauff/tests/data/cat_a_params.txt
@@ -43,3 +43,6 @@ auf_region_points = 131 134 4 -1 1 3
 dens_dist = 0.25
 # Magnitudes, in each bandpass, down to which to count nearby local sources when calculating local density
 dens_mags = 20 20 20
+
+# Test for whether we need to correct astrometry of catalogue for systematic biases before performing matches
+correct_astrometry = no

--- a/macauff/tests/data/cat_b_params.txt
+++ b/macauff/tests/data/cat_b_params.txt
@@ -43,3 +43,6 @@ auf_region_points = 131 134 4 -1 1 4
 dens_dist = 0.25
 # Magnitudes, in each bandpass, down to which to count nearby local sources when calculating local density
 dens_mags = 20 20 20 20
+
+# Test for whether we need to correct astrometry of catalogue for systematic biases before performing matches
+correct_astrometry = no

--- a/macauff/tests/data/crossmatch_params.txt
+++ b/macauff/tests/data/crossmatch_params.txt
@@ -49,3 +49,6 @@ num_trials = 10000
 d_mag = 0.1
 # Flag to indicate whether to use pre-computed local normalising densities for simulating PSFs
 compute_local_density = no
+
+# Multiprocessing CPU count
+n_pool = 2

--- a/macauff/tests/test_fit_astrometry.py
+++ b/macauff/tests/test_fit_astrometry.py
@@ -277,11 +277,15 @@ class TestAstroCorrection:
 
         if coord_or_chunk == 'coord':
             assert os.path.isfile('ac_save_folder/pdf/auf_fits_105.0_0.0.pdf')
+            assert os.path.isfile('ac_save_folder/pdf/counts_comparison_105.0_0.0.pdf')
+            assert os.path.isfile('ac_save_folder/pdf/s_vs_snr_105.0_0.0.pdf')
+            assert os.path.isfile('ac_save_folder/pdf/sig_fit_comparisons_105.0_0.0.pdf')
         else:
             assert os.path.isfile('ac_save_folder/pdf/auf_fits_2017.pdf')
-        assert os.path.isfile('ac_save_folder/pdf/counts_comparison.pdf')
-        assert os.path.isfile('ac_save_folder/pdf/s_vs_snr_W1.pdf')
-        assert os.path.isfile('ac_save_folder/pdf/sig_fit_comparisons.pdf')
+            assert os.path.isfile('ac_save_folder/pdf/counts_comparison_2017.pdf')
+            assert os.path.isfile('ac_save_folder/pdf/s_vs_snr_2017.pdf')
+            assert os.path.isfile('ac_save_folder/pdf/sig_fit_comparisons_2017.pdf')
+
         assert os.path.isfile('ac_save_folder/pdf/sig_h_stats.pdf')
 
         marray = np.load('ac_save_folder/npy/m_sigs_array.npy')

--- a/macauff/tests/test_fit_astrometry.py
+++ b/macauff/tests/test_fit_astrometry.py
@@ -165,16 +165,10 @@ class TestAstroCorrection:
         self.b_cat_name = 'store_data/b_cat{}{}.npy'
         with pytest.raises(ValueError, match='a_cat_func must be given if pregenerate_cutouts '):
             ac(self.a_cat_name, self.b_cat_name, a_cat_func=None, b_cat_func=None,
-               cat_recreate=True, snr_model_recreate=True, count_recreate=True, tri_download=False,
-               dens_recreate=True, nn_recreate=True, auf_sim_recreate=True, auf_pdf_recreate=True,
-               h_o_fit_recreate=True, fit_x2s_recreate=True, make_plots=True,
-               make_summary_plot=True)
+               tri_download=False, make_plots=True, make_summary_plot=True)
         with pytest.raises(ValueError, match='b_cat_func must be given if pregenerate_cutouts '):
             ac(self.a_cat_name, self.b_cat_name, a_cat_func=self.fake_cata_cutout, b_cat_func=None,
-               cat_recreate=True, snr_model_recreate=True, count_recreate=True, tri_download=False,
-               dens_recreate=True, nn_recreate=True, auf_sim_recreate=True, auf_pdf_recreate=True,
-               h_o_fit_recreate=True, fit_x2s_recreate=True, make_plots=True,
-               make_summary_plot=True)
+               tri_download=False, make_plots=True, make_summary_plot=True)
         dd_params = np.load(os.path.join(os.path.dirname(__file__), 'data/dd_params.npy'))
         l_cut = np.load(os.path.join(os.path.dirname(__file__), 'data/l_cut.npy'))
         ax1_mids, ax2_mids = np.array([105], dtype=float), np.array([0], dtype=float)
@@ -185,7 +179,7 @@ class TestAstroCorrection:
         ax_dimension = 1
         ac = AstrometricCorrections(
             psf_fwhm=6.1, numtrials=1000, nn_radius=30, dens_search_radius=900,
-            save_folder='ac_save_folder', trifolder='tri_folder', triname='trilegal_sim',
+            save_folder='ac_save_folder', trifolder='tri_folder', triname='trilegal_sim_{}_{}',
             maglim_f=25, magnum=11, tri_num_faint=1500000, trifilterset='2mass_spitzer_wise',
             trifiltname='W1', gal_wav_micron=3.35, gal_ab_offset=2.699, gal_filtname='wise2010-W1',
             gal_alav=0.039, bright_mag=16, dm=0.1, dd_params=dd_params, l_cut=l_cut,
@@ -206,21 +200,15 @@ class TestAstroCorrection:
         with pytest.raises(ValueError, match="If pregenerate_cutouts is 'True' all files must "
                            "exist already, but {} does not.".format(
                                self.a_cat_name.format(*cat_args))):
-            ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func, cat_recreate=True,
-               snr_model_recreate=True, count_recreate=True, tri_download=False, dens_recreate=True,
-               nn_recreate=True, auf_sim_recreate=True, auf_pdf_recreate=True,
-               h_o_fit_recreate=True, fit_x2s_recreate=True, make_plots=True,
-               make_summary_plot=True)
+            ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func,
+               tri_download=False, make_plots=True, make_summary_plot=True)
         ax1_min, ax1_max, ax2_min, ax2_max = 100, 110, -3, 3
         self.fake_cata_cutout(ax1_min, ax1_max, ax2_min, ax2_max, *cat_args)
         with pytest.raises(ValueError, match="If pregenerate_cutouts is 'True' all files must "
                            "exist already, but {} does not.".format(
                                self.b_cat_name.format(*cat_args))):
-            ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func, cat_recreate=True,
-               snr_model_recreate=True, count_recreate=True, tri_download=False, dens_recreate=True,
-               nn_recreate=True, auf_sim_recreate=True, auf_pdf_recreate=True,
-               h_o_fit_recreate=True, fit_x2s_recreate=True, make_plots=True,
-               make_summary_plot=True)
+            ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func,
+               tri_download=False, make_plots=True, make_summary_plot=True)
 
     @pytest.mark.parametrize("npy_or_csv,coord_or_chunk,coord_system,pregenerate_cutouts",
                              [("csv", "chunk", "equatorial", True),
@@ -241,7 +229,7 @@ class TestAstroCorrection:
             ax_dimension = 2
         ac = AstrometricCorrections(
             psf_fwhm=6.1, numtrials=1000, nn_radius=30, dens_search_radius=900,
-            save_folder='ac_save_folder', trifolder='tri_folder', triname='trilegal_sim',
+            save_folder='ac_save_folder', trifolder='tri_folder', triname='trilegal_sim_{}_{}',
             maglim_f=25, magnum=11, tri_num_faint=1500000, trifilterset='2mass_spitzer_wise',
             trifiltname='W1', gal_wav_micron=3.35, gal_ab_offset=2.699, gal_filtname='wise2010-W1',
             gal_alav=0.039, bright_mag=16, dm=0.1, dd_params=dd_params, l_cut=l_cut,
@@ -254,11 +242,11 @@ class TestAstroCorrection:
             cutout_height=6 if not pregenerate_cutouts else None)
 
         if coord_or_chunk == 'coord':
-            self.a_cat_name = 'store_data/a_cat{}{}.npy'
-            self.b_cat_name = 'store_data/b_cat{}{}.npy'
+            self.a_cat_name = 'store_data/a_cat{}{}' + ('.csv' if npy_or_csv == 'csv' else '.npy')
+            self.b_cat_name = 'store_data/b_cat{}{}' + ('.csv' if npy_or_csv == 'csv' else '.npy')
         else:
-            self.a_cat_name = 'store_data/a_cat{}.npy'
-            self.b_cat_name = 'store_data/b_cat{}.npy'
+            self.a_cat_name = 'store_data/a_cat{}' + ('.csv' if npy_or_csv == 'csv' else '.npy')
+            self.b_cat_name = 'store_data/b_cat{}' + ('.csv' if npy_or_csv == 'csv' else '.npy')
         if pregenerate_cutouts:
             # Cutout area is 60 sq deg with a height of 6 deg for a 10x6 box around (105, 0).
             cat_args = (chunks[0],)
@@ -270,10 +258,8 @@ class TestAstroCorrection:
         else:
             a_cat_func = self.fake_cata_cutout
             b_cat_func = self.fake_catb_cutout
-        ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func, cat_recreate=True,
-           snr_model_recreate=True, count_recreate=True, tri_download=False, dens_recreate=True,
-           nn_recreate=True, auf_sim_recreate=True, auf_pdf_recreate=True,
-           h_o_fit_recreate=True, fit_x2s_recreate=True, make_plots=True, make_summary_plot=True)
+        ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func,
+           tri_download=False, make_plots=True, make_summary_plot=True)
 
         if coord_or_chunk == 'coord':
             assert os.path.isfile('ac_save_folder/pdf/auf_fits_105.0_0.0.pdf')

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -1540,6 +1540,40 @@ class TestInputs:
 
         assert np.all(np.load('wise_folder/in_chunk_overlap.npy') == y[:, 12].astype(int))
 
+        old_line = 'chunk_overlap_col = '
+        new_line = 'chunk_overlap_col = None\n'
+        f = open(os.path.join(os.path.dirname(__file__),
+                              'data/cat_b_params_2.txt')).readlines()
+        idx = np.where([old_line in line for line in f])[0][0]
+        _replace_line(os.path.join(os.path.dirname(__file__),
+                      'data/cat_b_params_2.txt'), idx, new_line)
+
+        if os.path.isfile('ac_folder/npy/snr_mag_params.npy'):
+            os.remove('ac_folder/npy/snr_mag_params.npy')
+        # Swapped a+b to test a_* versions of things
+        cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
+                             'data/crossmatch_params.txt'),
+                             os.path.join(os.path.dirname(__file__),
+                             'data/cat_b_params_2.txt'),
+                             os.path.join(os.path.dirname(__file__),
+                             'data/cat_a_params.txt'))
+        assert cm.a_best_mag_index == 0
+        assert_allclose(cm.a_nn_radius, 30)
+        assert cm.a_correct_astro_save_folder == os.path.abspath('ac_folder')
+        assert cm.a_csv_cat_file_string == os.path.abspath('file_{}.csv')
+        assert cm.a_ref_csv_cat_file_string == os.path.abspath('ref_{}.csv')
+        assert_allclose(cm.a_correct_mag_array, np.array([14.07, 14.17, 14.27, 14.37]))
+        assert_allclose(cm.a_correct_mag_slice, np.array([0.05, 0.05, 0.05, 0.05]))
+        assert_allclose(cm.a_correct_sig_slice, np.array([0.1, 0.1, 0.1, 0.1]))
+        assert np.all(cm.a_pos_and_err_indices == np.array([[0, 1, 2], [0, 1, 2]]))
+        assert np.all(cm.a_mag_indices == np.array([3, 5, 7, 9]))
+        assert np.all(cm.a_mag_unc_indices == np.array([4, 6, 8, 10]))
+        marray = np.load('ac_folder/npy/m_sigs_array.npy')
+        narray = np.load('ac_folder/npy/n_sigs_array.npy')
+        assert_allclose([marray[0], narray[0]], [2, 0], rtol=0.1, atol=0.01)
+
+        assert np.all(np.load('wise_folder/in_chunk_overlap.npy') == 0)
+
         for old_line, new_line, x, match_text in zip(
                 ['best_mag_index = ', 'best_mag_index = ', 'best_mag_index = ',
                  'nn_radius = ', 'nn_radius = ', 'correct_mag_array = ',


### PR DESCRIPTION
A larger-scale restructure to `AstrometricCorrections` to allow for its calling from within `CrossMatch` ahead of the matching calls.

This allows for individual "chunks" to have their positional uncertainties derived and potential systematic biases corrected within the matching framework, allowing for the probabilistic matching algorithms to work correctly.

This required a re-structure to `AstrometricCorrections` to loop on a "per sightline" rather than "per loop" basis, splitting each sightline up separately. Then `CrossMatch` can call it, with limited parameters, for a singular sightline, using its own input match catalogues to derive a singular bias correction.

We therefore extend the inputs to `CrossMatch` to account for these extra keywords, and require a few more in cases where astrometric corrections are occurring (instead of only needing them if e.g. ``include_perturb_auf`` is ``True``), but extensions can be made to better unionise these cases and fit for AUFs that mirror the assumptions made about the AUF during the matching process down the line.

We also then call ``csv_to_npy`` after ``AstrometricCorrections``, ensuring that ``CrossMatch`` has its appropriate inputs once the systematics are corrected for.