### PR TITLE
cibuildwheel for wheel building

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -1,0 +1,59 @@
+name: Build and publish wheels
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Wheels on ${{ matrix.os }} with CIBW_ARCHS=${{ matrix.archs }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Numpy provides wheels for x86_64 and aarch64 only, we do the same
+          - os: ubuntu-latest
+            archs: x86_64 aarch64
+          # macOS and Windows are not supported yet
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      if: ${{ runner.os == 'Linux' }}
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.16.2
+      env:
+        CIBW_ARCHS: ${{ matrix.archs }}
+    - uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build SDist
+      run: pipx run build --sdist
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz
+
+  publish:
+    needs: [ build_wheels, make_sdist ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+    # Publish only on new "v*" tags
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      if: startsWith(github.ref, 'refs/tags/v')
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,6 @@ docs = [
 build-frontend = "build"
 config-settings = { "build-args" = "--full-build" }
 skip = [
-    "pp*"  # we don't support PyPy
+    "*musl*",  # we don't support MUSL Linux
+    "pp*",  # we don't support PyPy
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,28 @@
 [build-system]
-requires = [ "setuptools >= 35.0.2, < 60.0", "wheel >= 0.29.0", "numpy"]
+requires = [ "setuptools", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "macauff"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "astropy",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "skypy",
+    "speclite",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest-astropy",
+    "scipy",
+]
+docs = [
+    "sphinx-astropy",
+    "sphinx-fortran",
+    "six",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "macauff"
 version = "0.1.0"
 readme = "README.md"
-requires-python = ">=3.8"
+# 3.12 has removed distutils
+requires-python = ">=3.8,<3.12"
 dependencies = [
     "astropy",
     "matplotlib",
@@ -25,4 +26,11 @@ docs = [
     "sphinx-astropy",
     "sphinx-fortran",
     "six",
+]
+
+[tool.cibuildwheel]
+build-frontend = "build"
+config-settings = { "build-args" = "--full-build" }
+skip = [
+    "pp*"  # we don't support PyPy
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[options.extras_require]
-test =
-	numpy
-	scipy
-    pytest-astropy
-docs =
-    sphinx-astropy
-    sphinx-fortran
-    six


### PR DESCRIPTION
This is an initial implementation of [`cibuildwheel`](https://cibuildwheel.readthedocs.io/en/stable/) (CIBW) support. It misses Windows (because I don't know it) and macOS (because OpenMP support is tricky) for now.

When this is merge, all we need for the package release is create a git tag "vX.Y.Z" and push it on GitHub. It requires `PYPI_API_TOKEN` GitHub secret to be set to an appropriate value.

This is based on #64 and should be merged after it.