### PR TITLE
Update pyproject.toml for modern setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,28 @@
 [build-system]
-requires = [ "setuptools >= 35.0.2, < 60.0", "wheel >= 0.29.0", "numpy"]
+requires = [ "setuptools", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "macauff"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "astropy",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "skypy",
+    "speclite",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest-astropy",
+    "scipy",
+]
+docs = [
+    "sphinx-astropy",
+    "sphinx-fortran",
+    "six",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[options.extras_require]
-test =
-	numpy
-	scipy
-    pytest-astropy
-docs =
-    sphinx-astropy
-    sphinx-fortran
-    six


### PR DESCRIPTION
I remove `setup.cfg` and move it content to `pyproject.toml`. In pyproject.toml I add a short `[project]` section with mandatory fields, and replace `numpy` with `oldest-supported-numpy` in build dependencies to ensure binary compatibility of the package with elder `numpy` versions.